### PR TITLE
chore(renovate): enable OSV alerts and label security PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
   "prHourlyLimit": 5,
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": ["dependencies", "renovate", "security"]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Adds a second vulnerability-detection net to the Renovate config and makes security PRs triage-visible.

## Changes
- `osvVulnerabilityAlerts: true` — OSV.dev-sourced vulnerability PRs for direct dependencies. Queried offline, needs **no** GitHub token permission, so it is independent of the Dependabot-alerts path.
- `vulnerabilityAlerts.labels: [dependencies, renovate, security]` — tags security PRs with an extra `security` label. Fix behavior is unchanged (Renovate's built-in defaults: `prCreation: immediate`, `commitMessageSuffix: [SECURITY]`, `minimumReleaseAge: null` so security fixes bypass the repo's 7-day hold).

## Context
The GitHub Dependabot-alerts path (`vulnerabilityAlerts`, on by default) was already enabled but its token lacked `Dependabot alerts: Read-only` (dashboard WARN "Cannot access vulnerability alerts"); that permission has now been granted on the fine-grained `RENOVATE_GITHUB_TOKEN`. This PR adds OSV as a complementary source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled automated OSV vulnerability alerts.
  * Security-related update pull requests now receive clearer dependency, automation, and security labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->