### PR TITLE
fix(uzi-tui): drop stale detail load to stop nil-map panic on exit

### DIFF
--- a/api/cmd/uzi/tui.go
+++ b/api/cmd/uzi/tui.go
@@ -101,9 +101,10 @@ type buildInfoMsg struct {
 }
 
 type detailLoadedMsg struct {
-	run  apitypes.RunDTO
-	msgs []apitypes.MessageDTO
-	err  error
+	runID string
+	run   apitypes.RunDTO
+	msgs  []apitypes.MessageDTO
+	err   error
 }
 
 type streamReadyMsg struct {
@@ -310,10 +311,10 @@ func (m tuiModel) loadDetailCmd(runID string) tea.Cmd {
 	return func() tea.Msg {
 		run, err := c.GetRun(ctx, runID)
 		if err != nil {
-			return detailLoadedMsg{err: err}
+			return detailLoadedMsg{runID: runID, err: err}
 		}
 		msgs, err := c.RunLogs(ctx, runID, 0)
-		return detailLoadedMsg{run: run, msgs: msgs, err: err}
+		return detailLoadedMsg{runID: runID, run: run, msgs: msgs, err: err}
 	}
 }
 
@@ -445,6 +446,21 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case detailLoadedMsg:
+		// Drop a load that resolved for a run the user has since navigated away from:
+		// esc/exitToBoard resets m.detail to its zero value (runID "", nil `seen` map), and
+		// drilling into another run swaps runID — a late applyLoaded from the previous run
+		// would splice the wrong transcript in, and against the zero value it would write the
+		// nil map and panic. Same runID guard every sibling detail message carries. runID is
+		// set by loadDetailCmd on both the success and error paths; run.ID is the fallback for
+		// a message that carries only the run (the error path leaves run zero, which is why the
+		// explicit field exists).
+		id := msg.runID
+		if id == "" {
+			id = msg.run.ID
+		}
+		if id != m.detail.runID {
+			return m, nil
+		}
 		m.detail.applyLoaded(msg)
 		// The ownership probe rides the same call the queue indicator needs.
 		return m, m.fetchInputsCmd(m.detail.runID)

--- a/api/cmd/uzi/tui_detail.go
+++ b/api/cmd/uzi/tui_detail.go
@@ -141,6 +141,12 @@ func (d *detailState) applyEvents(evs []apitypes.RunEventDTO) bool {
 // a reconnect replays from the last seq seen and the live socket may deliver the same
 // frame, and a duplicate would double a lane's contribution.
 func (d *detailState) addFrame(f laneFrame) {
+	if d.seen == nil {
+		// Total on a zero-value detailState: newDetailState seeds this map, but the
+		// handler guard is the load-bearing fix — this keeps a nil map from panicking
+		// the program if any future path reaches addFrame without the constructor.
+		d.seen = map[int32]bool{}
+	}
 	if f.Seq > 0 {
 		if d.seen[f.Seq] {
 			return

--- a/api/cmd/uzi/tui_model_test.go
+++ b/api/cmd/uzi/tui_model_test.go
@@ -2198,4 +2198,68 @@ func TestTUIDetailCostAsciiSurvives(t *testing.T) {
 	}
 }
 
+// A detail load that resolves AFTER the user has left the run must be dropped, not applied:
+// exitToBoard resets m.detail to its zero value (nil `seen` map), so a late applyLoaded would
+// write the nil map and panic (observed in the field). The runID guard drops it.
+func TestTUIDetailLateLoadAfterExitIsDropped(t *testing.T) {
+	now := time.Now()
+	runID := "late-1"
+	m := tuiTestModel(t, &uzicli.FakeClient{}, runID)
+	// Leave the run before its load resolves.
+	m = press(t, m, keyEsc)
+	if m.view != viewBoard {
+		t.Fatalf("esc should return to the board, got view %v", m.view)
+	}
+	// The in-flight load lands now, for the run just left. It must be dropped, and must not
+	// panic against the torn-down (nil-seen) detail.
+	next, _ := m.Update(detailLoadedMsg{
+		runID: runID,
+		run:   apitypes.RunDTO{ID: runID, Status: "running", Health: "ok"},
+		msgs:  []apitypes.MessageDTO{msgDTO(1, "text", "lead", "", "", "hello", now)},
+	})
+	m = next.(tuiModel)
+	if m.detail.loaded {
+		t.Error("a load for a run the user has left must not populate the detail")
+	}
+	if len(m.detail.frames) != 0 {
+		t.Errorf("stale load spliced %d frames into a torn-down detail", len(m.detail.frames))
+	}
+}
+
+// A load that resolves for a DIFFERENT run than the one now open must be dropped, so a slow
+// run-A load cannot overwrite the run-B transcript the user drilled into next.
+func TestTUIDetailStaleLoadForOtherRunIsDropped(t *testing.T) {
+	now := time.Now()
+	m := tuiTestModel(t, &uzicli.FakeClient{}, "run-b")
+	next, _ := m.Update(detailLoadedMsg{
+		runID: "run-a",
+		run:   apitypes.RunDTO{ID: "run-a", Status: "running", Health: "ok"},
+		msgs:  []apitypes.MessageDTO{msgDTO(1, "text", "lead", "", "", "from A", now)},
+	})
+	m = next.(tuiModel)
+	if m.detail.run.ID == "run-a" {
+		t.Error("a load for run-a overwrote the open run-b detail")
+	}
+	if len(m.detail.frames) != 0 {
+		t.Errorf("run-a load spliced %d frames into run-b", len(m.detail.frames))
+	}
+}
+
+// addFrame must be total on a zero-value detailState: newDetailState seeds `seen`, but a
+// constructor-less detail (the zero value exitToBoard assigns) has a nil map, and the
+// field-observed crash was exactly a write to it. Lazy-init keeps it from panicking.
+func TestDetailAddFrameTotalOnZeroValue(t *testing.T) {
+	var d detailState // zero value: seen is nil
+	d.addFrame(laneFrame{Seq: 1})
+	if len(d.frames) != 1 {
+		t.Fatalf("addFrame on a zero-value detailState dropped the frame: got %d", len(d.frames))
+	}
+	// A second frame with the same seq is deduped, which only works if seen was initialized
+	// and written — so this also proves the lazy map is live, not just non-nil.
+	d.addFrame(laneFrame{Seq: 1})
+	if len(d.frames) != 1 {
+		t.Errorf("dedup did not hold; seen map not initialized: got %d frames", len(d.frames))
+	}
+}
+
 var _ tea.Model = tuiModel{}


### PR DESCRIPTION
## The bug

`uzi tui` panicked with `assignment to entry in nil map` at `api/cmd/uzi/tui_detail.go:148` (`d.seen[f.Seq] = true`), inside `(*detailState).applyLoaded`, reached from the `detailLoadedMsg` handler.

## Root cause

`detailLoadedMsg` was the only detail-related message with no runID guard. Every sibling (`detailMetaMsg`, `runInputsMsg`, `steerResultMsg`, `reviewLoadedMsg`, ...) drops a message whose runID does not match the open run. `exitToBoard` resets `m.detail = detailState{}` (nil `seen` map, empty runID). An in-flight `loadDetailCmd` that resolved after the user hit esc then ran `applyLoaded` on the zero-value detail and wrote the nil map, panicking. A slow run-A load could likewise splice run-A's transcript into a run-B detail the user drilled into next.

## Fix

- Carry a `runID` on `detailLoadedMsg`, set by `loadDetailCmd` on both the success and error paths.
- Guard the handler: drop a load whose id does not match `m.detail.runID`. `run.ID` is the fallback for the error path (where the DTO is zero); it is dead in production since `loadDetailCmd` always sets `runID`, and only keeps the existing test call sites valid without churn.
- Lazy-init `seen` in `addFrame` so the primitive is total (belt-and-braces).

## Tests

Three regression tests, mutation-verified as load-bearing (removing the guard fails them by assertion; removing the guard and the lazy-init reproduces the exact nil-map panic):

- a late load after exit is dropped, no panic
- a load for a different run does not overwrite the open one
- `addFrame` is total on a zero-value `detailState`

`task gate:api` (fmt, vet, build, lint, deadcode, test with -race) passes. No render/layout change, so no screenshot review needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated run details from appearing after navigating away or switching runs.
  * Improved handling when reopening or resetting detail views.
  * Prevented errors when processing transcript frames in an uninitialized detail view.

* **Tests**
  * Added coverage for stale detail results, view transitions, and duplicate transcript frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->