### PR TITLE
chore(skill): tighten uzi-watcher poll interval to 30s

### DIFF
--- a/.claude/skills/uzi-watcher/scripts/watch-run.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-run.sh
@@ -29,8 +29,12 @@
 set -u
 RID="${1:?usage: watch-run.sh <run-id> [stop-csv] [interval] [max] [min-plan-seq]}"
 STOP="${2:-completed,failed,cancelled,awaiting_approval,awaiting_input}"
-INT="${3:-45}"
-MAX="${4:-160}"
+# 30s default balances gate-detection latency against poll volume; MAX 240 keeps
+# total coverage at ~2h (30*240=7200s) so a long implementation phase still fits.
+# Pass a coarser interval (e.g. 60) for a to-completion watch where the state you
+# await is hours off and snappy detection buys nothing.
+INT="${3:-30}"
+MAX="${4:-240}"
 MIN_PLAN_SEQ="${5:-}"
 
 max_plan_seq() {


### PR DESCRIPTION
Reduces the bundled `watch-run.sh` default poll interval from 45s to 30s so a run's plan-gate transition surfaces faster, and raises MAX polls 160->240 so total coverage stays ~2h. shellcheck-clean. No behavior change to callers (exit-code contract unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved watcher monitoring defaults to provide longer coverage with fewer interruptions.
  * Added guidance for configuring longer polling intervals when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->