### PR TITLE
ci: make release/CI image builds resilient to transient network blips (#739)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,9 @@ jobs:
           # (issue #739). First release has no :buildcache yet -- build-push-action
           # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
           cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache
-          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache,mode=max
+          # ignore-error: a cache EXPORT failure (GHCR blip) must not fail the release
+          # build or block signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/api:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/api:${{ needs.prep.outputs.short_sha }}
@@ -254,7 +256,9 @@ jobs:
           # (issue #739). First release has no :buildcache yet -- build-push-action
           # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
           cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache
-          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache,mode=max
+          # ignore-error: a cache EXPORT failure (GHCR blip) must not fail the release
+          # build or block signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/web:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/web:${{ needs.prep.outputs.short_sha }}
@@ -297,7 +301,9 @@ jobs:
           # (issue #739). First release has no :buildcache yet -- build-push-action
           # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
           cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache
-          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache,mode=max
+          # ignore-error: a cache EXPORT failure (GHCR blip) must not fail the release
+          # build or block signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/controller:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/controller:${{ needs.prep.outputs.short_sha }}
@@ -429,7 +435,9 @@ jobs:
           # Per-template cache ref; base/jvm never collide. First release has no
           # :buildcache yet -- build-push-action tolerates the cache-from miss.
           cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:buildcache,mode=max
+          # ignore-error: a cache EXPORT failure must not fail the release or block
+          # signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:${{ needs.prep.outputs.short_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,12 @@ jobs:
           push: true
           platforms: linux/amd64
           provenance: false
+          # Registry layer cache: a warm build reuses the `go mod download` layer instead
+          # of re-fetching from proxy.golang.org, shrinking the per-release network window
+          # (issue #739). First release has no :buildcache yet -- build-push-action
+          # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
+          cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache,mode=max
           tags: |
             ghcr.io/vtmocanu/uzi/api:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/api:${{ needs.prep.outputs.short_sha }}
@@ -243,6 +249,12 @@ jobs:
           push: true
           platforms: linux/amd64
           provenance: false
+          # Registry layer cache: a warm build reuses the `npm ci` layer instead of
+          # re-fetching from the npm registry, shrinking the per-release network window
+          # (issue #739). First release has no :buildcache yet -- build-push-action
+          # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
+          cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache,mode=max
           tags: |
             ghcr.io/vtmocanu/uzi/web:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/web:${{ needs.prep.outputs.short_sha }}
@@ -280,6 +292,12 @@ jobs:
           push: true
           platforms: linux/amd64
           provenance: false
+          # Registry layer cache: a warm build reuses the `go mod download` layer instead
+          # of re-fetching from proxy.golang.org, shrinking the per-release network window
+          # (issue #739). First release has no :buildcache yet -- build-push-action
+          # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
+          cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache,mode=max
           tags: |
             ghcr.io/vtmocanu/uzi/controller:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/controller:${{ needs.prep.outputs.short_sha }}

--- a/agent/templates/base/Dockerfile
+++ b/agent/templates/base/Dockerfile
@@ -29,7 +29,9 @@ WORKDIR /app
 # ("cannot connect to the Docker daemon") rather than reaching for a host socket, and
 # the Bash guardrail denies docker outright until a daemon is wired. compose ships the
 # v2 subcommand plugin (`docker compose`), buildx the build plugin.
-RUN apk add --no-cache git bash tini curl xz tar setpriv docker-cli docker-cli-compose docker-cli-buildx \
+# Retry apk on a transient Alpine-mirror blip (issue #739). 5 attempts, n*3s backoff;
+# the setpriv assertion stays outside the loop (it is not a network step).
+RUN n=0; until apk add --no-cache git bash tini curl xz tar setpriv docker-cli docker-cli-compose docker-cli-buildx; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "apk add: giving up after $n attempts" >&2; exit 1; }; echo "apk add failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done \
     && /bin/setpriv --help 2>&1 | grep -q -- --reuid
 
 # Two runtime uids (PRD #51 A1). `worker` (uid 10001) holds the run credentials
@@ -87,7 +89,7 @@ ARG TARGETARCH
 # sandbox off (can't nest in a build), flakes on (devbox needs them).
 ARG NIX_INSTALLER_VERSION=3.21.5
 RUN NIX_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; esac)" \
-    && curl -fsSL -o /tmp/nix-installer \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 -o /tmp/nix-installer \
       "https://github.com/DeterminateSystems/nix-installer/releases/download/v${NIX_INSTALLER_VERSION}/nix-installer-${NIX_ARCH}-linux" \
     && chmod +x /tmp/nix-installer \
     && /tmp/nix-installer install linux --init none --no-confirm \
