### PR TITLE
Judge page: label counts (groups) don't reconcile with the To-triage count (recommendations)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,14 @@ jobs:
           push: true
           platforms: linux/amd64
           provenance: false
+          # Registry layer cache: a warm build reuses the `go mod download` layer instead
+          # of re-fetching from proxy.golang.org, shrinking the per-release network window
+          # (issue #739). First release has no :buildcache yet -- build-push-action
+          # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
+          cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache
+          # ignore-error: a cache EXPORT failure (GHCR blip) must not fail the release
+          # build or block signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/api:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/api:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/api:${{ needs.prep.outputs.short_sha }}
@@ -243,6 +251,14 @@ jobs:
           push: true
           platforms: linux/amd64
           provenance: false
+          # Registry layer cache: a warm build reuses the `npm ci` layer instead of
+          # re-fetching from the npm registry, shrinking the per-release network window
+          # (issue #739). First release has no :buildcache yet -- build-push-action
+          # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
+          cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache
+          # ignore-error: a cache EXPORT failure (GHCR blip) must not fail the release
+          # build or block signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/web:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/web:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/web:${{ needs.prep.outputs.short_sha }}
@@ -280,6 +296,14 @@ jobs:
           push: true
           platforms: linux/amd64
           provenance: false
+          # Registry layer cache: a warm build reuses the `go mod download` layer instead
+          # of re-fetching from proxy.golang.org, shrinking the per-release network window
+          # (issue #739). First release has no :buildcache yet -- build-push-action
+          # tolerates the cache-from miss. GHCR (not type=gha) has no cache-size cap.
+          cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache
+          # ignore-error: a cache EXPORT failure (GHCR blip) must not fail the release
+          # build or block signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/controller:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/controller:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/controller:${{ needs.prep.outputs.short_sha }}
@@ -411,7 +435,9 @@ jobs:
           # Per-template cache ref; base/jvm never collide. First release has no
           # :buildcache yet -- build-push-action tolerates the cache-from miss.
           cache-from: type=registry,ref=ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:buildcache,mode=max
+          # ignore-error: a cache EXPORT failure must not fail the release or block
+          # signing -- the cache is an optimization, not a gate (#739).
+          cache-to: type=registry,ref=ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:buildcache,mode=max,ignore-error=true
           tags: |
             ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:${{ needs.prep.outputs.version }}
             ghcr.io/vtmocanu/uzi/agent-${{ matrix.template }}:${{ needs.prep.outputs.short_sha }}

--- a/web/src/lib/judgeBacklog.test.ts
+++ b/web/src/lib/judgeBacklog.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   bucketTabCount,
   bucketTabLabel,
+  judgeBridgeLine,
   JUDGE_BUCKETS,
   verdictTrend,
   rollupLabel,
@@ -42,6 +43,23 @@ describe("judgeBacklog — evidence copy", () => {
   it("singularises 'seen in N runs'", () => {
     expect(seenInRunsLabel(1)).toBe("seen in 1 run");
     expect(seenInRunsLabel(3)).toBe("seen in 3 runs");
+  });
+});
+
+describe("judgeBacklog — judgeBridgeLine reconciles rows against groups", () => {
+  it("carries the per-bucket adjective (none for `all`) and pluralises BOTH nouns", () => {
+    // Both singular: the adjective sits between the count and the noun, no plural on either.
+    expect(judgeBridgeLine(1, 1, "todo")).toBe("1 to-do recommendation across 1 group");
+    // Both plural.
+    expect(judgeBridgeLine(42, 18, "todo")).toBe("42 to-do recommendations across 18 groups");
+    // A done case — different adjective, mixed plurality (plural recs, singular group).
+    expect(judgeBridgeLine(3, 1, "done")).toBe("3 done recommendations across 1 group");
+    // filed and dismissed adjectives.
+    expect(judgeBridgeLine(2, 5, "filed")).toBe("2 filed recommendations across 5 groups");
+    expect(judgeBridgeLine(1, 4, "dismissed")).toBe("1 dismissed recommendation across 4 groups");
+    // `all` carries NO bucket adjective — "recommendations", not "all recommendations".
+    expect(judgeBridgeLine(9, 5, "all")).toBe("9 recommendations across 5 groups");
+    expect(judgeBridgeLine(1, 1, "all")).toBe("1 recommendation across 1 group");
   });
 });
 

--- a/web/src/lib/judgeBacklog.ts
+++ b/web/src/lib/judgeBacklog.ts
@@ -105,6 +105,26 @@ export function seenInRunsLabel(runCount: number): string {
   return `seen in ${runCount} ${runCount === 1 ? "run" : "runs"}`;
 }
 
