### PR TITLE
PRD #590 follow-ups: self_improve schedule editability, auto_approve no-op, and vault-skip polish

### DIFF
--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -395,6 +395,18 @@ func TestSelfImproveScheduleReconfigureLiveDB(t *testing.T) {
 	if !defFalse.AutoApprove {
 		t.Fatalf("default-origin self_improve auto_approve after false patch = %v, want true (forced)", defFalse.AutoApprove)
 	}
+
+	// Item 1 defense-in-depth: a PATCH must not CONVERT a non-self_improve row into a
+	// self_improve one (that would be a create-by-patch the direct POST path blocks). Create a
+	// plain sweep schedule, then try to repoint its target to self_improve → 400.
+	sweep, code := f.createSchedule(t, f.owner.ID, f.repoID,
+		`{"target":"sweep","timing":"recurring","cron_expr":"0 3 * * *","timezone":"UTC"}`)
+	if code != http.StatusCreated {
+		t.Fatalf("create sweep status = %d, want 201", code)
+	}
+	if _, cc := f.patchSchedule(t, f.owner.ID, sweep.ID, `{"target":"self_improve"}`); cc != http.StatusBadRequest {
+		t.Fatalf("convert sweep→self_improve via PATCH status = %d, want 400 (conversion blocked)", cc)
+	}
 }
 
 // TestCloneToDifferentRepoLiveDB: a {"repo_id"} body clones into a second owned repo; a

--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -321,6 +321,82 @@ func TestCloneUserScheduleCopiesFieldsLiveDB(t *testing.T) {
 	}
 }
 