@@ -113,9 +115,9 @@ ARG DEVBOX_VERSION=0.17.5
 RUN set -o pipefail \
     && cd /tmp \
     && TARBALL="devbox_${DEVBOX_VERSION}_linux_${TARGETARCH}.tar.gz" \
-    && curl -fsSL -o "${TARBALL}" \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 -o "${TARBALL}" \
       "https://github.com/jetify-com/devbox/releases/download/${DEVBOX_VERSION}/${TARBALL}" \
-    && curl -fsSL -o checksums.txt \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 -o checksums.txt \
       "https://github.com/jetify-com/devbox/releases/download/${DEVBOX_VERSION}/checksums.txt" \
     && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - \
     && mkdir -p devbox-extract \
@@ -189,7 +191,8 @@ RUN bash /tmp/assert-toolchain.sh /tmp/toolchain-guard.tsv \
 # files are under agent/ — the per-Dockerfile ignore (Dockerfile.dockerignore next
 # to this file) trims the context to source only.
 COPY agent/package.json agent/package-lock.json ./
-RUN npm ci --omit=dev
+# Retry the registry fetch on a transient npm-registry blip (issue #739). 5 attempts, n*3s backoff.
+RUN n=0; until npm ci --omit=dev; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "npm ci: giving up after $n attempts" >&2; exit 1; }; echo "npm ci failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done
 
 # --- PRD #87: prebaked browser (chromium + agent-browser) for the web-ux role -----------
 # The browser rides the SHARED devbox-global toolchain (chromium + fontconfig + dejavu_fonts

--- a/agent/templates/jvm/Dockerfile
+++ b/agent/templates/jvm/Dockerfile
@@ -19,7 +19,8 @@ WORKDIR /app
 # docker-cli-compose + docker-cli-buildx (PRD #83 Decision 1): the docker CLIENT only,
 # NO dockerd, inert without a wired daemon (DOCKER_HOST not baked). MIRRORED from
 # templates/base (jvm is NOT `FROM base`; keep in lockstep).
-RUN apk add --no-cache git bash tini curl xz tar openjdk17 setpriv docker-cli docker-cli-compose docker-cli-buildx \
+# Retry apk on a transient Alpine-mirror blip (issue #739); see templates/base for rationale.
+RUN n=0; until apk add --no-cache git bash tini curl xz tar openjdk17 setpriv docker-cli docker-cli-compose docker-cli-buildx; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "apk add: giving up after $n attempts" >&2; exit 1; }; echo "apk add failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done \
     && /bin/setpriv --help 2>&1 | grep -q -- --reuid
 
 # JAVA_HOME + PATH so `java`/`javac` and Maven/Gradle wrappers resolve for the
@@ -51,7 +52,7 @@ ENV HOME=/home/worker
 ARG TARGETARCH
 ARG NIX_INSTALLER_VERSION=3.21.5
 RUN NIX_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; esac)" \
-    && curl -fsSL -o /tmp/nix-installer \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 -o /tmp/nix-installer \
       "https://github.com/DeterminateSystems/nix-installer/releases/download/v${NIX_INSTALLER_VERSION}/nix-installer-${NIX_ARCH}-linux" \
     && chmod +x /tmp/nix-installer \
     && /tmp/nix-installer install linux --init none --no-confirm \
@@ -70,9 +71,9 @@ ARG DEVBOX_VERSION=0.17.5
 RUN set -o pipefail \
     && cd /tmp \
     && TARBALL="devbox_${DEVBOX_VERSION}_linux_${TARGETARCH}.tar.gz" \
-    && curl -fsSL -o "${TARBALL}" \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 -o "${TARBALL}" \
       "https://github.com/jetify-com/devbox/releases/download/${DEVBOX_VERSION}/${TARBALL}" \
-    && curl -fsSL -o checksums.txt \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 -o checksums.txt \
       "https://github.com/jetify-com/devbox/releases/download/${DEVBOX_VERSION}/checksums.txt" \
     && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - \
     && mkdir -p devbox-extract \
@@ -137,7 +138,8 @@ RUN bash /tmp/assert-toolchain.sh /tmp/toolchain-guard.tsv \
 # files are under agent/ — the per-Dockerfile ignore (Dockerfile.dockerignore next
 # to this file) trims the context to source only. MIRRORED from templates/base.
 COPY agent/package.json agent/package-lock.json ./
-RUN npm ci --omit=dev
+# Retry the registry fetch on a transient npm-registry blip (issue #739); see templates/base.
+RUN n=0; until npm ci --omit=dev; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "npm ci: giving up after $n attempts" >&2; exit 1; }; echo "npm ci failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done
 
 # --- PRD #87: prebaked browser (chromium + agent-browser) for the web-ux role -----------
 # MIRRORED from templates/base (jvm is NOT `FROM base` — no ENV inheritance; forgetting this

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,10 @@ FROM golang:1.26@sha256:26326682769ca980f8f1d3b1f52be2dd1c1d25270e3de3fe0c97d6bb
 WORKDIR /src
 
 COPY go.mod go.sum ./