+// judgeBridgeLine reconciles the two count units the Judge page shows: the per-ROW
+// recommendation count for the active bucket (bucketTabCount) against the deduped GROUP
+// total for that same bucket. Pure so the wiring is unit-tested without the DOM. The caller
+// supplies groupTotal from a CANONICAL uncapped source (the category-stats matrix sum), never
+// backlog.groups.length (which is capped/filtered). "all" carries no bucket adjective.
+const BRIDGE_ADJECTIVE: Record<JudgeBacklogBucket, string> = {
+  todo: "to-do ",
+  filed: "filed ",
+  done: "done ",
+  dismissed: "dismissed ",
+  all: "",
+};
+
+export function judgeBridgeLine(recCount: number, groupTotal: number, bucket: JudgeBacklogBucket): string {
+  const adj = BRIDGE_ADJECTIVE[bucket];
+  const recNoun = recCount === 1 ? "recommendation" : "recommendations";
+  const groupNoun = groupTotal === 1 ? "group" : "groups";
+  return `${recCount} ${adj}${recNoun} across ${groupTotal} ${groupNoun}`;
+}
+
 // VerdictTrend is the zero-state's verdict summary: a per-verdict count over the DISTINCT
 // runs the caller has judged, ALL TIME. Distinct-by-run because a run carries one
 // verdict (its review's), while a group lists it once per occurrence — tallying raw

--- a/web/src/pages/Judge.test.tsx
+++ b/web/src/pages/Judge.test.tsx
@@ -959,6 +959,99 @@ describe("Judge — per-category chip counts (PRD #270)", () => {
   });
 });
 
+// Issue #620 — the bridge line reconciling the page's two count units: the whole-backlog
+// recommendation-ROW count for the active bucket (the tab number) against the whole-backlog
+// deduped GROUP total for that bucket (the category-stats matrix slice SUM). It sits directly
+// above the "Showing N groups" line, and is deliberately suppressed whenever the rec half (a
+// whole-backlog count) could not honestly reconcile against the group half: a category filter
+// is active, the backlog is truncated, or the group total is 0.
+describe("Judge — the row-vs-group bridge line (#620)", () => {
+  // todo slice sums to 18, done slice to 4; triage.todo is 42 and triage.done is 7, so the two
+  // halves of the bridge line come from genuinely different sources and a wrong-bucket read
+  // would be visible.
+  const counts_by_bucket = {
+    todo: { improve_uzi: 10, install_worker_tool: 8 },
+    filed: {},
+    done: { improve_uzi: 3, install_worker_tool: 1 },
+    dismissed: {},
+    all: { improve_uzi: 13, install_worker_tool: 9 },
+  };
+  const triage = { total: 60, todo: 42, filed: 5, done: 7, dismissed: 6, false_positives: 0 };
+
+  it("renders both counts for the active tab, the group half from the category-stats sum", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ triage }));
+    mockApi.getJudgeCategoryStats.mockResolvedValue({ counts_by_bucket });
+    renderJudge();
+
+    // triage.todo (42) is the rec half; the todo matrix slice (10+8) is the group half.
+    expect(await screen.findByText("42 to-do recommendations across 18 groups")).toBeTruthy();
+  });
+
+  it("re-scopes to the active bucket on a tab switch (Done → done count and done sum)", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ triage }));
+    mockApi.getJudgeCategoryStats.mockResolvedValue({ counts_by_bucket });
+    renderJudge();
+
+    expect(await screen.findByText("42 to-do recommendations across 18 groups")).toBeTruthy();
+
+    // /Done/ addresses the Done tab only — "Dismissed" does not contain "Done".
+    fireEvent.click(screen.getByRole("tab", { name: /Done/ }));
+
+    // triage.done (7) against the done matrix slice (3+1).
+    expect(await screen.findByText("7 done recommendations across 4 groups")).toBeTruthy();
+  });
+
+  it("is suppressed when a category filter is active (the rec half is whole-backlog)", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ triage }));
+    mockApi.getJudgeCategoryStats.mockResolvedValue({ counts_by_bucket });
+    renderJudge(["/judge?category=improve_uzi"]);
+
+    // The filtered "Showing N groups matching …" line still renders; the bridge does not.
+    await waitFor(() => expect(screen.getByText(/Showing/)).toBeTruthy());
+    expect(screen.queryByText(/recommendations across/)).toBeNull();
+  });
+
+  it("is suppressed when the backlog is truncated (the truncation Alert owns the caveat)", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ triage, truncated: true }));
+    mockApi.getJudgeCategoryStats.mockResolvedValue({ counts_by_bucket });
+    renderJudge();
+
+    expect(await screen.findByText(/backlog is large and was truncated/i)).toBeTruthy();
+    expect(screen.queryByText(/recommendations across/)).toBeNull();
+  });
+
+  it("is suppressed when the category-stats sum is 0 (a failed/empty aggregate)", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ triage }));
+    mockApi.getJudgeCategoryStats.mockResolvedValue({
+      counts_by_bucket: { todo: {}, filed: {}, done: {}, dismissed: {}, all: {} },
+    });
+    renderJudge();
+
+    // The "Showing N groups" line still renders off the returned groups, so the page settled…
+    await waitFor(() => expect(screen.getByText(/Showing/)).toBeTruthy());
+    // …but the bridge would read "across 0 groups", so it is withheld entirely.
+    expect(screen.queryByText(/recommendations across/)).toBeNull();
+  });
+});
+
+describe("Judge — the subtitle and filter-panel caption copy (#620)", () => {
+  it("drops the 'deduped by target' clause from the page subtitle", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog());
+    renderJudge();
+
+    const subtitle = await screen.findByText(/Recommendations across all your runs/);
+    expect(subtitle.textContent).toBe("Recommendations across all your runs. Triage a whole group in one action.");
+    expect(subtitle.textContent).not.toContain("deduped by target");
+  });
+
+  it("explains the count unit on the filter panel with a distinct caption", async () => {
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog());
+    renderJudge();
+
+    expect(await screen.findByText("counts are groups, deduped by target")).toBeTruthy();
+  });
+});
+
 // Issue #204: the fixed bulk-action bar used `inset-x-0`, spanning full width UNDER the
 // w-60 (240px) z-30 sidebar and clipping its "N groups selected" label at desktop widths.
 // jsdom has no layout engine, so this asserts the class contract rather than a measured

