### PR TITLE
Default jobs tab: show per-repo last-run outcome to match My schedules

### DIFF
--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -11,8 +11,9 @@
 // lock marker is retained (it encodes a baked/read-only prompt).
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { DefaultJobs } from "./DefaultJobs";
-import { api, type CatalogEntry, type Repo, type Schedule, type ScheduleCatalog } from "../lib/api";
+import { api, type CatalogEntry, type LastFire, type Repo, type Schedule, type ScheduleCatalog } from "../lib/api";
 
 vi.mock("../lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/api")>();
@@ -103,22 +104,25 @@ function noop() {}
 const asyncNoop = async () => {};
 
 function renderTab(props: Partial<Parameters<typeof DefaultJobs>[0]> = {}) {
+  // Wrapped in a router: a sub-row's expanded LastFireDetail renders <Link> run chips.
   return render(
-    <DefaultJobs
-      catalog={props.catalog ?? catalog([entry()])}
-      schedules={props.schedules ?? []}
-      repos={props.repos ?? REPOS}
-      busyId=""
-      onEnable={props.onEnable ?? asyncNoop}
-      onTogglePause={noop}
-      onRunNow={noop}
-      onReset={noop}
-      onClone={noop}
-      onRemove={noop}
-      onEdit={noop}
-      notice=""
-      error=""
-    />,
+    <MemoryRouter>
+      <DefaultJobs
+        catalog={props.catalog ?? catalog([entry()])}
+        schedules={props.schedules ?? []}
+        repos={props.repos ?? REPOS}
+        busyId=""
+        onEnable={props.onEnable ?? asyncNoop}
+        onTogglePause={noop}
+        onRunNow={noop}
+        onReset={noop}
+        onClone={noop}
+        onRemove={noop}
+        onEdit={noop}
+        notice=""
+        error=""
+      />
+    </MemoryRouter>,
   );
 }
 
@@ -237,6 +241,59 @@ describe("DefaultJobs — Layout A (one summary row, per-repo sub-rows)", () => 
     // repo-atlas (not materialized) is offered; repo-uzi (materialized) is not.
     expect(within(picker).getByRole("option", { name: "vtmocanu/atlas-api" })).toBeTruthy();
     expect(within(picker).queryByRole("option", { name: "vtmocanu/uzi" })).toBeNull();
+  });
+});
+
+// ── issue #690: per-repo last-run parity on default sub-rows ────────────────────
+const NOW = new Date().toISOString();
+function fire(over: Partial<LastFire>): LastFire {
+  return { fired_at: NOW, matched: 0, capped: false, started: [], skips: [], ...over };
+}
+
+describe("DefaultJobs — last-run parity on sub-rows (issue #690)", () => {
+  it("an enabled default sub-row with a last_fire shows the outcome badge and expands to the fire detail", async () => {
+    const schedules = [
+      defRow({
+        id: "sch-uzi",
+        repo_id: "repo-uzi",
+        repo_path: "vtmocanu/uzi",
+        last_fire: fire({
+          matched: 1,
+          started: [{ issue_iid: 7, run_id: "77777777-0000-0000-0000-000000000000", title: "started thing" }],
+        }),
+      }),
+    ];
+    renderTab({ schedules });
+
+    // Expand the summary to reveal the single per-repo sub-row.
+    fireEvent.click(screen.getByRole("button", { name: /Show repos for Bug triage sweep/ }));
+    await waitFor(() => expect(screen.getByRole("switch", { name: "Pause on vtmocanu/uzi" })).toBeTruthy());
+
+    // Collapsed sub-row: the enriched green outcome badge, no detail panel yet (non-vacuous
+    // against the expanded assertion below).
+    expect(screen.getByText("1 started")).toBeTruthy();
+    expect(screen.queryByText("started thing")).toBeNull();
+
+    // One sub-row, so the "Last fire" disclosure is unambiguous. Expanding reveals the
+    // started run (LastFireDetail) below the flex row.
+    fireEvent.click(screen.getByRole("button", { name: "Last fire" }));
+    expect(screen.getByText("started thing")).toBeTruthy();
+  });
+
+  it("an enabled default sub-row that never fired shows the '— never fired' fallback and offers no disclosure", async () => {
+    const schedules = [
+      defRow({ id: "sch-uzi", repo_id: "repo-uzi", repo_path: "vtmocanu/uzi", last_fire: null, last_fired_at: null }),
+    ];
+    renderTab({ schedules });
+
+    fireEvent.click(screen.getByRole("button", { name: /Show repos for Bug triage sweep/ }));
+    await waitFor(() => expect(screen.getByRole("switch", { name: "Pause on vtmocanu/uzi" })).toBeTruthy());
+
+    // Scope to the sub-row (the group summary's Last-run cell also shows "— never fired"
+    // when no member has fired). The never-fired fallback is present and offers no disclosure.
+    const subRow = screen.getByRole("switch", { name: "Pause on vtmocanu/uzi" }).closest<HTMLElement>("div.rounded-lg")!;
+    expect(within(subRow).getByText("— never fired")).toBeTruthy();
+    expect(within(subRow).queryByRole("button", { name: "Last fire" })).toBeNull();
   });
 });
 

