### PR TITLE
Hosted-worker upgrade classifier flags 'outdated' when workers.image.tag points at a reuse-retagged agent image

### DIFF
--- a/adr/0738-hosted-worker-settled-trumps-version.md
+++ b/adr/0738-hosted-worker-settled-trumps-version.md
@@ -1,0 +1,43 @@
+# ADR-738: Hosted-worker upgrade classification trusts the controller's `settled` signal over the baked worker version
+
+**Status**: Accepted (issue #738; classifier rule + tests + docs merged)
+**Date**: 2026-08-28
+**Deciders**: Vlad Mocanu + agent team (issue #738 / PRD #738 Decision Log)
+**PRD**: [prds/done/738-worker-upgrade-settled-classify.md](../prds/done/738-worker-upgrade-settled-classify.md) — the PRD carries the full Decision Log, milestone tests, and the offline validation split; this ADR carries the durable design shape and its rationale.
+
+## Decision (summary)
+
+For a **hosted** worker, the upgrade classifier (`api/internal/workersvc/upgrade.go` `classifyWithTarget`) now trusts the controller's `settled` roll phase over the worker's self-reported, baked `UZI_AGENT_VERSION`. A new rule — "R7.5" — clears a hosted worker to `up_to_date` even when the semver compare would say `outdated`, whenever the controller reports a **fresh** `settled` phase **and** its `RolledTag` is a parseable version. `settled` is a *direct* observation that the worker's current-generation pod is Ready on its Deployment's rendered image; the baked version string is only a *proxy* for "what image is this running", and the reuse-retag optimization (ADR-422 / PRD #422) is exactly the case where that proxy lies. When they disagree, the direct observation wins.
+
+## Context
+
+The classifier compares a worker's reported `UZI_AGENT_VERSION` (baked into the agent image at build time — `agent/src/config.ts`) against a resolved target tag. For a hosted worker that target is the tag the controller actually rolls to (`RollSignal.RolledTag`), because `workers.image.tag` is pinned independently of the api's own release (ADR-422 D1).
+
+`.github/workflows/release.yml`'s `publish-agent` **reuse-retag** step (the PRD #422 cost-saver) re-tags the *previous* release's image digest under the new version — skipping the version-stamping build — whenever the agent runtime surface is unchanged since the previous release. So `agent-base:0.66.1` and `:0.66.0` can be literally the same digest, and the reused image's baked `UZI_AGENT_VERSION` stays `0.66.0`.
+
+If `workers.image.tag` is pinned to such a reuse-retagged version (a deliberate fleet roll onto it — e.g. to retire an older agent image), every worker pulls that image, self-reports the **old** baked version, and the classifier marks the whole fleet `outdated` **permanently** (reported `0.66.0` < target `0.66.1`) even though every worker is running exactly the pinned image. Observed live: a fleet pinned to `0.66.1` reported `0.66.0+g4a5c0f4` against target `0.66.1`. It does not block scheduling (the controller rolls on the pod-spec hash, not this classification), but it is a persistent false `outdated` / attention signal in the web Fleet panel, the nav badge, and `uzi admin workers` — the fleet-wide cry-wolf that PRD #113's badge exists to avoid, arriving by a different route.
+
+## The decisions
+
+### D1 — Trust `settled` over the baked version for hosted workers
+
+`settled` means the controller has selected the current-generation pod (its `AnnotationSpecHash` matches the worker's Deployment) and found it Ready and not flapping — strictly stronger than Ready alone (a Ready-but-flapping pod is reported `stuck`, not `settled`; issue #145). That current pod runs the Deployment's rendered image, and the Deployment is rendered from the pinned tag. So `settled` ⟹ the worker is running the pinned target, by construction. The rule is an **additive softener**: it fires only when the version compare already returned `outdated`, so it can never override `unknown`, an ahead/equal worker, a dev control plane, or the roll-health states (`stuck` → R1, `rolling` → R2, in-grace `settled`+behind → R3), all of which are decided above it. No new wire field, migration, DTO, controller change, or agent change was needed — the fix reads a signal the controller already sends.
+
+### D2 — The `semver.IsValid(RolledTag)` guard is load-bearing, not incidental
+
+`settled` proves only that the worker runs the tag the controller **rendered from** — which the classifier sees as `RolledTag`. The proof "settled ⟹ on target" therefore holds only when the resolved `target` equals that `RolledTag`. The classifier resolves `target` as CPVersion → pin → RolledTag, taking `RolledTag` only when it is fresh and parseable; when `RolledTag` is unparseable or absent, `target` falls back to CPVersion/pin, and `settled` no longer confirms the worker is on that fallback coordinate. R7.5 is therefore gated on `semver.IsValid(normSemver(s.RolledTag))` in addition to `hosted && signalFresh && s.Phase == settled`: it fires only where `target == RolledTag`. Without the guard, a genuinely-behind worker on a stale **non-semver** pinned tag (e.g. `nightly`) reporting an old version would be falsely cleared to `up_to_date` — hiding real drift and printing a false "running the target image" detail. With the guard, that case correctly falls through to the version-compare fail-safe (`outdated`) and keeps its attention badge. (This guard was added during implementation after the originally-specified rule was found too broad on this fallback path; see PRD Decision 5.)
+
+### D3 — No new INV-5 ceiling on the softener
+
+R7.5 clears a hosted worker to `up_to_date` on a controller-supplied `settled` phase, so a compromised or buggy controller could suppress an `outdated`. This grants **no new capability**. The controller already owns these workers' lifecycle — it renders and patches their Deployments, so it can *cause* any state directly rather than needing to assert it — which is the same reasoning that leaves R1 (`stuck` → `upgrade_failed`) un-gated by the INV-5 ceiling. And the pre-existing "B-1 concession" already lets a controller reporting a stale tag with `phase=settled` hold a fleet `up_to_date` indefinitely. Bounding R7.5 with a ceiling would protect nothing an attacker cannot already reach, so none is added.
+
+### D4 — Digest comparison and an out-of-band audit digest are rejected / deferred
+
+Comparing a per-worker running-image digest against the pinned tag's digest was considered and rejected: it is classification-**redundant** with `settled` (a settled current-gen pod runs the target by construction) and, resolved per-worker in-cluster, is circular. Surfacing a running-image digest for manual registry audit is a real but **optional** defense-in-depth for a trust boundary this change does not widen; it is deferred, not built here, keeping the fix a single-function change with no schema or wire surface.
+
+## Consequences
+
+- A hosted worker on a reuse-retagged pinned tag reads `up_to_date` and no longer inflates the nav-badge attention count.
+- Genuine drift still surfaces: a `rolling` worker past the INV-5 ceiling, a `stuck` worker, a hosted worker with no fresh controller signal, and a worker settled on an unparseable pinned tag all still read their non-`up_to_date` result.
+- External workers, a `dev` control plane, and any worker without a fresh controller signal are unchanged — R7.5 requires `hosted && signalFresh`.
+- The residual — that a `settled`-derived `up_to_date` is not registry-auditable — is the pre-existing, unwidened trust boundary D4 defers.

--- a/api/internal/uzidocs/embed/worker-upgrades.md
+++ b/api/internal/uzidocs/embed/worker-upgrades.md
@@ -83,3 +83,15 @@ reports rolling to, so a pinned worker reads *up to date* at its pinned tag. `uz
 carries the same states in an `UPGRADE` column rendered for that surface (`FAILED`, and `-` for
 no badge), documented in [uzi CLI](cli.md#upgrade-status) — a second definition rather than a
 deferral, so a state added or renamed must be edited in both.
+
+**A reused agent image reads *up to date*, not *outdated*.** Recall the version is baked at
+build time and reported at registration. When a release leaves the worker agent unchanged, the
+build is skipped and the new tag simply re-points at the previous release's image, so that image
+still reports the *older* version even though it is exactly the pinned release. For a hosted
+worker this would otherwise read *outdated* forever: its reported version trails the tag it is
+pinned to. It does not, because the cluster reports the worker's roll as *settled* — a direct
+confirmation that the worker's current pod is running the image its deployment pins — and that
+confirmation is trusted over the baked version string. So a hosted worker the cluster has
+confirmed is on its target image reads *up to date* even when its reported version looks a
+release behind. This applies only to hosted workers with a live controller signal; an external
+worker, which has no such signal, is still read by its version string alone.

--- a/api/internal/workersvc/upgrade.go
+++ b/api/internal/workersvc/upgrade.go
@@ -461,12 +461,12 @@ func classifyWithTarget(in UpgradeInput, p UpgradeParams) (status string, detail
 	// Valid-RolledTag only (the semver.IsValid guard): `settled` only proves the
 	// current-gen pod runs the tag the controller RENDERED FROM, which the classifier
 	// sees as RolledTag. When RolledTag is unparseable/absent the target falls back to
-	// CPVersion/pin (see the target-resolution block above, ~:410 and :415) and
-	// `settled` no longer confirms the worker is on that fallback coordinate, so we
-	// defer to the version-compare fail-safe (`outdated`) rather than assert a false
-	// `up_to_date` and hide real drift. Because R7.5 already requires signalFresh, a
-	// valid RolledTag means target == RolledTag (:415-417), so the guard fires exactly
-	// where "settled ⟹ on target" holds.
+	// CPVersion/pin (see the hosted target-resolution block above) and `settled` no
+	// longer confirms the worker is on that fallback coordinate, so we defer to the
+	// version-compare fail-safe (`outdated`) rather than assert a false `up_to_date`
+	// and hide real drift. Because R7.5 already requires signalFresh, a valid RolledTag
+	// means the target-resolution block above already set target == RolledTag, so the
+	// guard fires exactly where "settled ⟹ on target" holds.
 	if status == UpgradeStatusOutdated && hosted && signalFresh &&
 		s.Phase == PhaseSettled && semver.IsValid(normSemver(s.RolledTag)) {
 		return UpgradeStatusUpToDate,

--- a/api/internal/workersvc/upgrade.go
+++ b/api/internal/workersvc/upgrade.go
@@ -146,6 +146,9 @@ func classifyByVersion(reported, target string) (status string, detail string) {
 
 // -------------------------------------------------------------------------
 // The full decision table (PRD #113 M4): version compare + controller roll health.
+// R7.5 (issue #738) adds a settled-only, outdated-only softener below the compare rows:
+// a hosted worker the controller confirms is on the target image reads up_to_date even
+// when its baked version trails the tag (a reuse-retagged image, PRD #422).
 // -------------------------------------------------------------------------
 
 // RollSignal is a persisted controller report, as the classifier reads it. Nil means
@@ -340,6 +343,10 @@ func (p UpgradeParams) withDefaults() UpgradeParams {
 //     a version stamp would throw away the incident's own signal.
 //   - R8 (no-signal grace) sits BELOW the compare rows, so it can only ever soften
 //     `outdated` — never override `up_to_date` or `unknown`.
+//   - R7.5 (issue #738), a `settled`-only, `outdated`-only softener, sits just below
+//     the compare rows too: it clears a hosted worker the controller confirms is on the
+//     target image despite a trailing baked version (a reuse-retagged image, PRD #422).
+//     Like R8 it can only soften `outdated`, never override `up_to_date` or `unknown`.
 func ClassifyUpgrade(in UpgradeInput, p UpgradeParams) (status string, detail string) {
 	status, detail, _ = classifyWithTarget(in, p)
 	return status, detail
@@ -438,6 +445,34 @@ func classifyWithTarget(in UpgradeInput, p UpgradeParams) (status string, detail
 
 	// R4-R7, R9: the version-compare core.
 	status, detail = classifyByVersion(in.Reported, target)
+
+	// R7.5 (issue #738) — the controller has CONFIRMED this hosted worker's
+	// current-generation pod is running its Deployment's pinned target image
+	// (phase == settled means the current-spec-hash pod is Ready). So an `outdated`
+	// from the version compare above is the baked UZI_AGENT_VERSION lying under a
+	// reuse-retagged image (PRD #422): the tag advanced to a new release that points
+	// at a PRIOR release's digest, so the baked version trails the tag while the
+	// worker is, in fact, running the target. Trust the controller's direct
+	// observation over the self-reported string. Softener only: it fires solely when
+	// the compare already said `outdated`, so it can never override `unknown`, a
+	// dev-plane, or an ahead/equal worker. Phase-settled only: a `rolling` worker
+	// past the INV-5 ceiling (which falls through R2 to here) stays `outdated`.
+	//
+	// Valid-RolledTag only (the semver.IsValid guard): `settled` only proves the
+	// current-gen pod runs the tag the controller RENDERED FROM, which the classifier
+	// sees as RolledTag. When RolledTag is unparseable/absent the target falls back to
+	// CPVersion/pin (see the target-resolution block above, ~:410 and :415) and
+	// `settled` no longer confirms the worker is on that fallback coordinate, so we
+	// defer to the version-compare fail-safe (`outdated`) rather than assert a false
+	// `up_to_date` and hide real drift. Because R7.5 already requires signalFresh, a
+	// valid RolledTag means target == RolledTag (:415-417), so the guard fires exactly
+	// where "settled ⟹ on target" holds.
+	if status == UpgradeStatusOutdated && hosted && signalFresh &&
+		s.Phase == PhaseSettled && semver.IsValid(normSemver(s.RolledTag)) {
+		return UpgradeStatusUpToDate,
+			fmt.Sprintf("running the target image (%s); reported %s trails it (re-tagged image)", target, in.Reported),
+			target
+	}
 
 	// R8 — behind, hosted, and NO fresh signal, within the grace after api start.
 	// Model B rolls the api in the same release, so a recently started api means a

--- a/api/internal/workersvc/upgrade_ceiling_test.go
+++ b/api/internal/workersvc/upgrade_ceiling_test.go
@@ -1,6 +1,7 @@
 package workersvc
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -655,5 +656,263 @@ func TestComposeDegradationNoControllerMeansVersionCompareOnly(t *testing.T) {
 			t.Errorf("%s: classified %q with NO controller signal — that is an assertion about a "+
 				"component that is not running", tc.name, status)
 		}
+	}
+}
+
+// -------------------------------------------------------------------------
+// R7.5 (issue #738): trust the controller's `settled` observation over a baked
+// UZI_AGENT_VERSION that trails a reuse-retagged image (PRD #422).
+//
+// The live-observed repro: a release tag advanced to a new version that points at a
+// PRIOR release's digest, so a hosted worker's baked version (reported at register)
+// trails the tag while the pod is, in fact, running the target image. The controller
+// reports `settled` for the current-spec-hash pod, which is direct confirmation the
+// worker is on the target. Before R7.5 the version compare read `outdated` and the
+// worker was counted for the nav badge; R7.5 clears it.
+//
+// CALIBRATION: every fixture below reports a version GENUINELY BELOW its target
+// (0.66.0 < 0.66.1), so classifyByVersion alone returns `outdated`. If R7.5 were
+// removed from upgrade.go, the reuse case would read `outdated` — that is what makes
+// these tests non-vacuous.
+// -------------------------------------------------------------------------
+
+// hostedSettledInput builds a HOSTED worker with a FRESH `settled` controller signal
+// rolling to `target`, reporting `reported`, whose Ready transition happened
+// `phaseSinceAge` ago. `phaseSinceAge` older than RegisterConvergenceGrace keeps R3 out
+// of the way so any `upgrading` here would have to come from R3 and any `up_to_date`
+// from R7.5 — never a grace. The fresh RolledTag == target makes `target` the resolved
+// hosted comparison target (Decision 9).
+func hostedSettledInput(now time.Time, reported, target string, phaseSinceAge time.Duration) UpgradeInput {
+	settledAt := now.Add(-phaseSinceAge)
+	anchor := now.Add(-time.Minute)
+	return UpgradeInput{
+		Reported:  reported,
+		Kind:      "hosted",
+		CPVersion: target,
+		Signal: &RollSignal{
+			Phase:          PhaseSettled,
+			ObservedAt:     now, // fresh: the api's own receipt time is now
+			UpgradingSince: &anchor,
+			RolledTag:      target,
+			PhaseSince:     &settledAt,
+		},
+		Now:          now,
+		APIStartedAt: now.Add(-24 * time.Hour), // long ago, so R8's grace is never the cause
+	}
+}
+
+// (a) The reuse case. A hosted worker the controller confirms `settled` on the target
+// image, reporting a version that trails the tag (a reuse-retagged image, PRD #422),
+// must read `up_to_date` — not `outdated` — and the detail must name the target.
+func TestR7_5ReuseRetaggedImageReadsUpToDate_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	// Ready long ago (past the register grace), so R3 cannot be the reason.
+	in := hostedSettledInput(now, "0.66.0+g4a5c0f4", "0.66.1", time.Hour)
+
+	status, detail := ClassifyUpgrade(in, ceilingParams())
+	if status != UpgradeStatusUpToDate {
+		t.Fatalf("issue #738: a `settled` worker on a reuse-retagged image must read %q, got %q (%q). "+
+			"The controller directly confirms the pod is on the target; the trailing baked version is the lie.",
+			UpgradeStatusUpToDate, status, detail)
+	}
+	if !strings.Contains(detail, "0.66.1") {
+		t.Errorf("the detail should name the target image (0.66.1) so the divergence is legible, got %q", detail)
+	}
+	// (e) attention: `up_to_date` is by definition NOT in the attention set, so the reuse
+	// worker no longer inflates the nav-badge count. The summary endpoint counts through
+	// exactly this InUpgradeAttentionSet, so pinning the classification pins the count.
+	if InUpgradeAttentionSet(status) {
+		t.Errorf("issue #738: the reuse worker (%q) is still counted for the nav badge; R7.5 must clear it "+
+			"from the attention set", status)
+	}
+}
+
+// (b) control: a `rolling` signal past the INV-5 ceiling falls through R2 to the compare
+// and must stay `outdated` — R7.5 is `settled`-only and must not rescue it.
+func TestR7_5DoesNotFireForRollingPastCeiling_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	anchor := now.Add(-testWindow - time.Minute) // past the ceiling
+	in := UpgradeInput{
+		Reported:  "0.66.0",
+		Kind:      "hosted",
+		CPVersion: "0.66.1",
+		Signal: &RollSignal{
+			Phase: PhaseRolling, ObservedAt: now, UpgradingSince: &anchor,
+			RolledTag: "0.66.1", BlockingReason: "Pulling image",
+		},
+		Now:          now,
+		APIStartedAt: now.Add(-24 * time.Hour),
+	}
+	status, detail := ClassifyUpgrade(in, ceilingParams())
+	if status == UpgradeStatusUpToDate {
+		t.Fatalf("issue #738: a `rolling` worker past the ceiling must NOT be cleared by R7.5 (settled-only); got %q", status)
+	}
+	if status != UpgradeStatusOutdated {
+		t.Errorf("want %q for a past-ceiling `rolling` worker, got %q (%q)", UpgradeStatusOutdated, status, detail)
+	}
+}
+
+// (b) control: a `stuck` signal is R1 (`upgrade_failed`) and must never be softened to
+// `up_to_date` by R7.5.
+func TestR7_5DoesNotFireForStuckSignal_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	anchor := now.Add(-time.Minute)
+	in := UpgradeInput{
+		Reported:  "0.66.0",
+		Kind:      "hosted",
+		CPVersion: "0.66.1",
+		Signal: &RollSignal{
+			Phase: PhaseStuck, ObservedAt: now, UpgradingSince: &anchor,
+			RolledTag: "0.66.1", BlockingContainer: "seed-nix", BlockingReason: "CrashLoopBackOff",
+		},
+		Now:          now,
+		APIStartedAt: now.Add(-24 * time.Hour),
+	}
+	status, _ := ClassifyUpgrade(in, ceilingParams())
+	if status == UpgradeStatusUpToDate {
+		t.Fatalf("issue #738: a `stuck` worker must stay an alert, never `up_to_date`; got %q", status)
+	}
+	if status != UpgradeStatusUpgradeFailed {
+		t.Errorf("want %q (R1) for a fresh `stuck` signal, got %q", UpgradeStatusUpgradeFailed, status)
+	}
+}
+
+// (b) control: a hosted worker with NO fresh controller signal past the api-start grace
+// classifies by version compare alone — `outdated`. R7.5 needs a fresh `settled`
+// observation to fire and there is none. Covers both the nil-signal and stale-signal
+// shapes.
+func TestR7_5RequiresFreshSettledSignal_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+
+	// nil signal, past the hosted roll grace.
+	nilSig := UpgradeInput{
+		Reported: "0.66.0", Kind: "hosted", CPVersion: "0.66.1", Signal: nil,
+		Now: now, APIStartedAt: now.Add(-24 * time.Hour),
+	}
+	if status, _ := ClassifyUpgrade(nilSig, ceilingParams()); status != UpgradeStatusOutdated {
+		t.Errorf("no signal + past the grace ⇒ %q, got %q. R7.5 must not fire without a fresh settled signal",
+			UpgradeStatusOutdated, status)
+	}
+
+	// A `settled` signal that is STALE (observed outside the TTL): freshness gates R7.5,
+	// so it must not clear the worker.
+	anchor := now.Add(-time.Minute)
+	settledAt := now.Add(-time.Hour)
+	staleSig := UpgradeInput{
+		Reported: "0.66.0", Kind: "hosted", CPVersion: "0.66.1",
+		Signal: &RollSignal{
+			Phase: PhaseSettled, ObservedAt: now.Add(-10 * time.Minute), // outside the 60s TTL
+			UpgradingSince: &anchor, RolledTag: "0.66.1", PhaseSince: &settledAt,
+		},
+		Now: now, APIStartedAt: now.Add(-24 * time.Hour),
+	}
+	if status, _ := ClassifyUpgrade(staleSig, ceilingParams()); status != UpgradeStatusOutdated {
+		t.Errorf("a STALE settled signal must not clear the worker; want %q, got %q", UpgradeStatusOutdated, status)
+	}
+}
+
+// (c) fallback unchanged: an EXTERNAL worker genuinely behind stays `outdated` even with a
+// fresh `settled` signal — every controller row (R7.5 included) is hosted-only, because
+// nothing upgrades an external worker for its owner.
+func TestR7_5DoesNotFireForExternalWorker_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	in := hostedSettledInput(now, "0.66.0", "0.66.1", time.Hour)
+	in.Kind = "external"
+	if status, _ := ClassifyUpgrade(in, ceilingParams()); status != UpgradeStatusOutdated {
+		t.Errorf("issue #738: R7.5 must be hosted-only; an external worker behind its target stays %q, got %q",
+			UpgradeStatusOutdated, status)
+	}
+}
+
+// (c) fallback unchanged: a `dev` control plane disables version comparison fleet-wide
+// (R4 ⇒ `unknown`), and R7.5 only ever softens `outdated`, so it can never override
+// `unknown`. Even with a fresh `settled` signal the worker stays `unknown`.
+func TestR7_5DoesNotOverrideUnknownOnDevControlPlane_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	anchor := now.Add(-time.Minute)
+	settledAt := now.Add(-time.Hour)
+	in := UpgradeInput{
+		Reported:  "0.66.0",
+		Kind:      "hosted",
+		CPVersion: "dev", // unstamped control plane
+		Signal: &RollSignal{
+			Phase: PhaseSettled, ObservedAt: now, UpgradingSince: &anchor,
+			RolledTag: "", PhaseSince: &settledAt, // no rolled tag, so target stays "dev"
+		},
+		Now:          now,
+		APIStartedAt: now.Add(-24 * time.Hour),
+	}
+	status, _ := ClassifyUpgrade(in, ceilingParams())
+	if status != UpgradeStatusUnknown {
+		t.Fatalf("issue #738: a `dev` control plane must stay %q; R7.5 must never override unknown, got %q",
+			UpgradeStatusUnknown, status)
+	}
+	if InUpgradeAttentionSet(status) {
+		t.Errorf("a `dev`-plane worker must not badge the nav item, got attention-set status %q", status)
+	}
+}
+
+// (d) ordering vs R3. SAME versions, differing ONLY in how long ago the pod became Ready:
+//   - Ready recently (within RegisterConvergenceGrace): R3 wins ⇒ `upgrading` (awaiting
+//     re-registration), NOT R7.5.
+//   - Ready long ago (past the grace): R3 falls through and R7.5 clears it ⇒ `up_to_date`,
+//     NOT `outdated`.
+//
+// R7.5 sits BELOW R3 exactly so a still-converging roll reads `upgrading` rather than
+// prematurely `up_to_date`.
+func TestR7_5OrdersBelowR3_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+
+	// Ready just now — inside the 1s register grace of ceilingParams(): R3 fires.
+	recent := hostedSettledInput(now, "0.66.0+g4a5c0f4", "0.66.1", 0)
+	if status, detail := ClassifyUpgrade(recent, ceilingParams()); status != UpgradeStatusUpgrading {
+		t.Errorf("within the register grace a settled+behind worker must read %q (R3, awaiting re-register), "+
+			"got %q (%q)", UpgradeStatusUpgrading, status, detail)
+	}
+
+	// Ready an hour ago — past the grace: R3 falls through, R7.5 clears it.
+	old := hostedSettledInput(now, "0.66.0+g4a5c0f4", "0.66.1", time.Hour)
+	if status, detail := ClassifyUpgrade(old, ceilingParams()); status != UpgradeStatusUpToDate {
+		t.Errorf("past the register grace the same worker must read %q (R7.5), not outdated, got %q (%q)",
+			UpgradeStatusUpToDate, status, detail)
+	}
+}
+
+// (b) control / the narrowing guard: R7.5 fires only when the RolledTag is PARSEABLE, so
+// `settled` provably means "on the resolved target" (target == RolledTag). When the pinned
+// tag is a non-semver string (e.g. "nightly"), the controller reports `settled` but with an
+// UNPARSEABLE RolledTag, so the classifier's target falls back to CPVersion and `settled`
+// no longer confirms the worker is on that fallback coordinate. A genuinely-behind worker on
+// a stale non-semver pin must therefore STILL surface attention (`outdated`), never be
+// falsely cleared. This is the adversarial repro that made the verbatim (guard-less) R7.5
+// too broad; the semver.IsValid(RolledTag) conjunct closes it.
+func TestR7_5DoesNotFireWhenRolledTagUnparseable_Issue738(t *testing.T) {
+	now := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	settledLongAgo := now.Add(-time.Hour) // past R3's grace
+	anchor := now.Add(-time.Minute)
+	in := UpgradeInput{
+		Reported:  "0.11.0", // genuinely below the CPVersion fallback target 0.11.7
+		Kind:      "hosted",
+		CPVersion: "0.11.7",
+		// No valid pin; the controller renders a non-semver tag and reports settled on it.
+		PinnedWorkerVersion: "nightly",
+		Signal: &RollSignal{
+			Phase:          PhaseSettled,
+			ObservedAt:     now, // fresh
+			UpgradingSince: &anchor,
+			RolledTag:      "nightly", // unparseable ⇒ target falls back to CPVersion 0.11.7
+			PhaseSince:     &settledLongAgo,
+		},
+		Now:          now,
+		APIStartedAt: now.Add(-24 * time.Hour),
+	}
+	status, detail, target := ClassifyUpgradeWithTarget(in, ceilingParams())
+	if target != "0.11.7" {
+		t.Errorf("an unparseable RolledTag must fall the target back to CPVersion 0.11.7, got %q", target)
+	}
+	if status != UpgradeStatusOutdated {
+		t.Fatalf("issue #738: a genuinely-behind worker settled on an UNPARSEABLE pinned tag must stay %q "+
+			"(settled proves nothing about the CPVersion fallback), got %q (%q). R7.5's semver.IsValid guard "+
+			"exists precisely to keep this real drift visible.", UpgradeStatusOutdated, status, detail)
 	}
 }

--- a/api/internal/workersvc/upgrade_pinned_test.go
+++ b/api/internal/workersvc/upgrade_pinned_test.go
@@ -77,9 +77,14 @@ func TestHostedTargetIsThePinnedWorkerVersion(t *testing.T) {
 }
 
 // (d) A FRESH controller RolledTag stays authoritative ABOVE the static pin (Decision 9):
-// it is what the controller actually rolls to, confirmed live, so it governs even when a
-// pin is configured. Here the pin alone would say up_to_date, but the fresh RolledTag is
-// ahead of the worker, so the RolledTag governs and the worker reads outdated.
+// it is what the controller actually rolls to, confirmed live, so it GOVERNS THE TARGET
+// even when a pin is configured — here target resolves to 0.49.0, not the pin 0.48.0.
+// The STATUS, though, is the reuse/mis-stamp case (issue #738): the worker is `settled`
+// on the 0.49.0-rendered pod with a parseable RolledTag one step ahead of its reported
+// 0.48.0, past R3's convergence grace. `settled` proves the pod runs the 0.49.0 image, so
+// a reported version below it is the baked stamp trailing a re-tagged image (PRD #422),
+// not real drift — R7.5 reads it `up_to_date`. Target governance (Decision 9) and status
+// softening (R7.5) are independent: target stays 0.49.0 while the status clears.
 func TestFreshRolledTagOverridesTheStaticPin(t *testing.T) {
 	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
 	anchor := now.Add(-time.Minute)
@@ -105,9 +110,11 @@ func TestFreshRolledTagOverridesTheStaticPin(t *testing.T) {
 	if target != "0.49.0" {
 		t.Errorf("target = %q, want the fresh RolledTag 0.49.0 to govern over the static pin 0.48.0", target)
 	}
-	if status != UpgradeStatusOutdated {
-		t.Errorf("status = %q, want %q: the fresh RolledTag is ahead of the worker so it must govern",
-			status, UpgradeStatusOutdated)
+	if status != UpgradeStatusUpToDate {
+		t.Errorf("status = %q, want %q: a fresh settled worker whose parseable RolledTag is one step ahead, "+
+			"past the R3 grace, is the reuse/mis-stamp case (issue #738) — settled proves it is on the "+
+			"RolledTag image and the trailing baked version is the lie",
+			status, UpgradeStatusUpToDate)
 	}
 }
 

--- a/docs/worker-upgrades.md
+++ b/docs/worker-upgrades.md
@@ -83,3 +83,15 @@ reports rolling to, so a pinned worker reads *up to date* at its pinned tag. `uz
 carries the same states in an `UPGRADE` column rendered for that surface (`FAILED`, and `-` for
 no badge), documented in [uzi CLI](cli.md#upgrade-status) — a second definition rather than a
 deferral, so a state added or renamed must be edited in both.
+
+**A reused agent image reads *up to date*, not *outdated*.** Recall the version is baked at
+build time and reported at registration. When a release leaves the worker agent unchanged, the
+build is skipped and the new tag simply re-points at the previous release's image, so that image
+still reports the *older* version even though it is exactly the pinned release. For a hosted
+worker this would otherwise read *outdated* forever: its reported version trails the tag it is
+pinned to. It does not, because the cluster reports the worker's roll as *settled* — a direct
+confirmation that the worker's current pod is running the image its deployment pins — and that
+confirmation is trusted over the baked version string. So a hosted worker the cluster has
+confirmed is on its target image reads *up to date* even when its reported version looks a
+release behind. This applies only to hosted workers with a live controller signal; an external
+worker, which has no such signal, is still read by its version string alone.

--- a/prds/done/738-worker-upgrade-settled-classify.md
+++ b/prds/done/738-worker-upgrade-settled-classify.md
@@ -153,14 +153,14 @@ offline.
 
 ## Milestones
 
-- [ ] **M1 — The classifier rule.** Add R7.5 to `classifyWithTarget`
+- [x] **M1 — The classifier rule.** Add R7.5 to `classifyWithTarget`
   (`api/internal/workersvc/upgrade.go`) exactly as specified above: between the
   `classifyByVersion` call (`:440`) and R8 (`:447`), gated on `status ==
   UpgradeStatusOutdated && hosted && signalFresh && s.Phase == PhaseSettled`, returning
   `up_to_date` with a detail naming the resolved target and the trailing reported
   version. Update the decision-table doc comment (`:147-149`, `:332-342`) to describe
   the new row and its rationale. No wire, migration, controller, or DTO change.
-- [ ] **M2 — Tests, both directions, in `upgrade_ceiling_test.go`.** Prove:
+- [x] **M2 — Tests, both directions, in `upgrade_ceiling_test.go`.** Prove:
   (a) **reuse case** — `Kind:"hosted"`, fresh `settled` signal, `target` a release
   ABOVE a **genuinely-behind** `Reported` (so that without R7.5 the worker reads
   `outdated`) → now `up_to_date`; (b) **genuine-outdated controls still red** — a
@@ -174,7 +174,7 @@ offline.
   worker no longer counts). Calibrate every fixture on a genuinely-behind version per
   the semver-trap discipline in `.claude/rules/go.md` — an all-current fixture passes
   against the broken code and proves nothing.
-- [ ] **M3 — Docs + decision record.** Update the worker upgrade-status doc (the PRD
+- [x] **M3 — Docs + decision record.** Update the worker upgrade-status doc (the PRD
   #113 page under `docs/`) to describe the `settled`-trumps-version rule and the
   reuse-retag interaction it fixes. Add a decision entry (Decision 3 below; an ADR
   `0738-*.md` if it warrants durability) recording that hosted-worker classification
@@ -193,8 +193,14 @@ offline.
    and a hosted worker with **no** fresh signal still reads `outdated` via the semver
    path. R7.5 does not blind the real signal.
 3. External workers, a `dev` control plane, and any worker without a fresh controller
-   signal behave exactly as today — zero change to the existing `upgrade_test.go` /
-   `upgrade_ceiling_test.go` results beyond the new rows.
+   signal behave exactly as today — beyond the new rows, the only pre-existing result
+   that changed is `TestFreshRolledTagOverridesTheStaticPin` (`upgrade_pinned_test.go`),
+   which necessarily FLIPPED from `outdated` to `up_to_date`: its scenario (fresh
+   `settled`, parseable RolledTag one step ahead of the reported version, past the R3
+   grace) is indistinguishable from the reuse-retag case, so #738's design overturns its
+   old expectation; its target-governance assertion (`target == "0.49.0"`, Decision 9) is
+   unchanged. `TestHostedTargetIsTheRolledTagWithFallback`'s unparseable-tag assertion was
+   PRESERVED by the Decision-5 narrowing guard.
 4. The change contains **zero** `.github/workflows/**` edits and no migration/wire/DTO
    change — `git diff --name-only <base>..HEAD` touches only
    `api/internal/workersvc/` and `docs/` (plus an `adr/` file if written).
@@ -267,3 +273,20 @@ offline.
   but optional defense-in-depth for a trust boundary this PRD does not widen; it is
   deferred rather than built here, keeping the fix a single-function change with no
   schema or wire surface.
+- **Decision 5 — Narrow R7.5 to a parseable `RolledTag` (added during implementation).**
+  The rule as originally specified above fired on `status == outdated && hosted &&
+  signalFresh && s.Phase == PhaseSettled` alone. Implementation review found that too
+  broad on the fallback path: `settled` proves only that the worker runs the tag the
+  controller RENDERED FROM (`RolledTag`), so "settled ⟹ on target" holds only when
+  `target == RolledTag`. When `RolledTag` is unparseable/absent, `target` falls back to
+  CPVersion/pin and `settled` no longer confirms that coordinate — a genuinely-behind
+  worker on a stale non-semver pinned tag (e.g. `nightly`) would be falsely cleared to
+  `up_to_date` with a lying "running the target image" detail. The shipped guard adds
+  `&& semver.IsValid(normSemver(s.RolledTag))`, so R7.5 fires only where the resolved
+  target is the controller-confirmed rendered tag; an unparseable `RolledTag` correctly
+  falls through to the version-compare fail-safe (`outdated`). This preserves the
+  `TestHostedTargetIsTheRolledTagWithFallback` fail-safe and is why Success Criterion 3
+  changed only `TestFreshRolledTagOverridesTheStaticPin` (which is genuinely the reuse
+  case and flips regardless of the guard). Cross-references Decision 4 — the guard is the
+  reason a digest comparison is unnecessary: `settled` + parseable `RolledTag` already
+  pins "on target" without one. Recorded durably in [adr/0738-hosted-worker-settled-trumps-version.md](../../adr/0738-hosted-worker-settled-trumps-version.md).


### PR DESCRIPTION
Implements issue #738.

Closes #738

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-738`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hosted workers with a fresh, settled deployment confirmation are now marked **up to date** when running the target image, even if their reported version is older due to image reuse.
  * Existing handling remains unchanged for stale, missing, invalid, rolling, external, and development environments.

* **Documentation**
  * Updated worker upgrade guidance and decision records to explain the classification behavior and fallback rules.

* **Tests**
  * Added coverage for settled, stale, rolling, external, and invalid-tag scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->