### PR TITLE
Schedule edit modal: Delete button overlaps footer summary at narrow width

### DIFF
--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -1006,7 +1006,7 @@ export function ScheduleModal({
         {/* Footer */}
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-t border-edge bg-ink/40 px-5 py-3.5">
           <span className="hidden min-w-0 flex-1 truncate text-[11px] text-faint sm:block">{footerSummary}</span>
-          <div className="ml-auto flex items-center justify-end gap-2">
+          <div className="ml-auto flex min-w-0 max-w-full flex-wrap items-center justify-end gap-2">
             {isEdit && (
               <Button type="button" variant="danger" size="sm" onClick={remove} disabled={deleting || saving}>
                 <TrashIcon /> {deleting ? "Deleting…" : "Delete"}

--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -1005,8 +1005,8 @@ export function ScheduleModal({
 
         {/* Footer */}
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-t border-edge bg-ink/40 px-5 py-3.5">
-          <span className="hidden truncate text-[11px] text-faint sm:inline">{footerSummary}</span>
-          <div className="flex flex-1 items-center justify-end gap-2">
+          <span className="hidden min-w-0 flex-1 truncate text-[11px] text-faint sm:block">{footerSummary}</span>
+          <div className="ml-auto flex items-center justify-end gap-2">
             {isEdit && (
               <Button type="button" variant="danger" size="sm" onClick={remove} disabled={deleting || saving}>
                 <TrashIcon /> {deleting ? "Deleting…" : "Delete"}


### PR DESCRIPTION
Implements issue #659.

Closes #659

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-659`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the schedule modal footer layout for better responsiveness.
  * Footer actions can wrap when space is limited while remaining right-aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->