--- a/web/src/components/DefaultJobs.tsx
+++ b/web/src/components/DefaultJobs.tsx
@@ -20,7 +20,7 @@ import type { CatalogEntry, Repo, Schedule, ScheduleCatalog } from "../lib/api";
 import { humanizeCron } from "../lib/schedulePresets";
 import { RepoMultiSelect } from "./RepoMultiSelect";
 import { ScheduleGroupRow, ScheduleSubRow } from "./ScheduleGroupRow";
-import { formatStamp } from "./LastRun";
+import { LastRunOutcome, LastFireDetail, formatStamp } from "./LastRun";
 import { SweepLabelWarn } from "./SweepLabelWarn";
 import { Alert, Badge, Button, Toggle } from "./ui";
 import {
@@ -370,12 +370,33 @@ function SubRow({
   onEdit: () => void;
 }) {
   const nextFire = s.next_fires[0] ?? s.next_fire_at;
+  const [expanded, setExpanded] = useState(false);
+  const panelId = `last-fire-${s.id}`;
   return (
     <ScheduleSubRow
       repoLabel={s.repo_path || s.repo_id}
       enabled={s.enabled}
       cronExpr={s.cron_expr}
       nextFire={nextFire}
+      panelId={panelId}
+      // Per-repo last-run parity with the standalone row (issue #690): the same three-way
+      // fallback (outcome badge / bare stamp / never-fired), and the expandable detail
+      // rendered below the flex row only while expanded.
+      lastRun={
+        s.last_fire ? (
+          <LastRunOutcome
+            fire={s.last_fire}
+            expanded={expanded}
+            onToggle={() => setExpanded((v) => !v)}
+            panelId={panelId}
+          />
+        ) : s.last_fired_at ? (
+          <div className="text-[12.5px] text-muted">{formatStamp(s.last_fired_at)}</div>
+        ) : (
+          <span className="text-faint">— never fired</span>
+        )
+      }
+      lastRunDetail={s.last_fire && expanded ? <LastFireDetail s={s} fire={s.last_fire} /> : null}
       badges={s.customized ? <Badge tone="warning">customized</Badge> : null}
       leadingAction={
         // Reset is prominent for a customized row (restores the catalog cadence).

--- a/web/src/components/DefaultJobs.tsx
+++ b/web/src/components/DefaultJobs.tsx
@@ -20,6 +20,7 @@ import type { CatalogEntry, Repo, Schedule, ScheduleCatalog } from "../lib/api";
 import { humanizeCron } from "../lib/schedulePresets";
 import { RepoMultiSelect } from "./RepoMultiSelect";
 import { ScheduleGroupRow, ScheduleSubRow } from "./ScheduleGroupRow";
+import { formatStamp } from "./LastRun";
 import { SweepLabelWarn } from "./SweepLabelWarn";
 import { Alert, Badge, Button, Toggle } from "./ui";
 import {
@@ -477,16 +478,4 @@ function Chip({ children }: { children: React.ReactNode }) {
       {children}
     </span>
   );
-}
-
-function formatStamp(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-    day: "numeric",
-  }).format(d);
 }

--- a/web/src/components/LastRun.tsx
+++ b/web/src/components/LastRun.tsx
@@ -63,7 +63,10 @@ export function LastRunOutcome({
         type="button"
         onClick={onToggle}
         aria-expanded={expanded}
-        aria-controls={panelId}
+        // Only reference the panel while it is mounted: the caller renders the detail
+        // (and its id={panelId} element) only when expanded, so a collapsed disclosure
+        // must not carry a dangling aria-controls to a non-existent id (issue #690 CR).
+        aria-controls={expanded ? panelId : undefined}
         className="inline-flex w-fit items-center gap-1 rounded text-[11px] font-medium text-muted transition-colors hover:text-fg"
       >
         Last fire

--- a/web/src/components/LastRun.tsx
+++ b/web/src/components/LastRun.tsx
@@ -1,0 +1,262 @@
+// LastRun — the shared "Last run" UI for a schedule row (PRD #308 M4, mock §1/§2).
+//
+// Extracted verbatim from Schedules.tsx so it can be reused without a circular import
+// (Schedules.tsx imports DefaultJobs and ScheduleGroupRow, so re-exporting the "last run"
+// pieces from Schedules.tsx would cycle). The public surface is LastRunOutcome (the list
+// cell), LastFireDetail (the expandable panel), and formatStamp (the single source of
+// truth for the schedules' timestamp formatting).
+
+import { Link } from "react-router-dom";
+import { Badge, type BadgeTone, cx } from "./ui";
+import { ChevronDownIcon } from "./icons";
+import { ForgeIssueAnchor } from "./ForgeIssueAnchor";
+import { scheduleSkipReasonLabel } from "../lib/scheduleSkipReasons";
+import type { LastFire, LastFireSkip, Schedule, ScheduleSkipReason } from "../lib/api";
+
+// Skip-reason badge tone, mirroring the mock's semantics: the actionable skips a
+// schedule owner can fix (no PRD link, not eligible, a transient fetch failure)
+// read amber; the benign, self-resolving ones (already running, body too large)
+// read neutral. Exhaustive so a new union member is a tsc error, not a default.
+const SKIP_REASON_TONES: Record<ScheduleSkipReason, BadgeTone> = {
+  no_prd_link: "warning",
+  not_eligible: "warning",
+  already_running: "neutral",
+  description_too_large: "neutral",
+  fetch_failed: "warning",
+  // A locked owner vault (self_improve, PRD #590) is benign and self-resolving: the
+  // cycle re-fires on schedule once the vault is unlocked, so it reads neutral like the
+  // other self-resolving skips.
+  vault_locked: "neutral",
+};
+
+// LastRunOutcome is the enriched "Last run" cell for a schedule that has a
+// persisted fire (PRD #308 M4, mock §1): an outcome badge, a muted "{stamp} ·
+// examined N" line, and a disclosure that toggles the "Last fire" detail row.
+export function LastRunOutcome({
+  fire,
+  expanded,
+  onToggle,
+  panelId,
+}: {
+  fire: LastFire;
+  expanded: boolean;
+  onToggle: () => void;
+  // The detail row's element id, for the disclosure's aria-controls.
+  panelId: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="inline-flex">
+        <OutcomeBadge fire={fire} />
+      </span>
+      <span className="text-[11px] text-faint tabular-nums">
+        {formatStamp(fire.fired_at)} · examined {fire.matched}
+      </span>
+      {/* A DISCLOSURE, not a link (ux-tweaks item 2): it expands the detail row in
+          place, so it must not wear the app's link costume (text-info + underline
+          promises navigation). Muted text + a chevron is the vocabulary every other
+          expander here uses. The chevron is the SVG icon, not the ▾ font glyph — the
+          glyph's metrics drift per font and its rotated open state rendered as thin
+          stray lines; the SVG is viewBox-centred and crisp in both themes (the same
+          trade ChevronsRightIcon records in icons.tsx). */}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        className="inline-flex w-fit items-center gap-1 rounded text-[11px] font-medium text-muted transition-colors hover:text-fg"
+      >
+        Last fire
+        <ChevronDownIcon className={cx("h-3 w-3 transition-transform", expanded && "rotate-180")} />
+      </button>
+    </div>
+  );
+}
+
+// OutcomeBadge is the one-line verdict shown in the list cell: green when a fire
+// started runs, amber when it fired but started nothing (skips only), neutral for
+// an empty-label sweep that matched nothing (a legitimate outcome, not an error).
+function OutcomeBadge({ fire }: { fire: LastFire }) {
+  if (fire.started.length > 0) {
+    return (
+      <Badge tone="ok" dot>
+        {fire.started.length} started
+      </Badge>
+    );
+  }
+  if (fire.skips.length > 0) {
+    return (
+      <Badge tone="warning" dot>
+        0 started · {fire.skips.length} skipped
+      </Badge>
+    );
+  }
+  return (
+    <Badge tone="neutral" dot>
+      matched 0
+    </Badge>
+  );
+}
+
+// LastFireDetail is the expandable "Last fire" panel (mock §2): a header with the
+// fire timestamp + a status badge, an examined/started/skipped/max-issues tally, one
+// row per started run (linking to the run) and per skipped candidate (with its
+// typed reason), and the actionable cap hint when a capped fire started nothing.
+export function LastFireDetail({ s, fire }: { s: Schedule; fire: LastFire }) {
+  const good = fire.started.length > 0;
+  const skippedOnly = fire.started.length === 0 && fire.skips.length > 0;
+  // The hint that is the whole point of Goal 2: a capped fire that reached only the
+  // oldest candidate(s) and started nothing — raising the cap or labelling the head
+  // candidate is the fix. Rendered ONLY under exactly that condition.
+  const showHint = fire.capped && fire.skips.length > 0 && fire.started.length === 0;
+  return (
+    <div
+      className={cx(
+        "rounded-lg border border-edge bg-surface p-4",
+        good ? "border-l-2 border-l-ok/60" : "border-l-2 border-l-warn/60",
+      )}
+    >
+      <div className="mb-3 flex flex-wrap items-baseline gap-2.5">
+        <span className="text-[13px] font-semibold text-fg">Last fire</span>
+        <span className="font-mono text-[12px] text-faint">
+          {formatStamp(fire.fired_at)} · {s.timezone}
+        </span>
+        <span className="ml-auto">
+          {good ? (
+            <Badge tone="ok" dot>
+              {fire.started.length} started
+            </Badge>
+          ) : skippedOnly ? (
+            <Badge tone="warning" dot>
+              started nothing
+            </Badge>
+          ) : (
+            <Badge tone="neutral" dot>
+              matched 0
+            </Badge>
+          )}
+        </span>
+      </div>
+
+      <div className="mb-3.5 flex flex-wrap gap-x-5 gap-y-2">
+        <Tally n={fire.matched} label="examined" tone="mut" />
+        <Tally n={fire.started.length} label="started" tone={fire.started.length > 0 ? "ok" : "mut"} />
+        <Tally n={fire.skips.length} label="skipped" tone={fire.skips.length > 0 ? "warn" : "mut"} />
+        <Tally
+          n={s.max_issues == null ? "—" : s.max_issues}
+          label="max issues"
+          tone="mut"
+        />
+      </div>
+
+      {(fire.started.length > 0 || fire.skips.length > 0) && (
+        <div className="flex flex-col gap-2">
+          {fire.started.map((r) => (
+            <div
+              key={r.run_id}
+              className="flex items-start gap-3 rounded-lg border border-edge bg-raised/50 px-3 py-2"
+            >
+              <IssueRef issueIID={r.issue_iid} webURL={r.web_url} />
+              <div className="min-w-0 flex-1">
+                {r.title && <div className="text-[12.5px] text-muted">{r.title}</div>}
+              </div>
+              <Link
+                to={`/runs/${r.run_id}`}
+                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ok/35 bg-ok/[0.08] px-2 py-0.5 font-mono text-[11.5px] text-ok hover:bg-ok/15"
+              >
+                run {r.run_id.slice(0, 8)}…
+              </Link>
+            </div>
+          ))}
+          {fire.skips.map((skip, i) => (
+            <SkipRow key={`${skip.issue_iid ?? "prompt"}-${i}`} skip={skip} />
+          ))}
+        </div>
+      )}
+
+      {showHint && (
+        <div className="mt-3.5 flex items-start gap-2.5 rounded-lg border border-brand/25 bg-brand/[0.06] px-3 py-2.5 text-[12.5px] text-muted">
+          <span aria-hidden="true" className="shrink-0 font-bold text-brand">
+            →
+          </span>
+          <div>
+            <span className="font-semibold text-fg">Nothing newer was reached.</span> max issues is{" "}
+            <span className="font-semibold text-fg">{s.max_issues ?? "—"}</span>, so only the oldest
+            candidate{fire.skips.length === 1 ? " was" : "s were"} tried. Raise the cap so the sweep
+            reaches the candidates behind them, or add <code className="rounded bg-raised px-1 text-fg">PRDLESS</code>{" "}
+            / a PRD link.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Tally renders one big number + uppercase key in the detail panel's summary row.
+function Tally({
+  n,
+  label,
+  tone,
+}: {
+  n: number | string;
+  label: string;
+  tone: "ok" | "warn" | "mut";
+}) {
+  const color = tone === "ok" ? "text-ok" : tone === "warn" ? "text-warn" : "text-muted";
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className={cx("text-[19px] font-semibold leading-none tabular-nums", color)}>{n}</span>
+      <span className="text-[11px] uppercase tracking-wide text-faint">{label}</span>
+    </div>
+  );
+}
+
+// IssueRef renders the fire row's issue ref (PRD #411): `#<iid>` as an external forge
+// link when the issue's web_url was snapshotted at fire time and is a valid https URL,
+// otherwise a plain `#<iid>`; an issue-less fire (null iid) renders the "prompt" marker.
+// The schedule DTO carries no forge_type on fire rows, so the accessible label uses a
+// generic "the forge". This span is a SIBLING of the row's run <Link>, so a plain anchor
+// is correct here (no nested-anchor, no stopPropagation needed).
+function IssueRef({ issueIID, webURL }: { issueIID: number | null; webURL?: string | null }) {
+  const cls = "min-w-[46px] shrink-0 pt-0.5 font-mono text-[12.5px] text-fg";
+  if (issueIID == null) {
+    return <span className={cls}>prompt</span>;
+  }
+  return (
+    <ForgeIssueAnchor
+      webUrl={webURL}
+      iid={issueIID}
+      label={`Open issue #${issueIID} on the forge`}
+      className={cx(cls, "hover:text-brand")}
+      fallbackClassName={cls}
+    />
+  );
+}
+
+// SkipRow renders one skipped candidate: its issue ref (or a prompt marker), its
+// title when present, and a tone-coded badge carrying the human reason label.
+function SkipRow({ skip }: { skip: LastFireSkip }) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-edge bg-raised/50 px-3 py-2">
+      <IssueRef issueIID={skip.issue_iid} webURL={skip.web_url} />
+      <div className="min-w-0 flex-1">
+        {skip.title && <div className="text-[12.5px] text-muted">{skip.title}</div>}
+      </div>
+      <span className="shrink-0">
+        <Badge tone={SKIP_REASON_TONES[skip.reason]}>{scheduleSkipReasonLabel(skip.reason)}</Badge>
+      </span>
+    </div>
+  );
+}
+
+export function formatStamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    day: "numeric",
+  }).format(d);
+}

--- a/web/src/components/ScheduleGroupRow.tsx
+++ b/web/src/components/ScheduleGroupRow.tsx
@@ -126,12 +126,23 @@ export function ScheduleGroupRow({
 // left block (repo label + badges + cron/next line) is shared; the variant supplies its
 // own badges, an optional leading action (default's prominent Reset), and its action
 // cluster (the ghost buttons + pause/resume toggle).
+//
+// Last-run parity (issue #690): a sub-row can also carry a per-repo last-run outcome
+// badge (`lastRun`, rendered inline after the info block) and an expandable "Last fire"
+// detail (`lastRunDetail`). A sub-row is a flex <div>, NOT a table row, so the detail
+// cannot be a sibling <tr> the way the standalone ScheduleRow does it — it renders as a
+// <div> BELOW the flex row, inside this component's own DOM. Its id (`panelId`) pairs
+// with the disclosure's aria-controls and, like the standalone's, exists only while the
+// detail is rendered — which is when aria-controls has anything to point at.
 export function ScheduleSubRow({
   repoLabel,
   enabled,
   badges,
   cronExpr,
   nextFire,
+  lastRun,
+  lastRunDetail,
+  panelId,
   leadingAction,
   actions,
 }: {
@@ -143,33 +154,51 @@ export function ScheduleSubRow({
   cronExpr: string;
   // The next fire instant for the enabled row; falsy hides the "next …" span.
   nextFire?: string | null;
+  // The per-repo last-run outcome badge + disclosure, rendered inline in the flex row
+  // between the info block and the leading action; omitted when absent.
+  lastRun?: ReactNode;
+  // The expandable "Last fire" detail, rendered as a <div> below the flex row; the caller
+  // passes it only while expanded, so the below-row region (and its id) exist only then.
+  lastRunDetail?: ReactNode;
+  // The id the lastRun disclosure's aria-controls points at; set on the detail region.
+  panelId?: string;
   // An action rendered between the info block and the action cluster (default: Reset).
   leadingAction?: ReactNode;
   // The right-aligned action cluster (run-now / edit / remove / toggle …).
   actions: ReactNode;
 }) {
   return (
-    <div
-      className={cx(
-        "flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border border-edge bg-surface px-3 py-2.5",
-        !enabled && "opacity-70",
-      )}
-    >
-      <div className="min-w-[160px] flex-1">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-[12.5px] text-fg">{repoLabel}</span>
-          {badges}
-          {!enabled && <Badge tone="neutral">paused</Badge>}
+    <div>
+      <div
+        className={cx(
+          "flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border border-edge bg-surface px-3 py-2.5",
+          !enabled && "opacity-70",
+        )}
+      >
+        <div className="min-w-[160px] flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[12.5px] text-fg">{repoLabel}</span>
+            {badges}
+            {!enabled && <Badge tone="neutral">paused</Badge>}
+          </div>
+          <div className="mt-0.5 font-mono text-[11.5px] text-faint">
+            {cronExpr} · {humanizeCron(cronExpr)}
+            {enabled && nextFire && <span> · next {relativeFromNow(nextFire)}</span>}
+          </div>
         </div>
-        <div className="mt-0.5 font-mono text-[11.5px] text-faint">
-          {cronExpr} · {humanizeCron(cronExpr)}
-          {enabled && nextFire && <span> · next {relativeFromNow(nextFire)}</span>}
-        </div>
+
+        {lastRun}
+
+        {leadingAction}
+
+        <div className="flex items-center gap-1.5">{actions}</div>
       </div>
 
-      {leadingAction}
-
-      <div className="flex items-center gap-1.5">{actions}</div>
+      {lastRunDetail != null && (
+        <div id={panelId} className="mt-2">
+          {lastRunDetail}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/Schedules.test.tsx
+++ b/web/src/pages/Schedules.test.tsx
@@ -600,6 +600,53 @@ describe("Schedules — sibling groups (PRD #636 M3)", () => {
   });
 });
 
+// ── issue #690: per-repo last-run parity on grouped sub-rows ───────────────────
+describe("Schedules — last-run parity on grouped sub-rows (issue #690)", () => {
+  it("a grouped sub-row with a last_fire shows the outcome badge and expands to the fire detail", async () => {
+    // Only the uzi sibling carries a fire; the atlas sibling never fired. That keeps the
+    // "Last fire" disclosure unambiguous (one sub-row has it) while proving both the
+    // outcome-badge and never-fired branches render per-repo.
+    mockApi.listSchedules.mockResolvedValue([
+      sched({
+        id: "g1",
+        target: "prompt",
+        prompt: "grouped job",
+        repo_id: "repo-uzi",
+        repo_path: "vtmocanu/uzi",
+        sibling_group_id: "grp-1",
+        last_fire: fire({
+          matched: 1,
+          started: [{ issue_iid: 8, run_id: "88888888-0000-0000-0000-000000000000", title: "grouped started" }],
+        }),
+      }),
+      sched({
+        id: "g2",
+        target: "prompt",
+        prompt: "grouped job",
+        repo_id: "repo-atlas",
+        repo_path: "vtmocanu/atlas",
+        sibling_group_id: "grp-1",
+        last_fire: null,
+        last_fired_at: null,
+      }),
+    ]);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Show repos for Prompt: grouped job/ }));
+    await waitFor(() => expect(screen.getByRole("switch", { name: "Pause on vtmocanu/uzi" })).toBeTruthy());
+
+    // The uzi sub-row shows the enriched green outcome badge; the atlas sub-row never fired.
+    expect(screen.getByText("1 started")).toBeTruthy();
+    expect(screen.getByText("— never fired")).toBeTruthy();
+
+    // Only one sub-row carries a fire, so the disclosure is unambiguous. Expanding reveals
+    // the started run (LastFireDetail) below that sub-row's flex row.
+    expect(screen.queryByText("grouped started")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Last fire" }));
+    expect(screen.getByText("grouped started")).toBeTruthy();
+  });
+});
+
 // ── issue #638: issue schedules can't span repos + per-repo target badges ───────
 describe("Schedules — issue-target add-repo gating + sub-row badges (issue #638)", () => {
   const reason = "Issue schedules can't span repos - issue numbers are repo-relative";

--- a/web/src/pages/Schedules.test.tsx
+++ b/web/src/pages/Schedules.test.tsx
@@ -636,8 +636,19 @@ describe("Schedules — last-run parity on grouped sub-rows (issue #690)", () =>
     await waitFor(() => expect(screen.getByRole("switch", { name: "Pause on vtmocanu/uzi" })).toBeTruthy());
 
     // The uzi sub-row shows the enriched green outcome badge; the atlas sub-row never fired.
-    expect(screen.getByText("1 started")).toBeTruthy();
-    expect(screen.getByText("— never fired")).toBeTruthy();
+    // Scope each outcome to its own sub-row (anchored on the unique per-repo pause switch)
+    // so a Uzi/Atlas swap fails the test — a document-level getByText would pass either way,
+    // and "— never fired" also appears in the group summary cell (issue #690 CR).
+    const uziRow = screen
+      .getByRole("switch", { name: "Pause on vtmocanu/uzi" })
+      .closest<HTMLElement>("div.rounded-lg")!;
+    const atlasRow = screen
+      .getByRole("switch", { name: "Pause on vtmocanu/atlas" })
+      .closest<HTMLElement>("div.rounded-lg")!;
+    expect(within(uziRow).getByText("1 started")).toBeTruthy();
+    expect(within(uziRow).queryByText("— never fired")).toBeNull();
+    expect(within(atlasRow).getByText("— never fired")).toBeTruthy();
+    expect(within(atlasRow).queryByText("1 started")).toBeNull();
 
     // Only one sub-row carries a fire, so the disclosure is unambiguous. Expanding reveals
     // the started run (LastFireDetail) below that sub-row's flex row.

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -6,27 +6,22 @@
 // distinctly. The "New schedule" button and the per-row ✎ open the shared modal.
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import {
   api,
   ApiError,
   type CatalogEntry,
-  type LastFire,
-  type LastFireSkip,
   type Repo,
   type Schedule,
   type ScheduleCatalog,
-  type ScheduleSkipReason,
 } from "../lib/api";
 import { relativeFromNow, ScheduleModal } from "../components/ScheduleModal";
 import { DefaultJobs } from "../components/DefaultJobs";
 import { AddAnotherRepo, ScheduleGroupRow, ScheduleSubRow } from "../components/ScheduleGroupRow";
+import { LastRunOutcome, LastFireDetail, formatStamp } from "../components/LastRun";
 import { humanizeCron } from "../lib/schedulePresets";
-import { scheduleSkipReasonLabel } from "../lib/scheduleSkipReasons";
 import {
   Alert,
   Badge,
-  type BadgeTone,
   Button,
   ListSkeleton,
   PageHeader,
@@ -34,7 +29,6 @@ import {
   cx,
 } from "../components/ui";
 import {
-  ChevronDownIcon,
   ClockIcon,
   CopyIcon,
   PencilIcon,
@@ -42,7 +36,6 @@ import {
   PlusIcon,
   TrashIcon,
 } from "../components/icons";
-import { ForgeIssueAnchor } from "../components/ForgeIssueAnchor";
 
 type Tab = "defaults" | "mine";
 
@@ -61,22 +54,6 @@ const COLS = 6;
 // "Add another repo" affordance is disabled with this tooltip rather than left to
 // no-op (PRD #636 follow-up, issue #638 P1c).
 const ISSUE_NO_MULTI_REPO = "Issue schedules can't span repos - issue numbers are repo-relative";
-
-// Skip-reason badge tone, mirroring the mock's semantics: the actionable skips a
-// schedule owner can fix (no PRD link, not eligible, a transient fetch failure)
-// read amber; the benign, self-resolving ones (already running, body too large)
-// read neutral. Exhaustive so a new union member is a tsc error, not a default.
-const SKIP_REASON_TONES: Record<ScheduleSkipReason, BadgeTone> = {
-  no_prd_link: "warning",
-  not_eligible: "warning",
-  already_running: "neutral",
-  description_too_large: "neutral",
-  fetch_failed: "warning",
-  // A locked owner vault (self_improve, PRD #590) is benign and self-resolving: the
-  // cycle re-fires on schedule once the vault is unlocked, so it reads neutral like the
-  // other self-resolving skips.
-  vault_locked: "neutral",
-};
 
 // TAB_CLASS mirrors AdminShell's tab strip (issue #204 overflow contract) so the two
 // in-page tabs read identically to the app's other tabbed surfaces.
@@ -902,226 +879,6 @@ function MyScheduleSubRow({
   );
 }
 
-// LastRunOutcome is the enriched "Last run" cell for a schedule that has a
-// persisted fire (PRD #308 M4, mock §1): an outcome badge, a muted "{stamp} ·
-// examined N" line, and a disclosure that toggles the "Last fire" detail row.
-function LastRunOutcome({
-  fire,
-  expanded,
-  onToggle,
-  panelId,
-}: {
-  fire: LastFire;
-  expanded: boolean;
-  onToggle: () => void;
-  // The detail row's element id, for the disclosure's aria-controls.
-  panelId: string;
-}) {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="inline-flex">
-        <OutcomeBadge fire={fire} />
-      </span>
-      <span className="text-[11px] text-faint tabular-nums">
-        {formatStamp(fire.fired_at)} · examined {fire.matched}
-      </span>
-      {/* A DISCLOSURE, not a link (ux-tweaks item 2): it expands the detail row in
-          place, so it must not wear the app's link costume (text-info + underline
-          promises navigation). Muted text + a chevron is the vocabulary every other
-          expander here uses. The chevron is the SVG icon, not the ▾ font glyph — the
-          glyph's metrics drift per font and its rotated open state rendered as thin
-          stray lines; the SVG is viewBox-centred and crisp in both themes (the same
-          trade ChevronsRightIcon records in icons.tsx). */}
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={expanded}
-        aria-controls={panelId}
-        className="inline-flex w-fit items-center gap-1 rounded text-[11px] font-medium text-muted transition-colors hover:text-fg"
-      >
-        Last fire
-        <ChevronDownIcon className={cx("h-3 w-3 transition-transform", expanded && "rotate-180")} />
-      </button>
-    </div>
-  );
-}
-
-// OutcomeBadge is the one-line verdict shown in the list cell: green when a fire
-// started runs, amber when it fired but started nothing (skips only), neutral for
-// an empty-label sweep that matched nothing (a legitimate outcome, not an error).
-function OutcomeBadge({ fire }: { fire: LastFire }) {
-  if (fire.started.length > 0) {
-    return (
-      <Badge tone="ok" dot>
-        {fire.started.length} started
-      </Badge>
-    );
-  }
-  if (fire.skips.length > 0) {
-    return (
-      <Badge tone="warning" dot>
-        0 started · {fire.skips.length} skipped
-      </Badge>
-    );
-  }
-  return (
-    <Badge tone="neutral" dot>
-      matched 0
-    </Badge>
-  );
-}
-
-// LastFireDetail is the expandable "Last fire" panel (mock §2): a header with the
-// fire timestamp + a status badge, an examined/started/skipped/max-issues tally, one
-// row per started run (linking to the run) and per skipped candidate (with its
-// typed reason), and the actionable cap hint when a capped fire started nothing.
-function LastFireDetail({ s, fire }: { s: Schedule; fire: LastFire }) {
-  const good = fire.started.length > 0;
-  const skippedOnly = fire.started.length === 0 && fire.skips.length > 0;
-  // The hint that is the whole point of Goal 2: a capped fire that reached only the
-  // oldest candidate(s) and started nothing — raising the cap or labelling the head
-  // candidate is the fix. Rendered ONLY under exactly that condition.
-  const showHint = fire.capped && fire.skips.length > 0 && fire.started.length === 0;
-  return (
-    <div
-      className={cx(
-        "rounded-lg border border-edge bg-surface p-4",
-        good ? "border-l-2 border-l-ok/60" : "border-l-2 border-l-warn/60",
-      )}
-    >
-      <div className="mb-3 flex flex-wrap items-baseline gap-2.5">
-        <span className="text-[13px] font-semibold text-fg">Last fire</span>
-        <span className="font-mono text-[12px] text-faint">
-          {formatStamp(fire.fired_at)} · {s.timezone}
-        </span>
-        <span className="ml-auto">
-          {good ? (
-            <Badge tone="ok" dot>
-              {fire.started.length} started
-            </Badge>
-          ) : skippedOnly ? (
-            <Badge tone="warning" dot>
-              started nothing
-            </Badge>
-          ) : (
-            <Badge tone="neutral" dot>
-              matched 0
-            </Badge>
-          )}
-        </span>
-      </div>
-
-      <div className="mb-3.5 flex flex-wrap gap-x-5 gap-y-2">
-        <Tally n={fire.matched} label="examined" tone="mut" />
-        <Tally n={fire.started.length} label="started" tone={fire.started.length > 0 ? "ok" : "mut"} />
-        <Tally n={fire.skips.length} label="skipped" tone={fire.skips.length > 0 ? "warn" : "mut"} />
-        <Tally
-          n={s.max_issues == null ? "—" : s.max_issues}
-          label="max issues"
-          tone="mut"
-        />
-      </div>
-
-      {(fire.started.length > 0 || fire.skips.length > 0) && (
-        <div className="flex flex-col gap-2">
-          {fire.started.map((r) => (
-            <div
-              key={r.run_id}
-              className="flex items-start gap-3 rounded-lg border border-edge bg-raised/50 px-3 py-2"
-            >
-              <IssueRef issueIID={r.issue_iid} webURL={r.web_url} />
-              <div className="min-w-0 flex-1">
-                {r.title && <div className="text-[12.5px] text-muted">{r.title}</div>}
-              </div>
-              <Link
-                to={`/runs/${r.run_id}`}
-                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ok/35 bg-ok/[0.08] px-2 py-0.5 font-mono text-[11.5px] text-ok hover:bg-ok/15"
-              >
-                run {r.run_id.slice(0, 8)}…
-              </Link>
-            </div>
-          ))}
-          {fire.skips.map((skip, i) => (
-            <SkipRow key={`${skip.issue_iid ?? "prompt"}-${i}`} skip={skip} />
-          ))}
-        </div>
-      )}
-
-      {showHint && (
-        <div className="mt-3.5 flex items-start gap-2.5 rounded-lg border border-brand/25 bg-brand/[0.06] px-3 py-2.5 text-[12.5px] text-muted">
-          <span aria-hidden="true" className="shrink-0 font-bold text-brand">
-            →
-          </span>
-          <div>
-            <span className="font-semibold text-fg">Nothing newer was reached.</span> max issues is{" "}
-            <span className="font-semibold text-fg">{s.max_issues ?? "—"}</span>, so only the oldest
-            candidate{fire.skips.length === 1 ? " was" : "s were"} tried. Raise the cap so the sweep
-            reaches the candidates behind them, or add <code className="rounded bg-raised px-1 text-fg">PRDLESS</code>{" "}
-            / a PRD link.
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// Tally renders one big number + uppercase key in the detail panel's summary row.
-function Tally({
-  n,
-  label,
-  tone,
-}: {
-  n: number | string;
-  label: string;
-  tone: "ok" | "warn" | "mut";
-}) {
-  const color = tone === "ok" ? "text-ok" : tone === "warn" ? "text-warn" : "text-muted";
-  return (
-    <div className="flex flex-col gap-0.5">
-      <span className={cx("text-[19px] font-semibold leading-none tabular-nums", color)}>{n}</span>
-      <span className="text-[11px] uppercase tracking-wide text-faint">{label}</span>
-    </div>
-  );
-}
-
-// IssueRef renders the fire row's issue ref (PRD #411): `#<iid>` as an external forge
-// link when the issue's web_url was snapshotted at fire time and is a valid https URL,
-// otherwise a plain `#<iid>`; an issue-less fire (null iid) renders the "prompt" marker.
-// The schedule DTO carries no forge_type on fire rows, so the accessible label uses a
-// generic "the forge". This span is a SIBLING of the row's run <Link>, so a plain anchor
-// is correct here (no nested-anchor, no stopPropagation needed).
-function IssueRef({ issueIID, webURL }: { issueIID: number | null; webURL?: string | null }) {
-  const cls = "min-w-[46px] shrink-0 pt-0.5 font-mono text-[12.5px] text-fg";
-  if (issueIID == null) {
-    return <span className={cls}>prompt</span>;
-  }
-  return (
-    <ForgeIssueAnchor
-      webUrl={webURL}
-      iid={issueIID}
-      label={`Open issue #${issueIID} on the forge`}
-      className={cx(cls, "hover:text-brand")}
-      fallbackClassName={cls}
-    />
-  );
-}
-
-// SkipRow renders one skipped candidate: its issue ref (or a prompt marker), its
-// title when present, and a tone-coded badge carrying the human reason label.
-function SkipRow({ skip }: { skip: LastFireSkip }) {
-  return (
-    <div className="flex items-start gap-3 rounded-lg border border-edge bg-raised/50 px-3 py-2">
-      <IssueRef issueIID={skip.issue_iid} webURL={skip.web_url} />
-      <div className="min-w-0 flex-1">
-        {skip.title && <div className="text-[12.5px] text-muted">{skip.title}</div>}
-      </div>
-      <span className="shrink-0">
-        <Badge tone={SKIP_REASON_TONES[skip.reason]}>{scheduleSkipReasonLabel(skip.reason)}</Badge>
-      </span>
-    </div>
-  );
-}
-
 function OptionChip({ children }: { children: React.ReactNode }) {
   return (
     <span className="inline-flex items-center rounded-md border border-edge bg-raised px-1.5 py-0.5 text-[11px] text-muted">
@@ -1173,16 +930,4 @@ function targetTitle(s: Schedule): string {
 
 function truncate(s: string, n: number): string {
   return s.length > n ? `${s.slice(0, n - 1)}…` : s;
-}
-
-function formatStamp(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-    day: "numeric",
-  }).format(d);
 }

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -823,12 +823,33 @@ function MyScheduleSubRow({
 }) {
   const repoLabel = s.repo_path || "repo unavailable";
   const nextFire = s.next_fires[0] ?? s.next_fire_at;
+  const [expanded, setExpanded] = useState(false);
+  const panelId = `last-fire-${s.id}`;
   return (
     <ScheduleSubRow
       repoLabel={repoLabel}
       enabled={s.enabled}
       cronExpr={s.cron_expr}
       nextFire={nextFire}
+      panelId={panelId}
+      // Per-repo last-run parity with the standalone ScheduleRow (issue #690): the same
+      // three-way fallback (outcome badge / bare stamp / never-fired), and the expandable
+      // detail rendered below the flex row only while expanded.
+      lastRun={
+        s.last_fire ? (
+          <LastRunOutcome
+            fire={s.last_fire}
+            expanded={expanded}
+            onToggle={() => setExpanded((v) => !v)}
+            panelId={panelId}
+          />
+        ) : s.last_fired_at ? (
+          <div className="text-[12.5px] text-muted">{formatStamp(s.last_fired_at)}</div>
+        ) : (
+          <span className="text-faint">— never fired</span>
+        )
+      }
+      lastRunDetail={s.last_fire && expanded ? <LastFireDetail s={s} fire={s.last_fire} /> : null}
       // Per-repo target pill: the group summary no longer carries the type (PRD #636 M3),
       // and a sibling can diverge (it is an independently editable row), so surface each
       // row's own target here rather than dropping it silently.


### PR DESCRIPTION
Implements issue #690.

Closes #690

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-690`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent latest-run status displays for schedules and repository rows.
  - Added outcome badges, timestamps, never-run states, and expandable execution details.
  - Added visibility into started runs, skipped candidates, skip reasons, related issues, and capped-run guidance.

- **Bug Fixes**
  - Improved grouped schedule views so each repository correctly shows its own latest-run state.
  - Added fallback handling for repositories that have never run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->