+// TestSelfImproveScheduleReconfigureLiveDB (PRD #590 follow-up, items 1 & 2) pins the
+// self_improve schedule lifecycle end to end against a real DB:
+//   - a DIRECT POST /schedules with target=self_improve stays a 400 (catalog-enable-only);
+//   - a user-origin CLONE of an enabled self_improve default is a valid row whose config
+//     PATCH (cron) is accepted (item 1);
+//   - auto_approve is force-true on BOTH the user-origin clone and the default row, so a
+//     PATCH setting it false is ignored and it stays true (item 2).
+func TestSelfImproveScheduleReconfigureLiveDB(t *testing.T) {
+	ctx := context.Background()
+	f := newScheduleFixture(ctx, t)
+
+	// Item 1 invariant: a direct create of a self_improve schedule is rejected with the
+	// unchanged target message (self_improve is not a directly-creatable target).
+	req := userReq(http.MethodPost, "/api/repos/"+f.repoID.String()+"/schedules",
+		`{"target":"self_improve","timing":"recurring","cron_expr":"0 4 */2 * *","timezone":"UTC"}`,
+		f.owner.ID, map[string]string{"id": f.repoID.String()})
+	rec := httptest.NewRecorder()
+	f.h.CreateSchedule(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("direct self_improve create status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "target must be one of: issue, sweep, prompt") {
+		t.Fatalf("direct self_improve create body = %q, want the unchanged target message", rec.Body.String())
+	}
+
+	// Enable the self_improve default, then clone it into a second owned repo → a user-origin
+	// self_improve row the owner may reconfigure.
+	def, code := f.enableCatalog(t, f.owner.ID, f.repoID, "self-improve")
+	if code != http.StatusCreated {
+		t.Fatalf("enable self-improve status = %d, want 201", code)
+	}
+	if def.Target != "self_improve" || def.Origin != "default" {
+		t.Fatalf("enabled self_improve dto = target %q origin %q, want self_improve/default", def.Target, def.Origin)
+	}
+	if !def.AutoApprove {
+		t.Fatalf("enabled self_improve default auto_approve = false, want true (catalog default)")
+	}
+
+	targetRepo := f.insertRepo(ctx, t, f.owner, 2, "g/sched-si")
+	clone, code := f.cloneSchedule(t, f.owner.ID, def.ID, `{"repo_id":"`+targetRepo.String()+`"}`)
+	if code != http.StatusCreated {
+		t.Fatalf("clone self_improve status = %d, want 201", code)
+	}
+	if clone.Target != "self_improve" || clone.Origin != "user" || clone.CatalogSlug != nil {
+		t.Fatalf("clone = target %q origin %q slug %v, want self_improve/user/nil", clone.Target, clone.Origin, clone.CatalogSlug)
+	}
+
+	// Item 1: a config PATCH (new cron) on the user-origin clone is ACCEPTED (200) and persists.
+	const newCron = "30 5 */3 * *"
+	patched := f.patchDefault(t, f.owner.ID, clone.ID, `{"cron_expr":"`+newCron+`"}`)
+	if patched.CronExpr != newCron {
+		t.Fatalf("patched clone cron = %q, want %q", patched.CronExpr, newCron)
+	}
+	// It really persisted.
+	got, gcode := f.getSchedule(t, f.owner.ID, clone.ID)
+	if gcode != http.StatusOK {
+		t.Fatalf("re-read clone status = %d, want 200", gcode)
+	}
+	if got.CronExpr != newCron {
+		t.Fatalf("re-read clone cron = %q, want the persisted %q", got.CronExpr, newCron)
+	}
+
+	// Item 2 (user-origin path): a PATCH trying to set auto_approve=false is ignored — a
+	// self_improve run is always auto-approved, so the stored flag stays true.
+	userFalse := f.patchDefault(t, f.owner.ID, clone.ID, `{"auto_approve":false}`)
+	if !userFalse.AutoApprove {
+		t.Fatalf("user-origin self_improve auto_approve after false patch = %v, want true (forced)", userFalse.AutoApprove)
+	}
+
+	// Item 2 (default-origin path): the same on the enabled default row stays true.
+	defFalse := f.patchDefault(t, f.owner.ID, def.ID, `{"auto_approve":false}`)
+	if !defFalse.AutoApprove {
+		t.Fatalf("default-origin self_improve auto_approve after false patch = %v, want true (forced)", defFalse.AutoApprove)
+	}
+}
+
 // TestCloneToDifferentRepoLiveDB: a {"repo_id"} body clones into a second owned repo; a
 // foreign/absent target repo is a 404.
 func TestCloneToDifferentRepoLiveDB(t *testing.T) {

--- a/api/internal/handler/schedules.go
+++ b/api/internal/handler/schedules.go
@@ -55,7 +55,13 @@ const MaxSweepIssues = 10000
 // stripped of blanks — and returns the normalized request plus an HTTP status/message
 // (status 0 == valid). It never touches the forge or the store; the per-target field
 // invariants it enforces mirror the DB CHECK the row would otherwise fail on insert.
-func validateScheduleConfig(req apitypes.ScheduleRequest, now time.Time) (apitypes.ScheduleRequest, int, string) {
+//
+// allowSelfImprove gates the self_improve target (PRD #590 follow-up, item 1): a
+// self_improve schedule is catalog-enable-only, so a DIRECT create (POST /schedules) must
+// keep returning the same "target must be one of: issue, sweep, prompt" 400 (pass false),
+// while a user-origin CLONE reconfiguring its own row routes its config PATCH through this
+// validator and must be accepted (pass true). It is true only on the patch/merge caller.
+func validateScheduleConfig(req apitypes.ScheduleRequest, now time.Time, allowSelfImprove bool) (apitypes.ScheduleRequest, int, string) {
 	n := req
 	n.Timezone = strings.TrimSpace(n.Timezone)
 	if n.Timezone == "" {
@@ -130,6 +136,25 @@ func validateScheduleConfig(req apitypes.ScheduleRequest, now time.Time) (apityp
 		if n.Guidance != nil {
 			return n, http.StatusBadRequest, "guidance is not valid for a prompt schedule"
 		}
+	case "self_improve":
+		// A self_improve schedule is catalog-enable-only: a DIRECT create (POST /schedules)
+		// stays rejected (defense in depth), but a user-origin CLONE (CloneSchedule) is a valid
+		// row the owner may reconfigure, so its config PATCH (which routes through this validator)
+		// must be accepted. allowSelfImprove is true only on the patch/merge caller.
+		// (PRD #590 follow-up, item 1.)
+		if !allowSelfImprove {
+			return n, http.StatusBadRequest, "target must be one of: issue, sweep, prompt"
+		}
+		// A self_improve row carries only cadence/model — no issue_iid/labels/prompt and no
+		// sweep cap (mirrors the issue/prompt arms rejecting a stray max_issues).
+		if n.MaxIssues != nil {
+			return n, http.StatusBadRequest, "max_issues is only valid for a sweep schedule"
+		}
+		// Item 2: a self_improve run is ALWAYS auto-approved (CreateSelfImproveRun hardcodes
+		// auto_approve=true, selfimprove.sql). Force the stored flag true so it can never
+		// misrepresent as manual-approve; do not honor a user-set false.
+		approve := true
+		n.AutoApprove = &approve
 	default:
 		return n, http.StatusBadRequest, "target must be one of: issue, sweep, prompt"
 	}
@@ -173,7 +198,7 @@ func (h *Handler) CreateSchedule(w http.ResponseWriter, r *http.Request) {
 	}
 	applyCreateDefaults(&req)
 
-	m, status, msg := validateScheduleConfig(req, h.clock())
+	m, status, msg := validateScheduleConfig(req, h.clock(), false)
 	if status != 0 {
 		httpx.Error(w, status, msg)
 		return
@@ -302,7 +327,7 @@ func (h *Handler) PatchSchedule(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		m, status, msg := validateScheduleConfig(merged, h.clock())
+		m, status, msg := validateScheduleConfig(merged, h.clock(), true)
 		if status != 0 {
 			httpx.Error(w, status, msg)
 			return
@@ -1028,6 +1053,14 @@ func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Requ
 	autoApprove := cur.AutoApprove
 	if req.AutoApprove != nil {
 		autoApprove = *req.AutoApprove
+	}
+	// Item 2 (PRD #590 follow-up): a self_improve run is always auto-approved
+	// (CreateSelfImproveRun hardcodes auto_approve=true, selfimprove.sql); force the schedule's
+	// stored flag true regardless of the request so the DTO/modal never misrepresent it as
+	// manual-approve. The catalog default is auto_approve=true, so this keeps the row from
+	// spuriously flagging customized.
+	if cur.Target == "self_improve" {
+		autoApprove = true
 	}
 	waitOnLimit := cur.WaitOnLimit
 	if req.WaitOnLimit != nil {

--- a/api/internal/handler/schedules.go
+++ b/api/internal/handler/schedules.go
@@ -60,7 +60,10 @@ const MaxSweepIssues = 10000
 // self_improve schedule is catalog-enable-only, so a DIRECT create (POST /schedules) must
 // keep returning the same "target must be one of: issue, sweep, prompt" 400 (pass false),
 // while a user-origin CLONE reconfiguring its own row routes its config PATCH through this
-// validator and must be accepted (pass true). It is true only on the patch/merge caller.
+// validator and must be accepted. The patch/merge caller passes true ONLY when the row is
+// already self_improve (cur.Target == "self_improve"), so editing an existing self_improve
+// row is allowed but CONVERTING an issue/sweep/prompt row into one via PATCH stays a 400 —
+// a create-by-patch the direct POST path also blocks.
 func validateScheduleConfig(req apitypes.ScheduleRequest, now time.Time, allowSelfImprove bool) (apitypes.ScheduleRequest, int, string) {
 	n := req
 	n.Timezone = strings.TrimSpace(n.Timezone)
@@ -327,7 +330,12 @@ func (h *Handler) PatchSchedule(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		m, status, msg := validateScheduleConfig(merged, h.clock(), true)
+		// self_improve is catalog-enable-only (defense in depth): a config PATCH may edit an
+		// EXISTING self_improve row (a catalog-enabled default or a clone of one) but must not
+		// CONVERT an issue/sweep/prompt row into one — that would be a create-by-patch the
+		// direct POST path deliberately blocks. So allow the self_improve arm only when the row
+		// is already self_improve (PRD #590 follow-up, item 1).
+		m, status, msg := validateScheduleConfig(merged, h.clock(), cur.Target == "self_improve")
 		if status != 0 {
 			httpx.Error(w, status, msg)
 			return

--- a/api/internal/handler/schedules_test.go
+++ b/api/internal/handler/schedules_test.go
@@ -150,7 +150,7 @@ func TestValidateScheduleConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, status, msg := validateScheduleConfig(tc.req, fixedNow)
+			_, status, msg := validateScheduleConfig(tc.req, fixedNow, false)
 			if status != tc.wantStatus {
 				t.Fatalf("status = %d (%q), want %d", status, msg, tc.wantStatus)
 			}
@@ -163,7 +163,7 @@ func TestValidateScheduleConfig(t *testing.T) {
 func TestValidateScheduleConfigNormalizes(t *testing.T) {
 	n, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "sweep", Labels: []string{"  ", "bug", ""}, Timing: "recurring", CronExpr: "0 2 * * *",
-	}, fixedNow)
+	}, fixedNow, false)
 	if status != 0 {
 		t.Fatalf("status = %d, want 0", status)
 	}
@@ -367,7 +367,7 @@ func TestValidateScheduleConfigGuidance(t *testing.T) {
 	big := strings.Repeat("g", MaxGuidanceBytes+1)
 	if _, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "issue", IssueIID: i64(7), Guidance: sptr(big), Timing: "recurring", CronExpr: "0 2 * * *",
-	}, fixedNow); status != http.StatusUnprocessableEntity {
+	}, fixedNow, false); status != http.StatusUnprocessableEntity {
 		t.Fatalf("oversize guidance status = %d, want 422", status)
 	}
 
@@ -375,28 +375,28 @@ func TestValidateScheduleConfigGuidance(t *testing.T) {
 	atCap := strings.Repeat("g", MaxGuidanceBytes)
 	if _, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "sweep", Guidance: sptr(atCap), Timing: "recurring", CronExpr: "0 9 * * 1",
-	}, fixedNow); status != 0 {
+	}, fixedNow, false); status != 0 {
 		t.Fatalf("at-cap guidance status = %d, want 0", status)
 	}
 
 	// Guidance on the prompt target → 400.
 	if _, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "prompt", Prompt: "do the thing", Guidance: sptr("steer me"), Timing: "recurring", CronExpr: "0 9 * * 1",
-	}, fixedNow); status != http.StatusBadRequest {
+	}, fixedNow, false); status != http.StatusBadRequest {
 		t.Fatalf("guidance-on-prompt status = %d, want 400", status)
 	}
 
 	// A blank/whitespace guidance on prompt is NOT a rejection — it normalizes to nil first.
 	if n, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "prompt", Prompt: "do the thing", Guidance: sptr("   \n\t "), Timing: "recurring", CronExpr: "0 9 * * 1",
-	}, fixedNow); status != 0 || n.Guidance != nil {
+	}, fixedNow, false); status != 0 || n.Guidance != nil {
 		t.Fatalf("blank guidance on prompt: status=%d guidance=%v, want status 0 and nil guidance", status, n.Guidance)
 	}
 
 	// A real value on issue is accepted and preserved.
 	if n, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "issue", IssueIID: i64(7), Guidance: sptr("keep the diff small"), Timing: "recurring", CronExpr: "0 2 * * *",