--- a/web/src/pages/Judge.test.tsx
+++ b/web/src/pages/Judge.test.tsx
@@ -1049,6 +1049,40 @@ describe("Judge — the row-vs-group bridge line (#620)", () => {
     // subtitle.
     expect(screen.queryByText(/recommendations across/)).toBeNull();
   });
+
+  it("is withheld while a post-mutation category-stats refetch is pending, then restored", async () => {
+    // A disposition installs the new `triage` (recommendation totals) synchronously but refetches
+    // the category-stats matrix async. Without the freshness gate the bridge would briefly show
+    // the NEW recommendation count against the STALE group total — a false reconciliation. Deferred
+    // promise, no timers: the second (post-dispose) stats fetch parks until released.
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ groups: [group()], triage }));
+    let releaseStats: (() => void) | undefined;
+    mockApi.getJudgeCategoryStats
+      .mockResolvedValueOnce({ counts_by_bucket }) // mount: bridge shows
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { releaseStats = () => resolve({ counts_by_bucket }); }),
+      );
+    mockApi.bulkSetJudgeDisposition.mockResolvedValue({
+      updated: 1,
+      settled: [{ run_id: "run-1", rec_id: "rec-1" }],
+      groups: [group({ bucket: "done", open_count: 0 })],
+      truncated: false,
+      triage: { ...triage, todo: 40, done: 9 }, // rec half drops 42 → 40
+    });
+
+    renderJudge();
+    expect(await screen.findByText("42 to-do recommendations across 18 groups")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Mark done/ }));
+
+    // Matrix refetch in flight → the bridge is withheld rather than reconciling the new
+    // recommendation total (40) against the stale group total.
+    await waitFor(() => expect(screen.queryByText(/recommendations across/)).toBeNull());
+
+    // Once the refetch lands, the bridge returns with the updated recommendation half.
+    releaseStats?.();
+    expect(await screen.findByText("40 to-do recommendations across 18 groups")).toBeTruthy();
+  });
 });
 
 describe("Judge — the subtitle and filter-panel caption copy (#620)", () => {

--- a/web/src/pages/Judge.test.tsx
+++ b/web/src/pages/Judge.test.tsx
@@ -1032,6 +1032,23 @@ describe("Judge — the row-vs-group bridge line (#620)", () => {
     // …but the bridge would read "across 0 groups", so it is withheld entirely.
     expect(screen.queryByText(/recommendations across/)).toBeNull();
   });
+
+  it("is suppressed under a run anchor (the rec half is whole-account, the group half run-scoped)", async () => {
+    // Absent the fix the bridge WOULD render: triage is non-zero (whole-account, no run arg on
+    // the server) and the run-anchor category-stats sum is non-zero, so both guard terms pass.
+    // But `triage` is "across all your runs" while the group half is scoped to this one run, so
+    // the two cannot honestly reconcile under `?run=` and the bridge must be withheld.
+    mockApi.getJudgeBacklog.mockResolvedValue(backlog({ bucket: "all", run: "run-1", triage }));
+    mockApi.getJudgeCategoryStats.mockResolvedValue({ counts_by_bucket });
+    renderJudge(["/judge?run=run-1"]);
+
+    // The run-anchor filter banner renders, so the page settled under the anchor…
+    await waitFor(() => expect(screen.getByText(/Filtered to one run's recommendations/i)).toBeTruthy());
+    // …but the whole-account/run-scoped mismatch means the bridge is withheld. The lowercase
+    // regex deliberately does not match the capital-R "Recommendations across all your runs"
+    // subtitle.
+    expect(screen.queryByText(/recommendations across/)).toBeNull();
+  });
 });
 
 describe("Judge — the subtitle and filter-panel caption copy (#620)", () => {

--- a/web/src/pages/Judge.tsx
+++ b/web/src/pages/Judge.tsx
@@ -32,6 +32,7 @@ import {
 import {
   bucketTabCount,
   bucketTabLabel,
+  judgeBridgeLine,
   JUDGE_BUCKETS,
   verdictTrend,
   rollupLabel,
@@ -211,6 +212,11 @@ export function Judge() {
   // dismissed/all — `all` is a real key, so indexing is uniform). A bucket with no groups is
   // {} in the matrix, so its chips read 0; LabelFilter is untouched and still takes {cat: n}.
   const categoryCounts = categoryStats[bucket] ?? {};
+  // The whole-backlog GROUP total for the active bucket, summed from the canonical
+  // category-stats matrix slice (uncapped, not category-filtered) — the honest denominator to
+  // reconcile against the whole-backlog recommendation count in the bridge line below. Never
+  // backlog.groups.length, which is capped/filtered.
+  const bridgeGroupTotal = Object.values(categoryCounts).reduce((s, n) => s + n, 0);
 
   // reloadAfterMutation refreshes BOTH the backlog and the chip matrix — the file-issue path
   // needs both (filing moves a group todo→filed), and it is passed as `onFiled` in place of a
@@ -448,7 +454,7 @@ export function Judge() {
             Judge
           </h1>
         }
-        description="Recommendations across all your runs, deduped by target. Triage a whole group in one action."
+        description="Recommendations across all your runs. Triage a whole group in one action."
       />
 
       {error && <Alert message={error} />}
@@ -521,6 +527,20 @@ export function Judge() {
           tone="warning"
           message="This backlog is large and was truncated — some groups' counts may be understated and a few groups may be missing. Dispose a smaller slice or narrow by bucket to see the whole picture."
         />
+      )}
+
+      {/* The bridge line reconciling the two count units on this page: the whole-backlog
+          recommendation-ROW count for the active bucket against the whole-backlog deduped
+          GROUP total. Suppressed when a category filter is active (the rec half is a
+          whole-backlog count and can only honestly reconcile against a whole-backlog group
+          total), when the backlog is truncated (the truncation Alert already flags the picture
+          as incomplete), and when the group total is 0 (a failed/empty category-stats fetch,
+          which would otherwise read "across 0 groups"). The "Showing N groups" line below stays
+          unchanged and covers the filtered/on-screen scope. */}
+      {!loading && backlog && !showZeroState && triage && categories.length === 0 && !backlog.truncated && bridgeGroupTotal > 0 && (
+        <p className="text-sm text-muted">
+          {judgeBridgeLine(bucketTabCount(triage, bucket), bridgeGroupTotal, bucket)}
+        </p>
       )}
 
       {/* A plain view hint reading the length of the RETURNED (filtered) groups — open
@@ -669,6 +689,7 @@ function LabelFilter({
           <XIcon /> Clear
         </button>
       </div>
+      <p className="mb-2 text-xs text-faint">counts are groups, deduped by target</p>
       <div role="group" aria-label="Recommendation labels" className="flex flex-wrap gap-2">
         {JUDGE_CATEGORIES.map((cat) => {
           const on = active.has(cat);

--- a/web/src/pages/Judge.tsx
+++ b/web/src/pages/Judge.tsx
@@ -535,9 +535,12 @@ export function Judge() {
           whole-backlog count and can only honestly reconcile against a whole-backlog group
           total), when the backlog is truncated (the truncation Alert already flags the picture
           as incomplete), and when the group total is 0 (a failed/empty category-stats fetch,
-          which would otherwise read "across 0 groups"). The "Showing N groups" line below stays
-          unchanged and covers the filtered/on-screen scope. */}
-      {!loading && backlog && !showZeroState && triage && categories.length === 0 && !backlog.truncated && bridgeGroupTotal > 0 && (
+          which would otherwise read "across 0 groups"). Also suppressed under a run anchor
+          (`?run=`): the recommendation half (`triage`) is whole-account, computed with no run
+          argument, while the group half is run-anchor scoped, so the two cannot honestly
+          reconcile there either. The "Showing N groups" line below stays unchanged and covers
+          the filtered/on-screen scope. */}
+      {!loading && backlog && !showZeroState && !runAnchor && triage && categories.length === 0 && !backlog.truncated && bridgeGroupTotal > 0 && (
         <p className="text-sm text-muted">
           {judgeBridgeLine(bucketTabCount(triage, bucket), bridgeGroupTotal, bucket)}
         </p>

--- a/web/src/pages/Judge.tsx
+++ b/web/src/pages/Judge.tsx
@@ -125,6 +125,12 @@ export function Judge() {
   // though NOT on a bucket-tab or category toggle since all buckets arrive in one payload.
   // Defaults to {} so a slow or failed fetch renders 0-count chips rather than crashing.
   const [categoryStats, setCategoryStats] = useState<JudgeCategoryStats["counts_by_bucket"]>({});
+  // Whether `categoryStats` reflects the LATEST issued fetch. A disposition installs the new
+  // `triage` (recommendation totals) synchronously but refetches the matrix async, so between
+  // the two the bridge line would reconcile the new recommendation count against the STALE
+  // group total. Gate the bridge on this: false while a matrix fetch is in flight (or after it
+  // failed), true only once the current fetch lands — so the reconciliation is never shown mid-flight.
+  const [categoryStatsFresh, setCategoryStatsFresh] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [actionErr, setActionErr] = useState("");
@@ -186,9 +192,16 @@ export function Judge() {
   const categoryStatsGen = useRef(0);
   const loadCategoryStats = useCallback(async () => {
     const gen = ++categoryStatsGen.current;
+    // The matrix in hand no longer matches the latest issued fetch — hide the bridge until this
+    // fetch lands (or keep it hidden if it fails). Reset every call so a post-mutation refetch
+    // suppresses the transient new-recs-vs-old-groups reconciliation.
+    setCategoryStatsFresh(false);
     try {
       const stats = await api.getJudgeCategoryStats(runAnchor || undefined);
-      if (gen === categoryStatsGen.current) setCategoryStats(stats.counts_by_bucket);
+      if (gen === categoryStatsGen.current) {
+        setCategoryStats(stats.counts_by_bucket);
+        setCategoryStatsFresh(true);
+      }
     } catch {
       /* chips render with 0 counts — a progressive enhancement, never a blocker */
     }
@@ -539,8 +552,10 @@ export function Judge() {
           (`?run=`): the recommendation half (`triage`) is whole-account, computed with no run
           argument, while the group half is run-anchor scoped, so the two cannot honestly
           reconcile there either. The "Showing N groups" line below stays unchanged and covers
-          the filtered/on-screen scope. */}
-      {!loading && backlog && !showZeroState && !runAnchor && triage && categories.length === 0 && !backlog.truncated && bridgeGroupTotal > 0 && (
+          the filtered/on-screen scope. Also gated on categoryStatsFresh: a disposition installs
+          the new triage synchronously but refetches the matrix async, so without this the bridge
+          would briefly reconcile the new recommendation count against the stale group total. */}
+      {!loading && backlog && !showZeroState && !runAnchor && triage && categories.length === 0 && !backlog.truncated && categoryStatsFresh && bridgeGroupTotal > 0 && (
         <p className="text-sm text-muted">
           {judgeBridgeLine(bucketTabCount(triage, bucket), bridgeGroupTotal, bucket)}
         </p>


### PR DESCRIPTION
Implements issue #620.

Closes #620

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-620`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Judge page comparison showing recommendation totals alongside groups deduplicated by target.
  * Counts update for the active backlog bucket with clearer singular and plural wording.
  * Added explanations clarifying how label counts are calculated.

* **Bug Fixes**
  * Improved count and subtitle accuracy across filtered, truncated, empty, and run-specific views.
  * Comparison counts are now hidden while results are loading, unavailable, or potentially misleading, then restored with fresh totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->