-RUN go mod download
+# Retry the module fetch: proxy.golang.org blips transiently and a single INTERNAL_ERROR
+# should not redden a whole CI validation or release-publish build (issue #739). 5 attempts,
+# n*3s backoff; POSIX sh so the same idiom works in the debian (golang) and alpine images.
+RUN n=0; until go mod download; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "go mod download: giving up after $n attempts" >&2; exit 1; }; echo "go mod download failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done
 
 COPY . .
 # UZI_VERSION stamps main.version so GET /api/version reports the release version.

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /src
 # previously deferred are now here — copied before the source so the dependency
 # layer caches independently of a code change (the same shape api/Dockerfile has).
 COPY go.mod go.sum ./
-RUN go mod download
+# Retry the module fetch on a transient proxy.golang.org blip (issue #739); see api/Dockerfile
+# for the rationale. 5 attempts, n*3s backoff, POSIX sh.
+RUN n=0; until go mod download; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "go mod download: giving up after $n attempts" >&2; exit 1; }; echo "go mod download failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done
 
 COPY . .
 # Static, VCS-stamp-free build, matching api/Dockerfile.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -28,7 +28,9 @@ COPY web/package.json web/package-lock.json ./
 # lockfile refresh, which is when nobody will be looking.
 # NOT to be copied to agent/templates/base/Dockerfile: that image WANTS its
 # postinstall, which is what bakes the agent-browser CLI into the worker.
-RUN npm ci --ignore-scripts
+# Retry the registry fetch on a transient npm-registry blip (issue #739): a single reset
+# should not redden a CI validation or release-publish build. 5 attempts, n*3s backoff.
+RUN n=0; until npm ci --ignore-scripts; do n=$((n+1)); [ "$n" -ge 5 ] && { echo "npm ci: giving up after $n attempts" >&2; exit 1; }; echo "npm ci failed (attempt $n/5); retrying in $((n*3))s" >&2; sleep "$((n*3))"; done
 
 COPY web/ ./
 COPY docs/ /app/docs/


### PR DESCRIPTION
Closes #739.

## What

Hardens the five image Dockerfiles and the release publish jobs against transient network blips. A single `proxy.golang.org`/npm-registry/mirror hiccup currently reddens a whole CI validation or release-publish build (observed cutting v0.66.3: `publish-api` died on a `go mod download` `INTERNAL_ERROR`).

Implements proposals **1-3** from the issue; **4 deferred** (job-level retry action) as the rarest failure mode and the only new-dependency proposal.

## Changes

**1. Retry-with-backoff in each Dockerfile `RUN`** (`api`, `controller`, `web`, `agent/templates/base`, `agent/templates/jvm`)
- Wraps `go mod download`, `npm ci`, and `apk add` in a POSIX-sh `until` loop: 5 attempts, `n*3s` backoff, `exit 1` after the 5th so a real failure still fails the build. Same idiom works in the debian (golang) and alpine (node) base images.
- Helps **both** CI `--no-push` validation builds and release publishes, since they share these Dockerfiles.

**2. `--retry` flags on the agent `curl` fetches** (nix installer, devbox tarball, checksums, in base + jvm)
- Adds `--retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15`, matching `ci.yml`'s existing tool-download convention.

**3. Registry build cache on `publish-api` / `publish-web` / `publish-controller`**
- `cache-from`/`cache-to` (`type=registry`, `mode=max`), mirroring `publish-agent`. A warm build reuses the deps layer instead of re-fetching, shrinking the per-release network window. First release tolerates the `cache-from` miss.

## Validation

- `buildx --check` clean on all 5 Dockerfiles.
- Real `api` + `web` build-stage builds green: the retry-wrapped `go mod download` (16.8s) and `npm ci` (263 packages) executed real network fetches and succeeded.
- `task gate:repo` (shell, YAML, formula, secrets) and `task lint:actions` (actionlint + zizmor) clean.
- Retry loop behavior unit-tested in POSIX sh: retries to success (rc=0), gives up with rc=1 after 5 attempts.

## Deferred (proposal 4)

Job-level retry (e.g. `nick-fields/retry`) around `build-push-action` / `cosign sign` / `helm push`: targets registry-push blips (rarer than the observed build-fetch blip) and adds a new pinned third-party action. Can be a follow-up if push-level blips recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved container build efficiency through layer caching for API, web, controller, and agent images.
  * Cache export issues no longer block release builds or image signing.

* **Reliability**
  * Added automatic retries and progressive backoff for dependency downloads and package installation during builds.
  * Improved handling of temporary network failures when downloading tools and dependencies.
  * Builds now provide clearer retry and failure messages before stopping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->