-	}, fixedNow); status != 0 || n.Guidance == nil || *n.Guidance != "keep the diff small" {
+	}, fixedNow, false); status != 0 || n.Guidance == nil || *n.Guidance != "keep the diff small" {
 		t.Fatalf("valid issue guidance: status=%d guidance=%v, want status 0 and preserved value", status, n.Guidance)
 	}
 }
@@ -482,14 +482,14 @@ func TestValidateScheduleConfigModel(t *testing.T) {
 	// A valid alias is accepted and normalized (trimmed) on issue.
 	if n, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "issue", IssueIID: i64(7), Model: sptr("  fable  "), Timing: "recurring", CronExpr: "0 2 * * *",
-	}, fixedNow); status != 0 || n.Model == nil || *n.Model != "fable" {
+	}, fixedNow, false); status != 0 || n.Model == nil || *n.Model != "fable" {
 		t.Fatalf("valid alias: status=%d model=%v, want status 0 and normalized \"fable\"", status, n.Model)
 	}
 
 	// A valid custom ID (a full model identifier) is accepted.
 	if n, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "sweep", Model: sptr("us.anthropic.claude-opus-4-1-20250805-v1:0"), Timing: "recurring", CronExpr: "0 9 * * 1",
-	}, fixedNow); status != 0 || n.Model == nil || *n.Model != "us.anthropic.claude-opus-4-1-20250805-v1:0" {
+	}, fixedNow, false); status != 0 || n.Model == nil || *n.Model != "us.anthropic.claude-opus-4-1-20250805-v1:0" {
 		t.Fatalf("valid custom ID: status=%d model=%v, want status 0 and preserved value", status, n.Model)
 	}
 
@@ -503,7 +503,7 @@ func TestValidateScheduleConfigModel(t *testing.T) {
 		{"sweep", apitypes.ScheduleRequest{Target: "sweep", Model: sptr("fable"), Timing: "recurring", CronExpr: "0 9 * * 1"}},
 		{"issue", apitypes.ScheduleRequest{Target: "issue", IssueIID: i64(7), Model: sptr("fable"), Timing: "recurring", CronExpr: "0 2 * * *"}},
 	} {
-		if n, status, _ := validateScheduleConfig(tc.req, fixedNow); status != 0 || n.Model == nil || *n.Model != "fable" {
+		if n, status, _ := validateScheduleConfig(tc.req, fixedNow, false); status != 0 || n.Model == nil || *n.Model != "fable" {
 			t.Fatalf("model on %s target: status=%d model=%v, want status 0 and \"fable\" (model is not target-scoped)", tc.name, status, n.Model)
 		}
 	}
@@ -511,7 +511,7 @@ func TestValidateScheduleConfigModel(t *testing.T) {
 	// A malformed token (interior whitespace) → 400 with a "model:" message.
 	if _, status, msg := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "issue", IssueIID: i64(7), Model: sptr("two words"), Timing: "recurring", CronExpr: "0 2 * * *",
-	}, fixedNow); status != http.StatusBadRequest || !strings.HasPrefix(msg, "model:") {
+	}, fixedNow, false); status != http.StatusBadRequest || !strings.HasPrefix(msg, "model:") {
 		t.Fatalf("malformed model: status=%d msg=%q, want 400 and a \"model:\" message", status, msg)
 	}
 
@@ -519,14 +519,14 @@ func TestValidateScheduleConfigModel(t *testing.T) {
 	tooLong := strings.Repeat("m", 101)
 	if _, status, msg := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "sweep", Model: sptr(tooLong), Timing: "recurring", CronExpr: "0 9 * * 1",
-	}, fixedNow); status != http.StatusBadRequest || !strings.HasPrefix(msg, "model:") {
+	}, fixedNow, false); status != http.StatusBadRequest || !strings.HasPrefix(msg, "model:") {
 		t.Fatalf("oversize model: status=%d msg=%q, want 400 and a \"model:\" message", status, msg)
 	}
 
 	// A blank/whitespace model normalizes to nil (inherit), status 0.
 	if n, status, _ := validateScheduleConfig(apitypes.ScheduleRequest{
 		Target: "issue", IssueIID: i64(7), Model: sptr("   \n\t "), Timing: "recurring", CronExpr: "0 2 * * *",
-	}, fixedNow); status != 0 || n.Model != nil {
+	}, fixedNow, false); status != 0 || n.Model != nil {
 		t.Fatalf("blank model: status=%d model=%v, want status 0 and nil model", status, n.Model)
 	}
 }

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -2144,9 +2144,14 @@ func TestTickSelfImproveVaultLockedSkipsAndAdvances(t *testing.T) {
 	if got := h.countKind("selfimprove_skipped"); got != 1 {
 		t.Fatalf("vault locked: selfimprove_skipped notifications = %d, want 1", got)
 	}
-	// Item 4 (PRD #590 follow-up): the reworded body no longer implies unlocking resumes the
-	// cycle soon — it must not carry the old "to resume" phrasing.
-	if body := selfImproveSkippedBody(t, h); strings.Contains(body, "to resume") {
+	// Item 4 (PRD #590 follow-up): the reworded body must state the next-scheduled-time retry
+	// and no longer imply unlocking resumes the cycle soon (no old "to resume" phrasing). Assert
+	// the positive wording too, so an empty or unrelated body cannot pass this check vacuously.
+	body := selfImproveSkippedBody(t, h)
+	if !strings.Contains(body, "It will try again at the next scheduled time") {
+		t.Fatalf("vault-lock body = %q, want next-scheduled-time retry wording", body)
+	}
+	if strings.Contains(body, "to resume") {
 		t.Fatalf("vault-lock body must not imply unlocking resumes it (no %q): %q", "to resume", body)
 	}
 	// The skip precedes any forge work.

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -2144,6 +2144,11 @@ func TestTickSelfImproveVaultLockedSkipsAndAdvances(t *testing.T) {
 	if got := h.countKind("selfimprove_skipped"); got != 1 {
 		t.Fatalf("vault locked: selfimprove_skipped notifications = %d, want 1", got)
 	}
+	// Item 4 (PRD #590 follow-up): the reworded body no longer implies unlocking resumes the
+	// cycle soon — it must not carry the old "to resume" phrasing.
+	if body := selfImproveSkippedBody(t, h); strings.Contains(body, "to resume") {
+		t.Fatalf("vault-lock body must not imply unlocking resumes it (no %q): %q", "to resume", body)
+	}
 	// The skip precedes any forge work.
 	if h.fb.f.createCount != 0 {
 		t.Fatalf("vault locked: tracking issue created %d, want 0", h.fb.f.createCount)
@@ -2176,6 +2181,65 @@ func TestTickSelfImproveActiveRunSkipsQuietly(t *testing.T) {
 	}
 	if len(h.st.advanceCalls) != 1 {
 		t.Fatalf("active run: advance calls = %d, want 1 (benign skip advances)", len(h.st.advanceCalls))
+	}
+}
+
+// selfImproveSkippedBody returns the body of the single selfimprove_skipped notification,
+// failing the test if there is not exactly one.
+func selfImproveSkippedBody(t *testing.T, h *harness) string {
+	t.Helper()
+	var bodies []string
+	for _, notif := range h.notif.notifications {
+		if notif.Kind == "selfimprove_skipped" && notif.Slack != nil {
+			bodies = append(bodies, notif.Slack.Body)
+		}
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("selfimprove_skipped notifications = %d, want exactly 1", len(bodies))
+	}
+	return bodies[0]
+}
+
+// TestTickSelfImproveActiveRunWinsOverVaultLocked pins item 5's ordering (PRD #590
+// follow-up): when a run is ALREADY active for the repo AND the vault is locked, the
+// active-run pre-check runs first, so the fire is a quiet already_running skip — NOT a
+// vault-locked skip. No selfimprove_skipped notification is emitted, no run is created, and
+// the schedule still advances (benign skip). A regression that reordered these back would
+// emit a spurious vault-locked notification here.
+func TestTickSelfImproveActiveRunWinsOverVaultLocked(t *testing.T) {
+	h := newHarness()
+	h.vault.unlocked = false // vault locked
+	h.st.activeSelfImprove = 1
+	h.st.due = []store.RunSchedule{h.selfImproveSchedule()}
+
+	h.sched.Boot(context.Background())
+
+	if len(h.runs.selfImprove) != 0 {
+		t.Fatalf("active run wins: created %d runs, want 0", len(h.runs.selfImprove))
+	}
+	if got := h.countKind("selfimprove_skipped"); got != 0 {
+		t.Fatalf("active run wins: selfimprove_skipped notifications = %d, want 0 (active-run skip precedes vault-lock)", got)
+	}
+	if len(h.notif.notifications) != 0 {
+		t.Fatalf("active run wins: sent %d notifications, want 0", len(h.notif.notifications))
+	}
+	if h.fb.f.createCount != 0 {
+		t.Fatalf("active run wins: tracking issue created %d, want 0 (skip precedes forge work)", h.fb.f.createCount)
+	}
+	// Benign skip still advances, and its recorded skip reason is already_running, not the
+	// vault-lock reason.
+	if len(h.st.advanceCalls) != 1 {
+		t.Fatalf("active run wins: advance calls = %d, want 1 (benign skip advances)", len(h.st.advanceCalls))
+	}
+	var rec lastFireRecord
+	if err := json.Unmarshal(h.st.advanceCalls[0].LastFire, &rec); err != nil {
+		t.Fatalf("last_fire not valid JSON: %v", err)
+	}
+	if len(rec.Skips) != 1 || rec.Skips[0].Reason != string(SkipAlreadyRunning) {
+		t.Fatalf("last_fire = %+v, want exactly one already_running skip", rec)
+	}
+	if len(h.st.statusCalls) != 0 {
+		t.Fatalf("active run wins must not park: statusCalls = %+v", h.st.statusCalls)
 	}
 }
 

--- a/api/internal/schedsvc/self_improve.go
+++ b/api/internal/schedsvc/self_improve.go
@@ -51,7 +51,7 @@ const selfImproveTrackingBody = "Autonomous self-improvement tracking issue (PRD
 const selfImproveBacklogCap = 50
 
 // fireSelfImprove fires one self_improve schedule: it resolves the owner's repo, skips
-// benignly if the vault is locked or a run is already active for the repo, files (or
+// benignly if a run is already active for the repo or the vault is locked, files (or
 // reuses) the tracking issue, folds the owner's improve_uzi backlog into an auto-approved
 // self_improve run, marks that backlog addressed, and notifies the owner. It is the
 // relocated runCycle from selfimprove/engine.go, adapted to the fire-per-schedule model
@@ -68,19 +68,13 @@ func (e *Scheduler) fireSelfImprove(ctx context.Context, sched store.RunSchedule
 		return FireOutcome{}, err // transient DB error: retry next tick
 	}
 
-	// 2. Vault-lock skip (benign): the owner's DEK is not cached, so the autonomous run can't
-	// spend their token this cycle. Notify + advance normally; the cadence re-fires on schedule
-	// once the vault is unlocked. A nil vault is treated as always unlocked (a deployment
-	// without the vault), mirroring the bespoke engine.
-	if e.vault != nil && !e.vault.Unlocked(sched.UserID) {
-		e.notifySelfImprove(ctx, sched.UserID, "selfimprove_skipped", "Self-improvement cycle skipped",
-			"Your vault is locked, so the self-improvement run can't spend your token this cycle. Unlock your vault to resume.", nil)
-		return FireOutcome{Matched: 1, Skips: []Skip{{Reason: SkipVaultLocked}}}, nil
-	}
-
-	// 3. Active-run pre-check, per repo. On a DB error retry next tick (transient). If a run
+	// 2. Active-run pre-check, per repo. On a DB error retry next tick (transient). If a run
 	// is already active for this repo, benign skip — no notification (mirrors firePrompt's
 	// active skip); the per-repo unique index is the hard guard, this just skips the forge work.
+	// This precedes the vault-lock check (PRD #590 follow-up, item 5): if a cycle is already
+	// running for the repo, the fire is a no-op regardless of vault state, so skipping quietly
+	// here avoids emitting a spurious "vault locked" notification for a cycle that was never
+	// going to start anyway.
 	active, err := e.store.CountActiveSelfImproveRunsForRepo(ctx, sched.RepoID)
 	if err != nil {
 		return FireOutcome{}, err // transient DB error
@@ -88,6 +82,16 @@ func (e *Scheduler) fireSelfImprove(ctx context.Context, sched store.RunSchedule
 	if active > 0 {
 		e.logger.Info("scheduler: self_improve run active for repo, skipping fire", "schedule", sched.ID.String())
 		return FireOutcome{Matched: 1, Skips: []Skip{{Reason: SkipAlreadyRunning}}}, nil
+	}
+
+	// 3. Vault-lock skip (benign): the owner's DEK is not cached, so the autonomous run can't
+	// spend their token this cycle. Notify + advance normally; the cadence re-fires on schedule
+	// once the vault is unlocked. A nil vault is treated as always unlocked (a deployment
+	// without the vault), mirroring the bespoke engine.
+	if e.vault != nil && !e.vault.Unlocked(sched.UserID) {
+		e.notifySelfImprove(ctx, sched.UserID, "selfimprove_skipped", "Self-improvement cycle skipped",
+			"Your vault is locked, so this self-improvement cycle was skipped — it can't spend your token while locked. It will try again at the next scheduled time; unlock your vault before then so it isn't skipped again.", nil)
+		return FireOutcome{Matched: 1, Skips: []Skip{{Reason: SkipVaultLocked}}}, nil
 	}
 
 	// 4. Build the forge driver. A build failure (decrypt/driver) is transient — retry next

--- a/api/internal/store/migrations/00158_self_improve_dedup_per_repo.sql
+++ b/api/internal/store/migrations/00158_self_improve_dedup_per_repo.sql
@@ -14,7 +14,23 @@ CREATE UNIQUE INDEX uq_runs_one_active_self_improve
     WHERE kind = 'self_improve' AND status NOT IN ('completed', 'failed', 'cancelled');
 
 -- +goose Down
+-- The up newly permits one active self_improve run PER REPO; the historical instance-wide
+-- UNIQUE(kind) index below admits only one total, so a faithful rollback must first collapse
+-- any surplus. Cancel every non-terminal self_improve run except the oldest so the unique
+-- index can be rebuilt deterministically (down-migrations are manual and this intentionally
+-- reverts to the stricter instance-wide guard).
 DROP INDEX IF EXISTS uq_runs_one_active_self_improve;
+
+UPDATE runs SET status = 'cancelled'
+ WHERE kind = 'self_improve'
+   AND status NOT IN ('completed', 'failed', 'cancelled')
+   AND id <> (
+       SELECT id FROM runs
+        WHERE kind = 'self_improve'
+          AND status NOT IN ('completed', 'failed', 'cancelled')
+        ORDER BY created_at ASC, id ASC
+        LIMIT 1
+   );
 
 CREATE UNIQUE INDEX uq_runs_one_active_self_improve
     ON runs (kind)

--- a/web/src/components/ScheduleModal.test.tsx
+++ b/web/src/components/ScheduleModal.test.tsx
@@ -324,6 +324,43 @@ describe("the create-only Enabled toggle (PRD #344 Feature B)", () => {
   });
 });
 
+describe("auto-approve is hidden for a self_improve schedule (PRD #590 follow-up 2)", () => {
+  it("hides the Auto-approve toggle and drops the approve segment from the footer", () => {
+    render(
+      <MemoryRouter>
+        <ScheduleModal
+          editing={schedFixture({ target: "self_improve", origin: "user", auto_approve: true })}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    // A self_improve run is always server-forced to auto_approve, so the toggle must not
+    // render (showing it would misrepresent a fixed value as a user choice).
+    expect(screen.queryByRole("switch", { name: "Auto-approve the plan" })).toBeNull();
+
+    // The footer summary drops the approve segment entirely but still names the target.
+    const footer = screen.getByText(/self-improve/);
+    expect(footer.textContent).not.toMatch(/auto-approve/);
+    expect(footer.textContent).not.toMatch(/manual approve/);
+  });
+
+  it("still renders the Auto-approve toggle for a non-self_improve schedule (control)", () => {
+    render(
+      <MemoryRouter>
+        <ScheduleModal
+          editing={schedFixture({ target: "sweep", auto_approve: true })}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("switch", { name: "Auto-approve the plan" })).toBeTruthy();
+  });
+});
+
 describe("the edit-mode repo selector (PRD #344 Feature A)", () => {
   // Two repos so an edit can pick a different one than the schedule's current repo.
   function twoRepos() {

--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -431,7 +431,9 @@ export function ScheduleModal({
   const buildDefaultInput = (): ScheduleInput => ({
     cron_expr: cron.trim(),
     timezone,
-    auto_approve: autoApprove,
+    // A self_improve run is always auto-approved (the server forces auto_approve=true on
+    // every path), so omit it here rather than send a client-chosen value the server ignores.
+    auto_approve: target === "self_improve" ? undefined : autoApprove,
     wait_on_limit: waitOnLimit,
     max_issues: target === "sweep" ? maxIssues : undefined,
     model: model.trim() === "" ? null : model,
@@ -458,7 +460,9 @@ export function ScheduleModal({
     cron_expr: timing === "recurring" ? cron.trim() : undefined,
     run_at: timing === "once" ? fromLocalInput(runAtLocal) : undefined,
     timezone,
-    auto_approve: autoApprove,
+    // A self_improve run is always auto-approved (the server forces auto_approve=true on
+    // every path), so omit it here rather than send a client-chosen value the server ignores.
+    auto_approve: target === "self_improve" ? undefined : autoApprove,
     wait_on_limit: waitOnLimit,
     // Model override on EVERY target (all-targets field, unlike guidance); an empty
     // control sends explicit null to clear-to-inherit (replace-semantics).
@@ -563,7 +567,7 @@ export function ScheduleModal({
     </Field>
   );
 
-  const footerSummary = [
+  const footerSummarySegments = [
     timing === "once" ? "One time" : "Recurring",
     target === "sweep"
       ? "sweep"
@@ -572,8 +576,13 @@ export function ScheduleModal({
         : target === "self_improve"
           ? "self-improve"
           : "issue",
-    autoApprove ? "auto-approve" : "manual approve",
-  ].join(" · ");
+  ];
+  // A self_improve run is always auto-approved (the server forces it), so drop the
+  // approve segment entirely there — it is a fixed value, not a user choice.
+  if (target !== "self_improve") {
+    footerSummarySegments.push(autoApprove ? "auto-approve" : "manual approve");
+  }
+  const footerSummary = footerSummarySegments.join(" · ");
 
   return (
     <div
@@ -956,15 +965,19 @@ export function ScheduleModal({
                 </span>
               </span>
             </div>
-            <div className="flex items-start gap-3">
-              <Toggle checked={autoApprove} onChange={setAutoApprove} label="Auto-approve the plan" />
-              <span className="text-[13px] text-fg">
-                Auto-approve the plan
-                <span className="block text-[11px] text-faint">
-                  Skip the approval gate so unattended runs proceed (like autopilot). Off = the run waits at the gate.
+            {/* A self_improve run is always auto-approved (the server forces auto_approve=true),
+                so hide the toggle rather than misrepresent a fixed value as a user choice. */}
+            {target !== "self_improve" && (
+              <div className="flex items-start gap-3">
+                <Toggle checked={autoApprove} onChange={setAutoApprove} label="Auto-approve the plan" />
+                <span className="text-[13px] text-fg">
+                  Auto-approve the plan
+                  <span className="block text-[11px] text-faint">
+                    Skip the approval gate so unattended runs proceed (like autopilot). Off = the run waits at the gate.
+                  </span>
                 </span>
-              </span>
-            </div>
+              </div>
+            )}
             {!isEdit && (
               <div className="flex items-start gap-3">
                 <Toggle checked={enabled} onChange={setEnabled} label="Enabled" />

--- a/web/src/pages/Schedules.test.tsx
+++ b/web/src/pages/Schedules.test.tsx
@@ -115,6 +115,23 @@ describe("Schedules list", () => {
     expect(screen.getByText("paused")).toBeTruthy();
   });
 
+  it("suppresses the auto-approve chip for a self_improve row (PRD #590 follow-up 2)", async () => {
+    // A self_improve run is always server-forced to auto_approve, so the chip is not a
+    // user option: with wait_on_limit off, the row falls back to "defaults", not a chip.
+    only1({ target: "self_improve", origin: "user", auto_approve: true, wait_on_limit: false });
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Self-improvement")).toBeTruthy());
+    expect(screen.queryByText("auto-approve")).toBeNull();
+    expect(screen.getByText("defaults")).toBeTruthy();
+  });
+
+  it("still shows the auto-approve chip for a non-self_improve row (control)", async () => {
+    only1({ target: "sweep", origin: "user", auto_approve: true, wait_on_limit: false });
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Sweep eligible PRD issues")).toBeTruthy());
+    expect(screen.getByText("auto-approve")).toBeTruthy();
+  });
+
   it("the enable toggle PATCHes { enabled } and adopts the returned row", async () => {
     mockApi.updateSchedule.mockImplementation(async (id: string, input) =>
       sched({ id, enabled: input.enabled ?? true }),

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -520,6 +520,9 @@ function ScheduleRow({
   const off = !s.enabled;
   const fired = s.timing === "once" && s.status === "fired";
   const parked = s.status === "error";
+  // A self_improve schedule is always auto-approved (server-forced), so it is not a
+  // user option — suppress the chip and let the "defaults" fallback show instead.
+  const showApprove = s.auto_approve && s.target !== "self_improve";
   const [expanded, setExpanded] = useState(false);
   const [addingRepo, setAddingRepo] = useState(false);
   return (
@@ -616,8 +619,8 @@ function ScheduleRow({
       <td className="px-4 py-3">
         <div className="flex flex-wrap gap-1">
           {s.wait_on_limit && <OptionChip>wait-on-limit</OptionChip>}
-          {s.auto_approve && <OptionChip>auto-approve</OptionChip>}
-          {!s.wait_on_limit && !s.auto_approve && <span className="text-[12px] text-faint">defaults</span>}
+          {showApprove && <OptionChip>auto-approve</OptionChip>}
+          {!s.wait_on_limit && !showApprove && <span className="text-[12px] text-faint">defaults</span>}
         </div>
       </td>
 


### PR DESCRIPTION
Implements issue #624.

Closes #624

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-624`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Self-improvement schedules are created and cloned with automatic approval enforced.
  - Self-improvement schedules display “defaults” instead of auto-approval controls or status indicators.
  - Schedule updates preserve self-improvement settings and prevent unsupported conversions.

- **Bug Fixes**
  - Improved handling of overlapping self-improvement runs and vault-locked schedules, including clearer retry messaging.
  - Database cleanup now safely resolves duplicate active self-improvement runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->