### PR TITLE
Run stays in the 'needs approval' grouping while it is actively re-planning after a revise

### DIFF
--- a/api/cmd/uzi/admin.go
+++ b/api/cmd/uzi/admin.go
@@ -64,7 +64,7 @@ func newAdminCmd(env Env, gf *globalFlags) *cobra.Command {
 			}
 			rows := make([][]string, 0, len(rs))
 			for _, r := range rs {
-				rows = append(rows, []string{r.ID, strOr(r.OwnerEmail, "-"), r.Kind, effectiveRunStatus(r.Status, r.IsPlanning), runTitle(r.RunDTO)})
+				rows = append(rows, []string{r.ID, strOr(r.OwnerEmail, "-"), r.Kind, effectiveRunStatus(r.Status, r.IsPlanning, r.IsRevising), runTitle(r.RunDTO)})
 			}
 			return p.Table([]string{"ID", "OWNER", "KIND", "STATUS", "TITLE"}, rows)
 		},

--- a/api/cmd/uzi/run.go
+++ b/api/cmd/uzi/run.go
@@ -53,12 +53,19 @@ const (
 // terminal would make `--follow` exit on a run that is about to produce more messages.
 const statusLimitWait = "limit_wait"
 
-// effectiveRunStatus is the status a run should RENDER as: "planning" while it is in its
-// pre-approval planning phase (issue #321), else its raw status. is_planning is a server-
-// computed display predicate meaningful only while running (chat/judge excluded server-
-// side), so this only maps the running→planning case. Mirrors the web helper of the same
-// name so the CLI and SPA name the phase identically.
-func effectiveRunStatus(status string, isPlanning bool) string {
+// effectiveRunStatus is the status a run should RENDER as: "revising" while a "revise"
+// replan is in flight (issue #750), "planning" while it is in its pre-approval planning
+// phase (issue #321), else its raw status. is_planning and is_revising are server-computed
+// display predicates, each meaningful only in one status: is_planning while running
+// (chat/judge excluded server-side), is_revising while awaiting_approval (a revise replan
+// leaves runs.status at awaiting_approval). CRITICAL: is_revising is NOT status-gated
+// server-side, so the awaiting_approval gate is applied HERE — mirroring how is_planning is
+// only honoured while running. Mirrors the web helper of the same name so the CLI and SPA
+// name the phase identically.
+func effectiveRunStatus(status string, isPlanning, isRevising bool) string {
+	if isRevising && status == "awaiting_approval" {
+		return "revising"
+	}
 	if isPlanning && status == "running" {
 		return "planning"
 	}
@@ -226,7 +233,7 @@ func newRunCmd(env Env, gf *globalFlags) *cobra.Command {
 			rows := make([][]string, 0, len(runs))
 			now := time.Now()
 			for _, r := range runs {
-				rows = append(rows, []string{r.ID, r.Kind, effectiveRunStatus(r.Status, r.IsPlanning), runAgeCell(r.RunDTO, now), runTitle(r.RunDTO)})
+				rows = append(rows, []string{r.ID, r.Kind, effectiveRunStatus(r.Status, r.IsPlanning, r.IsRevising), runAgeCell(r.RunDTO, now), runTitle(r.RunDTO)})
 			}
 			return p.Table([]string{"ID", "KIND", "STATUS", "AGE", "TITLE"}, rows)
 		},
@@ -1333,7 +1340,9 @@ func renderRunDetail(p *uzicli.Printer, r apitypes.RunDTO) error {
 	rows := [][]string{
 		{"ID", r.ID},
 		{"KIND", r.Kind},
-		{"STATUS", effectiveRunStatus(r.Status, r.IsPlanning)},
+		// RunDTO carries no is_revising (issue #750): the detail page keeps its own
+		// derivePlanRevision panel, so revising is never surfaced through this helper here.
+		{"STATUS", effectiveRunStatus(r.Status, r.IsPlanning, false)},
 		{"TITLE", runTitle(r)},
 		{"BRANCH", strOr(r.Branch, "-")},
 		{mrAbbrev(r.ForgeType), int64Or(r.MrIID, "-")},

--- a/api/cmd/uzi/run_planning_test.go
+++ b/api/cmd/uzi/run_planning_test.go
@@ -17,15 +17,25 @@ func TestEffectiveRunStatus(t *testing.T) {
 	for _, tc := range []struct {
 		status     string
 		isPlanning bool
+		isRevising bool
 		want       string
 	}{
-		{"running", true, "planning"},
-		{"running", false, "running"},
-		{"completed", true, "completed"}, // only running maps
-		{"queued", false, "queued"},
+		{"running", true, false, "planning"},
+		{"running", false, false, "running"},
+		{"completed", true, false, "completed"}, // only running maps
+		{"queued", false, false, "queued"},
+		// issue #750: is_revising maps awaiting_approval → "revising", and ONLY there.
+		{"awaiting_approval", false, true, "revising"},
+		{"awaiting_approval", false, false, "awaiting_approval"},
+		// is_revising is not status-gated server-side; a running+planning run is still
+		// "planning" even with is_revising set, and is_revising has no effect off
+		// awaiting_approval.
+		{"running", true, true, "planning"},
+		{"running", false, true, "running"},
+		{"completed", false, true, "completed"},
 	} {
-		if got := effectiveRunStatus(tc.status, tc.isPlanning); got != tc.want {
-			t.Errorf("effectiveRunStatus(%q, %v) = %q, want %q", tc.status, tc.isPlanning, got, tc.want)
+		if got := effectiveRunStatus(tc.status, tc.isPlanning, tc.isRevising); got != tc.want {
+			t.Errorf("effectiveRunStatus(%q, %v, %v) = %q, want %q", tc.status, tc.isPlanning, tc.isRevising, got, tc.want)
 		}
 	}
 }
@@ -36,8 +46,8 @@ func TestEffectiveRunStatus(t *testing.T) {
 func TestPlanningStatusColour(t *testing.T) {
 	p := newPalette(true)
 
-	planning := p.stateColor("running", "", true) // running + is_planning → planning
-	running := p.stateColor("running", "", false)
+	planning := p.stateColor("running", "", true, false) // running + is_planning → planning
+	running := p.stateColor("running", "", false, false)
 	if bgFillSGR(planning) == bgFillSGR(running) {
 		t.Error("planning and running resolve to the same colour; the planning phase is not visually distinct")
 	}
@@ -45,7 +55,7 @@ func TestPlanningStatusColour(t *testing.T) {
 		t.Error("planning resolved to the faint default; its own indigo entry is not being read")
 	}
 	// Health precedence: a stalled planning run is still the stall colour (triage wins).
-	if bgFillSGR(p.stateColor("running", "stalled", true)) != bgFillSGR(p.stall) {
+	if bgFillSGR(p.stateColor("running", "stalled", true, false)) != bgFillSGR(p.stall) {
 		t.Error("stalled health no longer overrides the planning bucket; the precedence rule regressed")
 	}
 }
@@ -53,10 +63,10 @@ func TestPlanningStatusColour(t *testing.T) {
 // TestStatusGlyphPlanning pins the NO_COLOR-safe state glyph (D3): planning is a hollow circle
 // ("nothing committed yet"), distinct from running's filled dot.
 func TestStatusGlyphPlanning(t *testing.T) {
-	if got, _ := stateGlyphWord("running", "", true); got != "○" {
+	if got, _ := stateGlyphWord("running", "", true, false); got != "○" {
 		t.Errorf("planning glyph = %q, want %q", got, "○")
 	}
-	if got, _ := stateGlyphWord("running", "", false); got != "●" {
+	if got, _ := stateGlyphWord("running", "", false, false); got != "●" {
 		t.Errorf("running glyph = %q, want %q", got, "●")
 	}
 }

--- a/api/cmd/uzi/tui_board.go
+++ b/api/cmd/uzi/tui_board.go
@@ -101,9 +101,9 @@ func (b *boardState) visible() []apitypes.RunListItemDTO {
 			// #321 hides) plus the human word, so a user can filter by either "awaiting_approval"
 			// or "plan gate". The truly-raw r.Status is deliberately NOT included: it would let
 			// "running" match a planning run again, the exact thing #321 fixed.
-			_, word := stateGlyphWord(r.Status, r.Health, r.IsPlanning)
+			_, word := stateGlyphWord(r.Status, r.Health, r.IsPlanning, r.IsRevising)
 			hay := strings.ToLower(strings.Join([]string{
-				r.ID, r.Kind, effectiveRunStatus(r.Status, r.IsPlanning),
+				r.ID, r.Kind, effectiveRunStatus(r.Status, r.IsPlanning, r.IsRevising),
 				word, r.Health, cellText(runTitle(r.RunDTO)),
 			}, " "))
 			if strings.Contains(hay, q) {
@@ -125,8 +125,16 @@ const (
 
 var bandNames = [numBands]string{"NEEDS YOU", "ON THE FLOOR", "DONE"}
 
-// runBand places a run in its triage band from its status alone.
-func runBand(status string) int {
+// runBand places a run in its triage band from its status (plus is_revising).
+//
+// issue #750: a run mid-"revise" replan keeps status == awaiting_approval but is NOT the
+// user's turn — the agent is re-planning (~90s) and will re-gate itself — so it drops to
+// ON THE FLOOR instead of sitting in NEEDS YOU. is_revising is NOT status-gated
+// server-side, so the awaiting_approval check is applied here (mirroring effectiveRunStatus).
+func runBand(status string, isRevising bool) int {
+	if status == "awaiting_approval" && isRevising {
+		return bandFloor
+	}
 	switch status {
 	case "awaiting_approval", "awaiting_input", "awaiting_followup":
 		// awaiting_followup (PRD #517) is the user's turn — an interactive task parked for
@@ -144,7 +152,7 @@ func runBand(status string) int {
 func bandOrder(runs []apitypes.RunListItemDTO) []apitypes.RunListItemDTO {
 	var buckets [numBands][]apitypes.RunListItemDTO
 	for _, r := range runs {
-		b := runBand(r.Status)
+		b := runBand(r.Status, r.IsRevising)
 		buckets[b] = append(buckets[b], r)
 	}
 	out := make([]apitypes.RunListItemDTO, 0, len(runs))
@@ -335,12 +343,12 @@ const (
 func (m tuiModel) buildBoardItems(rows []apitypes.RunListItemDTO) []boardItem {
 	var counts [numBands]int
 	for _, r := range rows {
-		counts[runBand(r.Status)]++
+		counts[runBand(r.Status, r.IsRevising)]++
 	}
 	items := make([]boardItem, 0, len(rows)+numBands*2)
 	prevBand := -1
 	for i, r := range rows {
-		if b := runBand(r.Status); b != prevBand {
+		if b := runBand(r.Status, r.IsRevising); b != prevBand {
 			if prevBand != -1 {
 				items = append(items, boardItem{kind: biSpacer})
 			}
@@ -863,9 +871,9 @@ func padSeg(s string, n int, bg color.Color) string {
 // selected row rides the full-width warm selection bar with a ▸ cursor; a DONE-band row is
 // faint end to end.
 func (m tuiModel) boardRow(r apitypes.RunListItemDTO, sel bool, mc boardMarkerCols) string {
-	band := runBand(r.Status)
+	band := runBand(r.Status, r.IsRevising)
 	terminal := band == bandDone
-	tok := m.pal.stateToken(r.Status, r.Health, r.IsPlanning)
+	tok := m.pal.stateToken(r.Status, r.Health, r.IsPlanning, r.IsRevising)
 	showCred := m.boardShowCred()
 
 	var bg color.Color

--- a/api/cmd/uzi/tui_board.go
+++ b/api/cmd/uzi/tui_board.go
@@ -620,7 +620,13 @@ func (m tuiModel) boardSummary() string {
 	for _, r := range m.board.runs {
 		switch r.Status {
 		case "awaiting_approval":
-			approvals++
+			// issue #750: a run mid-"revise" replan keeps status == awaiting_approval but is
+			// NOT the user's turn (the agent is re-planning and will re-gate itself), so it must
+			// not inflate the ⚑ counter — mirror runBand's !isRevising gate so the cluster count
+			// matches the NEEDS YOU band header.
+			if !r.IsRevising {
+				approvals++
+			}
 		case "awaiting_input":
 			inputs++
 		case "awaiting_followup":

--- a/api/cmd/uzi/tui_detail.go
+++ b/api/cmd/uzi/tui_detail.go
@@ -367,7 +367,9 @@ func (m tuiModel) detailHeaderLines() []string {
 	// elapsed time — a live run's runtime or a terminal run's total wall time.
 	statusTag := ""
 	if d.run.ID != "" {
-		tok := m.pal.stateToken(d.run.Status, d.run.Health, d.run.IsPlanning)
+		// RunDTO carries no is_revising (issue #750): the detail header keeps its own
+		// derivePlanRevision panel, so revising is not surfaced through this token here.
+		tok := m.pal.stateToken(d.run.Status, d.run.Health, d.run.IsPlanning, false)
 		statusTag = lipgloss.NewStyle().Foreground(tok.color).Render(tok.glyph + " " + tok.word)
 		if dur := runDuration(d.run, time.Now()); dur != "" {
 			statusTag += m.pal.faint.Render(" · " + dur)

--- a/api/cmd/uzi/tui_followup_test.go
+++ b/api/cmd/uzi/tui_followup_test.go
@@ -18,7 +18,7 @@ import (
 // the lowercased status), i.e. glyph "·" and word "awaiting_followup", so both assertions
 // fail. The word must NOT be "needs input" (awaiting_input's) either.
 func TestStateGlyphWordAwaitingFollowup(t *testing.T) {
-	glyph, word := stateGlyphWord("awaiting_followup", "", false)
+	glyph, word := stateGlyphWord("awaiting_followup", "", false, false)
 	if glyph != "➤" {
 		t.Errorf("awaiting_followup glyph = %q, want %q", glyph, "➤")
 	}
@@ -27,7 +27,7 @@ func TestStateGlyphWordAwaitingFollowup(t *testing.T) {
 	}
 	// A distinct glyph from the neighbouring parks, so the spine reads three different
 	// states under NO_COLOR where colour cannot tell them apart.
-	if inputGlyph, _ := stateGlyphWord("awaiting_input", "", false); glyph == inputGlyph {
+	if inputGlyph, _ := stateGlyphWord("awaiting_input", "", false, false); glyph == inputGlyph {
 		t.Errorf("awaiting_followup and awaiting_input share glyph %q — they must be distinguishable without colour", glyph)
 	}
 }
@@ -37,18 +37,18 @@ func TestStateGlyphWordAwaitingFollowup(t *testing.T) {
 // the faintC default, so it stops matching amber (and awaiting_input) and matches faintC.
 func TestStateColorAwaitingFollowup(t *testing.T) {
 	p := newPalette(true)
-	followup := bgFillSGR(p.stateColor("awaiting_followup", "", false))
+	followup := bgFillSGR(p.stateColor("awaiting_followup", "", false, false))
 	if followup != bgFillSGR(p.amber) {
 		t.Errorf("awaiting_followup colour is not amber; a needs-you park must share the amber attention ink")
 	}
-	if followup != bgFillSGR(p.stateColor("awaiting_input", "", false)) {
+	if followup != bgFillSGR(p.stateColor("awaiting_input", "", false, false)) {
 		t.Error("awaiting_followup and awaiting_input resolve to different colours; both are needs-you parks and share amber")
 	}
 	if followup == bgFillSGR(p.faintC) {
 		t.Error("awaiting_followup resolved to the faint default; its explicit amber case is not being read")
 	}
 	// Health precedence is unchanged: a stalled park is still the stall colour.
-	if bgFillSGR(p.stateColor("awaiting_followup", "stalled", false)) != bgFillSGR(p.stall) {
+	if bgFillSGR(p.stateColor("awaiting_followup", "stalled", false, false)) != bgFillSGR(p.stall) {
 		t.Error("stalled health no longer overrides the awaiting_followup bucket; the precedence rule regressed")
 	}
 }
@@ -57,13 +57,13 @@ func TestStateColorAwaitingFollowup(t *testing.T) {
 // awaiting_followup from runBand's needs-you case → it falls through to bandFloor (it is not
 // terminal), so it stops matching bandNeedsYou / awaiting_input's band.
 func TestRunBandAwaitingFollowup(t *testing.T) {
-	if got := runBand("awaiting_followup"); got != bandNeedsYou {
+	if got := runBand("awaiting_followup", false); got != bandNeedsYou {
 		t.Errorf("runBand(awaiting_followup) = %d, want bandNeedsYou (%d) — a follow-up park is the user's turn", got, bandNeedsYou)
 	}
-	if runBand("awaiting_followup") != runBand("awaiting_input") {
+	if runBand("awaiting_followup", false) != runBand("awaiting_input", false) {
 		t.Error("awaiting_followup and awaiting_input land in different bands; both are rows a human must act on")
 	}
-	if runBand("awaiting_followup") == bandFloor {
+	if runBand("awaiting_followup", false) == bandFloor {
 		t.Error("awaiting_followup fell through to ON THE FLOOR; it must be promoted to NEEDS YOU")
 	}
 }

--- a/api/cmd/uzi/tui_model_test.go
+++ b/api/cmd/uzi/tui_model_test.go
@@ -1559,6 +1559,31 @@ func TestTUIBoardSummaryCountsFollowupPark(t *testing.T) {
 	}
 }
 
+// TestTUIBoardSummaryExcludesRevisingApproval pins issue #750 in the summary cluster: a run
+// mid-"revise" replan keeps status == awaiting_approval but is NOT the user's turn, so it must
+// not inflate the ⚑ counter. With one genuine plan-gate run and one revising run the cluster
+// must read "⚑ 1" (not "⚑ 2"), matching the NEEDS YOU band — where the revising run does NOT
+// belong. Mutation that reddens this: dropping the !r.IsRevising gate in boardSummary.
+func TestTUIBoardSummaryExcludesRevisingApproval(t *testing.T) {
+	genuine := apitypes.RunListItemDTO{RunDTO: apitypes.RunDTO{ID: "aaaaaaaa-1", Kind: "issue", Status: "awaiting_approval", IssueTitle: "plan gate"}}
+	revising := apitypes.RunListItemDTO{RunDTO: apitypes.RunDTO{ID: "bbbbbbbb-2", Kind: "issue", Status: "awaiting_approval", IssueTitle: "re-planning"}, IsRevising: true}
+	fake := &uzicli.FakeClient{Runs: []apitypes.RunListItemDTO{genuine, revising}}
+	m := tuiTestModel(t, fake, "")
+	next, _ := m.Update(boardRunsMsg{runs: fake.Runs})
+	m = next.(tuiModel)
+	got := m.boardSummary()
+	if !strings.Contains(got, "⚑ 1") || strings.Contains(got, "⚑ 2") {
+		t.Errorf("board summary must count only the genuine plan gate (want ⚑ 1, not ⚑ 2): %q", got)
+	}
+	// The revising run drops to ON THE FLOOR; only the genuine plan gate sits in NEEDS YOU.
+	if b := runBand(revising.Status, revising.IsRevising); b == bandNeedsYou {
+		t.Errorf("revising awaiting_approval run must not be in NEEDS YOU, got band %d", b)
+	}
+	if b := runBand(genuine.Status, genuine.IsRevising); b != bandNeedsYou {
+		t.Errorf("genuine awaiting_approval run must be in NEEDS YOU, got band %d", b)
+	}
+}
+
 // assertNoRawControls fails on anything in a rendered frame that is not printable text
 // or a legitimate SGR colour sequence.
 //

--- a/api/cmd/uzi/tui_model_test.go
+++ b/api/cmd/uzi/tui_model_test.go
@@ -1537,7 +1537,7 @@ func TestTUIBoardSemanticStatusAndSummary(t *testing.T) {
 		t.Errorf("board has no background-fill SGR; the warm selection bar is missing\n%s", out)
 	}
 	// The NO_COLOR-safe state glyph for a running run survives independent of colour.
-	if g, _ := stateGlyphWord("running", "", false); !strings.Contains(out, g) {
+	if g, _ := stateGlyphWord("running", "", false, false); !strings.Contains(out, g) {
 		t.Errorf("running state glyph %q absent from the board\n%s", g, out)
 	}
 }

--- a/api/cmd/uzi/tui_render.go
+++ b/api/cmd/uzi/tui_render.go
@@ -211,15 +211,21 @@ func (p palette) state(s crewState) lipgloss.Style {
 // HEALTH OVERRIDE: a WARN health flag (stalled/looping/slow) replaces the status token
 // entirely with ▲ + the health word, because a run that needs attention is what the board
 // is FOR. ok/empty health shows the status token.
-func stateGlyphWord(status, health string, isPlanning bool) (glyph, word string) {
+func stateGlyphWord(status, health string, isPlanning, isRevising bool) (glyph, word string) {
 	if stalledHealth[health] {
 		return "▲", health
 	}
-	switch effectiveRunStatus(status, isPlanning) {
+	switch effectiveRunStatus(status, isPlanning, isRevising) {
 	case "running":
 		return "●", "running"
 	case "planning":
 		return "○", "planning"
+	case "revising":
+		// issue #750: a "revise" replan is in flight while status stays awaiting_approval.
+		// The ↻ glyph reads "re-planning" and is a calm sibling of planning's ○ (NOT the
+		// ⚑ plan-gate glyph), so a revising run reads as working, not needing-you. Legible
+		// under NO_COLOR/Ascii: the word "revising" carries the meaning without colour.
+		return "↻", "revising"
 	case "awaiting_approval":
 		return "⚑", "plan gate"
 	case "awaiting_input":
@@ -245,14 +251,17 @@ func stateGlyphWord(status, health string, isPlanning bool) (glyph, word string)
 
 // stateColor is the colour half of the state token, resolved from the same ANDON tokens.
 // Health warn wins (→ stall orange); otherwise the status maps to its material.
-func (p palette) stateColor(status, health string, isPlanning bool) color.Color {
+func (p palette) stateColor(status, health string, isPlanning, isRevising bool) color.Color {
 	if stalledHealth[health] {
 		return p.stall
 	}
-	switch effectiveRunStatus(status, isPlanning) {
+	switch effectiveRunStatus(status, isPlanning, isRevising) {
 	case "running":
 		return p.sage
-	case "planning":
+	case "planning", "revising":
+		// issue #750: revising is a calm/info state like planning (indigo), NOT the amber
+		// attention colour awaiting_approval draws — a run re-planning is working, not
+		// waiting on the human.
 		return p.indigo
 	case "awaiting_approval", "awaiting_input", "awaiting_followup":
 		// awaiting_followup (PRD #517) is a needs-you park like the other two: amber.
@@ -276,9 +285,9 @@ type runToken struct {
 // stateToken is the ONE shared helper the design mandates: (glyph, colour, word) from a
 // run's status/health/planning, used on the board row, the board strip and the detail
 // header so they cannot render one run three ways.
-func (p palette) stateToken(status, health string, isPlanning bool) runToken {
-	g, w := stateGlyphWord(status, health, isPlanning)
-	return runToken{glyph: g, word: w, color: p.stateColor(status, health, isPlanning)}
+func (p palette) stateToken(status, health string, isPlanning, isRevising bool) runToken {
+	g, w := stateGlyphWord(status, health, isPlanning, isRevising)
+	return runToken{glyph: g, word: w, color: p.stateColor(status, health, isPlanning, isRevising)}
 }
 
 // verdictColor maps a judge verdict to a severity colour: issues → alarm red, everything

--- a/api/cmd/uzi/tui_revising_test.go
+++ b/api/cmd/uzi/tui_revising_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vtmocanu/uzi/api/internal/apitypes"
+	"github.com/vtmocanu/uzi/api/internal/uzicli"
+)
+
+// issue #750: while a "revise" replan is in flight the server keeps runs.status at
+// awaiting_approval but sets is_revising. The TUI must treat such a run as its own calm
+// "revising" state — a working state, NOT a needs-you park — and drop it OUT of the NEEDS
+// YOU band until the next plan lands (server flips is_revising back to false). is_revising
+// is NOT status-gated server-side, so every helper gates on
+// status == "awaiting_approval" && isRevising itself, mirroring is_planning.
+
+// TestStateGlyphWordRevising pins the glyph + word. A revising run reads the ↻ / "revising"
+// vocabulary (a calm sibling of planning's ○), never the ⚑ / "plan gate" that a genuine
+// awaiting_approval gate draws. The gate is honoured: is_revising off awaiting_approval has
+// no effect. Reddening mutation: drop the "revising" case from stateGlyphWord → an
+// awaiting_approval+is_revising run renders ⚑ / "plan gate", so both assertions fail.
+func TestStateGlyphWordRevising(t *testing.T) {
+	glyph, word := stateGlyphWord("awaiting_approval", "", false, true)
+	if glyph != "↻" {
+		t.Errorf("revising glyph = %q, want %q", glyph, "↻")
+	}
+	if word != "revising" {
+		t.Errorf("revising word = %q, want %q (must not be the awaiting_approval plan-gate label)", word, "revising")
+	}
+	// A distinct glyph from the plan gate, so the spine reads the two apart under NO_COLOR.
+	if gateGlyph, _ := stateGlyphWord("awaiting_approval", "", false, false); glyph == gateGlyph {
+		t.Errorf("revising and the plan gate share glyph %q — they must be distinguishable without colour", glyph)
+	}
+	// is_revising is gated on awaiting_approval: it has no effect on any other status.
+	if _, w := stateGlyphWord("running", "", false, true); w != "running" {
+		t.Errorf("is_revising leaked onto a running run: word = %q, want %q", w, "running")
+	}
+}
+
+// TestStateColorRevising pins the colour to indigo, the calm/info ink planning uses — NOT
+// the amber attention ink an awaiting_approval gate draws. Reddening mutation: drop
+// "revising" from stateColor's planning case → it falls to amber (awaiting_approval's), so
+// it stops matching indigo and starts matching amber.
+func TestStateColorRevising(t *testing.T) {
+	p := newPalette(true)
+	revising := bgFillSGR(p.stateColor("awaiting_approval", "", false, true))
+	if revising != bgFillSGR(p.indigo) {
+		t.Error("revising colour is not indigo; a re-planning run must share planning's calm/info ink")
+	}
+	if revising == bgFillSGR(p.amber) {
+		t.Error("revising resolved to amber, the needs-you attention ink; it must read as working, not waiting")
+	}
+	// Health precedence is unchanged: a stalled revising run is still the stall colour.
+	if bgFillSGR(p.stateColor("awaiting_approval", "stalled", false, true)) != bgFillSGR(p.stall) {
+		t.Error("stalled health no longer overrides the revising bucket; the precedence rule regressed")
+	}
+}
+
+// TestRunBandRevising pins the triage band. A revising run (awaiting_approval + is_revising)
+// drops to ON THE FLOOR; the SAME status without is_revising stays in NEEDS YOU. The other
+// two parks are unaffected by is_revising. Reddening mutation: drop the is_revising check
+// from runBand → the revising run stays in bandNeedsYou.
+func TestRunBandRevising(t *testing.T) {
+	if got := runBand("awaiting_approval", true); got != bandFloor {
+		t.Errorf("runBand(awaiting_approval, true) = %d, want bandFloor (%d) — a revising run is not the user's turn", got, bandFloor)
+	}
+	if got := runBand("awaiting_approval", false); got != bandNeedsYou {
+		t.Errorf("runBand(awaiting_approval, false) = %d, want bandNeedsYou (%d) — a genuine plan gate is the user's turn", got, bandNeedsYou)
+	}
+	// The other needs-you parks are not affected by is_revising (it is gated on awaiting_approval).
+	if got := runBand("awaiting_input", true); got != bandNeedsYou {
+		t.Errorf("runBand(awaiting_input, true) = %d, want bandNeedsYou (%d) — is_revising must not leak past awaiting_approval", got, bandNeedsYou)
+	}
+	if got := runBand("awaiting_followup", true); got != bandNeedsYou {
+		t.Errorf("runBand(awaiting_followup, true) = %d, want bandNeedsYou (%d) — is_revising must not leak past awaiting_approval", got, bandNeedsYou)
+	}
+}
+
+// TestBandOrderPlacesRevisingOnFloor proves the whole-list partition: a revising row lands
+// in the ON THE FLOOR slice while a genuine plan-gate row stays in NEEDS YOU, so the board's
+// NEEDS YOU → ON THE FLOOR → DONE concatenation puts the revising run after the gate run.
+func TestBandOrderPlacesRevisingOnFloor(t *testing.T) {
+	runs := []apitypes.RunListItemDTO{
+		{RunDTO: apitypes.RunDTO{ID: "revising-1", Kind: "issue", Status: "awaiting_approval"}, IsRevising: true},
+		{RunDTO: apitypes.RunDTO{ID: "gate-1", Kind: "issue", Status: "awaiting_approval"}},
+	}
+	out := bandOrder(runs)
+	if len(out) != 2 {
+		t.Fatalf("bandOrder returned %d rows, want 2", len(out))
+	}
+	// NEEDS YOU comes first, so the genuine gate leads and the revising run is demoted below it.
+	if out[0].ID != "gate-1" {
+		t.Errorf("bandOrder[0] = %q, want the plan-gate run \"gate-1\" in NEEDS YOU", out[0].ID)
+	}
+	if out[1].ID != "revising-1" {
+		t.Errorf("bandOrder[1] = %q, want the revising run \"revising-1\" on the floor", out[1].ID)
+	}
+}
+
+// TestBoardRendersRevisingGlyphTwin proves the state's glyph is its NO_COLOR twin: it
+// survives an SGR-strip, so a reader on an Ascii/NoTTY profile still sees the "revising"
+// word and ↻ glyph. Reddening mutation: drop the revising case from stateGlyphWord → the
+// row draws ⚑ / "plan gate", so the ↻ / "revising" assertions fail.
+func TestBoardRendersRevisingGlyphTwin(t *testing.T) {
+	fake := &uzicli.FakeClient{Runs: []apitypes.RunListItemDTO{
+		{RunDTO: apitypes.RunDTO{ID: "aaaaaaaa-1", Kind: "issue", Status: "awaiting_approval", IssueTitle: "replanning one"}, IsRevising: true},
+	}}
+	m := tuiTestModel(t, fake, "")
+	next, _ := m.Update(boardRunsMsg{runs: fake.Runs})
+	m = next.(tuiModel)
+	// Strip every SGR escape: what remains is exactly what a NO_COLOR/Ascii terminal shows.
+	plain := stripANSI(m.View().Content)
+	if !strings.Contains(plain, "↻") {
+		t.Errorf("revising glyph ↻ absent from the colour-stripped board — it is not a NO_COLOR twin\n%s", plain)
+	}
+	if !strings.Contains(plain, "revising") {
+		t.Errorf("revising word \"revising\" absent from the colour-stripped board\n%s", plain)
+	}
+}

--- a/api/cmd/uzi/uxlab_gen_test.go
+++ b/api/cmd/uzi/uxlab_gen_test.go
@@ -83,6 +83,7 @@ func TestGenerateUXLabFrames(t *testing.T) {
 		"board-admin":              boardAdmin,
 		"board-filter":             func(d bool) string { return boardFilter(d, now) },
 		"board-planning":           func(d bool) string { return boardPlanning(d, now) },
+		"board-revising":           func(d bool) string { return boardRevising(d, now) },
 		"board-milestones":         func(d bool) string { return boardMilestones(d, now) },
 		"detail-running":           func(d bool) string { return detailRunning(d, now) },
 		"detail-planning":          func(d bool) string { return detailPlanning(d, now) },
@@ -268,6 +269,21 @@ func boardPlanning(dark bool, now time.Time) string {
 		{RunDTO: apitypes.RunDTO{ID: "d0e1f2a3-1111-2222-3333-444444444444", Kind: "issue", Status: "running", IsPlanning: true, IssueTitle: "Draft the plan for webhook delivery retries", CreatedAt: now.Add(-90 * time.Second)}},
 		{RunDTO: apitypes.RunDTO{ID: "a1b2c3d4-1111-2222-3333-444444444444", Kind: "issue", Status: "running", IssueTitle: "Add rate-limit headroom to the scheduler poll", CreatedAt: now.Add(-4 * time.Minute)}},
 		{RunDTO: apitypes.RunDTO{ID: "c3d4e5f6-1111-2222-3333-444444444444", Kind: "issue", Status: "running", Health: "stalled", IssueTitle: "Refactor the forge sync loop for the GitHub driver", CreatedAt: now.Add(-51 * time.Minute)}},
+	}})
+	return m.View().Content
+}
+
+// boardRevising renders a board carrying a mid-"revise" replan run (issue #750: status stays
+// awaiting_approval but IsRevising is true) beside a genuine plan-gate run. The revising run
+// drops to ON THE FLOOR and is excluded from the ⚑ summary count, so the frame shows the fixed
+// treatment — the cluster reads ⚑ 1 with two awaiting_approval runs on the board.
+func boardRevising(dark bool, now time.Time) string {
+	fake := &uzicli.FakeClient{}
+	m := uxModel(fake, "", dark)
+	m = step(m, boardRunsMsg{runs: []apitypes.RunListItemDTO{
+		{RunDTO: apitypes.RunDTO{ID: "b2c3d4e5-1111-2222-3333-444444444444", Kind: "ci_fix", Status: "awaiting_approval", IssueTitle: "Fix flaky pipeline on main", CreatedAt: now.Add(-2 * time.Minute)}},
+		{RunDTO: apitypes.RunDTO{ID: "d0e1f2a3-1111-2222-3333-444444444444", Kind: "issue", Status: "awaiting_approval", IssueTitle: "Re-plan webhook delivery retries after steer", CreatedAt: now.Add(-90 * time.Second)}, IsRevising: true},
+		{RunDTO: apitypes.RunDTO{ID: "a1b2c3d4-1111-2222-3333-444444444444", Kind: "issue", Status: "running", IssueTitle: "Add rate-limit headroom to the scheduler poll", CreatedAt: now.Add(-4 * time.Minute)}},
 	}})
 	return m.View().Content
 }

--- a/api/internal/apitypes/run.go
+++ b/api/internal/apitypes/run.go
@@ -418,6 +418,15 @@ type RunListItemDTO struct {
 	// bucketed in Go. See queries/runtime.sql for why the count cannot ride the join.
 	JudgeVerdict   *string `json:"judge_verdict"`
 	JudgeTodoCount int     `json:"judge_todo_count"`
+	// IsRevising is a server-computed display predicate (issue #750): true when the run's
+	// latest plan-ish message ({plan, plan_revising}) is a plan_revising — i.e. a "revise"
+	// replan is in flight. Like IsPlanning it is derived, not stored (no new column or
+	// status value), and meaningful only while status == "awaiting_approval": a plan
+	// revise leaves runs.status at awaiting_approval, so surfaces classifying from status
+	// alone need this to keep the run out of the human-attention grouping. It is
+	// deliberately NOT on RunDTO (the detail page keeps its own derivePlanRevision panel).
+	// A pre-feature api pod omits it; clients treat absent as false.
+	IsRevising bool `json:"is_revising"`
 }
 
 // MessageDTO is one persisted run message (the replay source a reconnecting

--- a/api/internal/apitypes/wire_test.go
+++ b/api/internal/apitypes/wire_test.go
@@ -178,7 +178,9 @@ func TestRunDTOTags(t *testing.T) {
 func TestRunListItemDTOTags(t *testing.T) {
 	// Embeds RunDTO (keys flatten in) plus repo_path + worker_name; owner_email is
 	// omitempty (absent when nil).
-	want := append(append([]string{}, runDTOKeys...), "repo_path", "worker_name", "judge_verdict", "judge_todo_count")
+	// is_revising (issue #750) is on RunListItemDTO only, deliberately NOT on RunDTO —
+	// so it is listed here, not in runDTOKeys.
+	want := append(append([]string{}, runDTOKeys...), "repo_path", "worker_name", "judge_verdict", "judge_todo_count", "is_revising")
 	assertTags(t, "RunListItemDTO(no owner)", RunListItemDTO{}, want...)
 	// owner_email present when set.
 	email := "u@example.test"

--- a/api/internal/handler/board.go
+++ b/api/internal/handler/board.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -129,7 +130,14 @@ type latestRunDTO struct {
 	// IsPlanning is issue #321's planning-phase display flag on the board card;
 	// non-sensitive, rides the shared card unconditionally like Status. Server-computed
 	// (running, iteration_count 0, no persisted plan yet; chat/judge excluded).
-	IsPlanning bool    `json:"is_planning"`
+	IsPlanning bool `json:"is_planning"`
+	// IsRevising is issue #750's plan-revise display flag on the board card: true when
+	// the run's latest plan-ish message ({plan, plan_revising}) is a plan_revising — a
+	// "revise" replan in flight. Non-sensitive, rides the shared card unconditionally
+	// like IsPlanning/Status. Server-computed (planRevisingSet), meaningful only while
+	// status == "awaiting_approval". Set by assembleCards after mapLatestRun, since the
+	// signal needs a batched per-run message fetch mapLatestRun's columns do not carry.
+	IsRevising bool    `json:"is_revising"`
 	OwnerName  string  `json:"owner_name"`
 	WorkerName *string `json:"worker_name"`
 	IsMine     bool    `json:"is_mine"`
@@ -182,6 +190,24 @@ func mapLatestRun(runID, ownerID uuid.UUID, status string, kind string, iteratio
 		dto.OwnerName = ownerName.String
 	}
 	return dto
+}
+
+// setLatestRunRevising stamps issue #750's derived is_revising flag on a
+// single-card latest-run DTO. The board-wide path (assembleCards) uses the batch
+// PlanRevisingForRuns map; the single-card refresh responses (drag, prdless toggle,
+// promote) go through here so a revising run keeps the flag — otherwise the card
+// would blank it and pop the attention ring back until the next full board poll.
+// Best-effort like the batch path: the flag is decoration, so a query error just
+// leaves it false rather than failing the response.
+func (h *Handler) setLatestRunRevising(ctx context.Context, dto *latestRunDTO, runID uuid.UUID) {
+	if dto == nil {
+		return
+	}
+	if m, err := h.wsvc.PlanRevisingForRuns(ctx, []uuid.UUID{runID}); err == nil {
+		dto.IsRevising = m[runID]
+	} else {
+		slog.Warn("single-card plan revising state", "error", err)
+	}
 }
 
 type boardDTO struct {
@@ -393,10 +419,23 @@ func (h *Handler) buildBoard(w http.ResponseWriter, r *http.Request, repo store.
 	repoPipeline := h.defaultBranchPipeline(r, repo)
 	cardPipelines := h.cardPipelines(r, repo.ID)
 
+	// Plan-revise display flag per card's latest run (issue #750). Best-effort like the
+	// pipeline badges above: the card is decoration, so a failure logs and leaves every
+	// flag false (a nil map indexes to false) rather than failing the board.
+	revisingIDs := make([]uuid.UUID, 0, len(runRows))
+	for _, rr := range runRows {
+		revisingIDs = append(revisingIDs, rr.ID)
+	}
+	revising, err := h.wsvc.PlanRevisingForRuns(r.Context(), revisingIDs)
+	if err != nil {
+		slog.Error("board plan revising states", "error", err)
+		revising = nil
+	}
+
 	// repo.UserID is the board viewer (the connection owner); IsMine gates the
 	// owner-only run-view link. repo.ForgeType stamps every card's forge for the
 	// per-card MR/PR noun (all cards on one board share the repo's connection).
-	cards := assembleCards(issues, runRows, cardPipelines, position, repo.UserID, repo.ForgeType)
+	cards := assembleCards(issues, runRows, cardPipelines, position, repo.UserID, repo.ForgeType, revising)
 
 	// Board membership extras default (PRD #196), best-effort like the other
 	// settings reads: the admin default the client falls back to when the user has
@@ -492,13 +531,17 @@ func nonNilLabels(labels []string) []string {
 // per issue (runRows, one row per issue that has run), the column position map,
 // and the board viewer. It is the pure, DB-free core of the board payload: it
 // keys each issue's latest_run by issue_iid (issues with no run get null), and
-// resolves each card's column. viewerID drives IsMine.
-func assembleCards(issues []store.Issue, runRows []store.ListLatestRunsForRepoRow, cardPipelines map[int64]*apitypes.PipelineDTO, position map[string]int, viewerID uuid.UUID, forgeType string) []cardDTO {
+// resolves each card's column. viewerID drives IsMine. revising is the set of run
+// ids whose latest plan-ish message is a plan_revising (issue #750); a nil map leaves
+// every IsRevising false.
+func assembleCards(issues []store.Issue, runRows []store.ListLatestRunsForRepoRow, cardPipelines map[int64]*apitypes.PipelineDTO, position map[string]int, viewerID uuid.UUID, forgeType string, revising map[uuid.UUID]bool) []cardDTO {
 	latestByIID := make(map[int64]*latestRunDTO, len(runRows))
 	for _, rr := range runRows {
-		latestByIID[rr.IssueIid.Int64] = mapLatestRun(rr.ID, rr.UserID, rr.Status, rr.Kind, rr.IterationCount, rr.HasPlanMd.Bool, rr.MrIid, rr.MrWebUrl,
+		dto := mapLatestRun(rr.ID, rr.UserID, rr.Status, rr.Kind, rr.IterationCount, rr.HasPlanMd.Bool, rr.MrIid, rr.MrWebUrl,
 			rr.MrState, rr.FailureReason, rr.StopKind, rr.Health, rr.HealthReason, rr.HealthSince,
 			rr.OwnerName, rr.WorkerName, rr.RunCount, rr.CreatedAt, rr.UpdatedAt, viewerID)
+		dto.IsRevising = revising[rr.ID] // nil map ⇒ false (issue #750)
+		latestByIID[rr.IssueIid.Int64] = dto
 	}
 
 	cards := make([]cardDTO, 0, len(issues))
@@ -850,6 +893,7 @@ func (h *Handler) MoveIssue(w http.ResponseWriter, r *http.Request) {
 		card.LatestRun = mapLatestRun(lr.ID, lr.UserID, lr.Status, lr.Kind, lr.IterationCount, lr.HasPlanMd.Bool, lr.MrIid, lr.MrWebUrl,
 			lr.MrState, lr.FailureReason, lr.StopKind, lr.Health, lr.HealthReason, lr.HealthSince,
 			lr.OwnerName, lr.WorkerName, lr.RunCount, lr.CreatedAt, lr.UpdatedAt, repo.UserID)
+		h.setLatestRunRevising(r.Context(), card.LatestRun, lr.ID) // issue #750
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		slog.Warn("latest run for moved card", "error", err)
 	}
@@ -949,6 +993,7 @@ func (h *Handler) SetIssuePrdless(w http.ResponseWriter, r *http.Request) {
 		card.LatestRun = mapLatestRun(lr.ID, lr.UserID, lr.Status, lr.Kind, lr.IterationCount, lr.HasPlanMd.Bool, lr.MrIid, lr.MrWebUrl,
 			lr.MrState, lr.FailureReason, lr.StopKind, lr.Health, lr.HealthReason, lr.HealthSince,
 			lr.OwnerName, lr.WorkerName, lr.RunCount, lr.CreatedAt, lr.UpdatedAt, repo.UserID)
+		h.setLatestRunRevising(r.Context(), card.LatestRun, lr.ID) // issue #750
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		slog.Warn("latest run for prdless card", "error", err)
 	}
@@ -1054,6 +1099,7 @@ func (h *Handler) PromoteIssue(w http.ResponseWriter, r *http.Request) {
 		card.LatestRun = mapLatestRun(lr.ID, lr.UserID, lr.Status, lr.Kind, lr.IterationCount, lr.HasPlanMd.Bool, lr.MrIid, lr.MrWebUrl,
 			lr.MrState, lr.FailureReason, lr.StopKind, lr.Health, lr.HealthReason, lr.HealthSince,
 			lr.OwnerName, lr.WorkerName, lr.RunCount, lr.CreatedAt, lr.UpdatedAt, repo.UserID)
+		h.setLatestRunRevising(r.Context(), card.LatestRun, lr.ID) // issue #750
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		slog.Warn("latest run for promoted card", "error", err)
 	}

--- a/api/internal/handler/board_latestrun_test.go
+++ b/api/internal/handler/board_latestrun_test.go
@@ -169,7 +169,7 @@ func TestAssembleCards(t *testing.T) {
 	}
 	position := map[string]int{"In Progress": 0}
 
-	cards := assembleCards(issues, runRows, nil, position, viewer, "forgejo")
+	cards := assembleCards(issues, runRows, nil, position, viewer, "forgejo", nil)
 	byIID := make(map[int64]cardDTO, len(cards))
 	for _, c := range cards {
 		byIID[c.IID] = c

--- a/api/internal/handler/card_labels_test.go
+++ b/api/internal/handler/card_labels_test.go
@@ -67,7 +67,7 @@ func TestCardLabelsNeverMarshalAsNull(t *testing.T) {
 				}
 			})
 			t.Run("assembleCards", func(t *testing.T) {
-				cards := assembleCards([]store.Issue{is}, nil, nil, nil, uuid.Nil, "gitlab")
+				cards := assembleCards([]store.Issue{is}, nil, nil, nil, uuid.Nil, "gitlab", nil)
 				if len(cards) != 1 {
 					t.Fatalf("expected one card, got %d", len(cards))
 				}

--- a/api/internal/handler/runs.go
+++ b/api/internal/handler/runs.go
@@ -61,6 +61,14 @@ func (h *Handler) ListRuns(w http.ResponseWriter, r *http.Request) {
 		slog.Error("judge todo counts", "error", err)
 		todo = nil
 	}
+	// Plan-revise display flag for the runs on this page (issue #750). Same best-effort
+	// contract as the judge badge above: it is decoration, so a failure logs and leaves
+	// every flag false (nil map indexes to false) rather than failing the run list.
+	revising, err := h.wsvc.PlanRevisingForRuns(r.Context(), runIDs)
+	if err != nil {
+		slog.Error("plan revising states", "error", err)
+		revising = nil
+	}
 
 	out := make([]apitypes.RunListItemDTO, 0, len(rows))
 	for _, row := range rows {
@@ -76,6 +84,7 @@ func (h *Handler) ListRuns(w http.ResponseWriter, r *http.Request) {
 		// nil stays nil for an unjudged run — absent, not a neutral verdict.
 		item.JudgeVerdict = textPtrValue(row.JudgeVerdict.Valid, row.JudgeVerdict.String)
 		item.JudgeTodoCount = todo[row.Run.ID]
+		item.IsRevising = revising[row.Run.ID] // nil map ⇒ false (issue #750)
 		out = append(out, item)
 	}
 	httpx.JSON(w, http.StatusOK, map[string]any{"runs": out})

--- a/api/internal/handler/runs.go
+++ b/api/internal/handler/runs.go
@@ -99,6 +99,20 @@ func (h *Handler) AdminListRuns(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	runIDs := make([]uuid.UUID, 0, len(rows))
+	for _, row := range rows {
+		runIDs = append(runIDs, row.Run.ID)
+	}
+	// Plan-revise display flag, same best-effort contract as ListRuns (issue #750): the
+	// admin CLI renders status through effectiveRunStatus(..., IsRevising), so without this
+	// a revising run would show as awaiting_approval here while the owner's own list says
+	// "revising". Decoration only — a failure logs and leaves every flag false.
+	revising, err := h.wsvc.PlanRevisingForRuns(r.Context(), runIDs)
+	if err != nil {
+		slog.Error("plan revising states", "error", err)
+		revising = nil
+	}
+
 	out := make([]apitypes.RunListItemDTO, 0, len(rows))
 	for _, row := range rows {
 		email := row.OwnerEmail
@@ -111,6 +125,7 @@ func (h *Handler) AdminListRuns(w http.ResponseWriter, r *http.Request) {
 		item.ForgeType = row.ForgeType // per-run MR/PR noun (PRD #65 D2)
 		// PRD #411: the joined forge issue web URL, nil for issue-less/uncached runs.
 		item.IssueWebURL = textPtrValue(row.IssueWebUrl.Valid, row.IssueWebUrl.String)
+		item.IsRevising = revising[row.Run.ID] // nil map ⇒ false (issue #750)
 		out = append(out, item)
 	}
 	httpx.JSON(w, http.StatusOK, map[string]any{"runs": out})

--- a/api/internal/handler/runs_test.go
+++ b/api/internal/handler/runs_test.go
@@ -908,12 +908,19 @@ func TestListRunsRejectsMalformedFilters(t *testing.T) {
 }
 
 func TestAdminListWorkersAndRuns(t *testing.T) {
+	revisingRun := uuid.New()
 	st := &runsStore{
 		allWorkers: []store.ListAllWorkersRow{
 			{Worker: store.Worker{ID: uuid.New(), Name: "w1", Status: "online"}, Busy: true, ActiveRuns: 1, OwnerEmail: "u@example.com"},
 		},
 		activeRuns: []store.ListActiveRunsAllRow{
-			{Run: store.Run{ID: uuid.New(), Status: "running"}, RepoPath: "grp/repo", OwnerEmail: "u@example.com"},
+			{Run: store.Run{ID: revisingRun, Status: "awaiting_approval"}, RepoPath: "grp/repo", OwnerEmail: "u@example.com"},
+		},
+		// The run is mid-replan: its latest plan-ish message is a plan_revising, so the admin
+		// list must enrich is_revising the same way ListRuns does (issue #750).
+		planRevisionRunRows: []store.ListPlanRevisionStateForRunsRow{
+			{RunID: revisingRun, Seq: 1, Kind: "plan"},
+			{RunID: revisingRun, Seq: 2, Kind: "plan_revising"},
 		},
 	}
 	h := newRunsHandler(t, st)
@@ -928,6 +935,14 @@ func TestAdminListWorkersAndRuns(t *testing.T) {
 	h.AdminListRuns(rec, httptest.NewRequest(http.MethodGet, "/api/admin/runs", nil))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "grp/repo") {
 		t.Fatalf("AdminListRuns = %d %q", rec.Code, rec.Body.String())
+	}
+	// The admin overview must carry is_revising too, so `uzi admin runs` renders a mid-replan
+	// run as "revising" (via effectiveRunStatus) rather than as awaiting_approval.
+	if !strings.Contains(rec.Body.String(), `"is_revising":true`) {
+		t.Fatalf("AdminListRuns must enrich is_revising for a revising run: %q", rec.Body.String())
+	}
+	if got := st.planRevisionRunArg; len(got) != 1 || got[0] != revisingRun {
+		t.Fatalf("AdminListRuns plan-revising lookup arg = %v, want [%v]", got, revisingRun)
 	}
 }
 

--- a/api/internal/handler/runs_test.go
+++ b/api/internal/handler/runs_test.go
@@ -39,6 +39,12 @@ type runsStore struct {
 	judgeTriageRunArg  *store.ListJudgeTriageRowsForRunsParams
 	judgeTriageRunErr  error
 
+	// issue #750 plan-revise flag: scripted plan-ish message rows for the page's runs,
+	// and the run ids the handler passed.
+	planRevisionRunRows []store.ListPlanRevisionStateForRunsRow
+	planRevisionRunArg  []uuid.UUID
+	planRevisionRunErr  error
+
 	workersvc.Store
 	ownerID uuid.UUID
 	run     store.Run
@@ -1031,4 +1037,12 @@ func TestServeWSRejectsCrossOrigin(t *testing.T) {
 func (s *runsStore) ListJudgeTriageRowsForRuns(_ context.Context, arg store.ListJudgeTriageRowsForRunsParams) ([]store.ListJudgeTriageRowsForRunsRow, error) {
 	s.judgeTriageRunArg = &arg
 	return s.judgeTriageRunRows, s.judgeTriageRunErr
+}
+
+// ListPlanRevisionStateForRuns backs the /runs plan-revise flag (issue #750). The
+// default is an empty set — no run revising — so every pre-existing run-list test keeps
+// its meaning; planRevisionRunRows lets a test script plan-ish message rows.
+func (s *runsStore) ListPlanRevisionStateForRuns(_ context.Context, runIds []uuid.UUID) ([]store.ListPlanRevisionStateForRunsRow, error) {
+	s.planRevisionRunArg = runIds
+	return s.planRevisionRunRows, s.planRevisionRunErr
 }

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -482,6 +482,16 @@ ORDER BY r.created_at DESC
 -- raise this without raising that and the badge counts start truncating silently.
 LIMIT 200;
 
+-- name: ListPlanRevisionStateForRuns :many
+-- The plan-ish message rows ({plan, plan_revising}) for a page of runs, so the
+-- "latest by seq is plan_revising ⇒ revising" fold happens in Go (planRevisingSet),
+-- mirroring web derivePlanRevision. Backed by run_messages UNIQUE (run_id, seq).
+SELECT run_id, seq, kind
+FROM run_messages
+WHERE run_id = ANY(@run_ids::uuid[])
+  AND kind IN ('plan', 'plan_revising')
+ORDER BY run_id, seq;
+
 -- name: ListActiveRunsAll :many
 -- Admin Agents-status: every non-terminal run across all users, with repo path,
 -- worker name, and owner email for the admin overview.

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -3202,6 +3202,43 @@ func (q *Queries) ListPendingColumnMoves(ctx context.Context, arg ListPendingCol
 	return items, nil
 }
 
+const listPlanRevisionStateForRuns = `-- name: ListPlanRevisionStateForRuns :many
+SELECT run_id, seq, kind
+FROM run_messages
+WHERE run_id = ANY($1::uuid[])
+  AND kind IN ('plan', 'plan_revising')
+ORDER BY run_id, seq
+`
+
+type ListPlanRevisionStateForRunsRow struct {
+	RunID uuid.UUID `json:"run_id"`
+	Seq   int32     `json:"seq"`
+	Kind  string    `json:"kind"`
+}
+
+// The plan-ish message rows ({plan, plan_revising}) for a page of runs, so the
+// "latest by seq is plan_revising ⇒ revising" fold happens in Go (planRevisingSet),
+// mirroring web derivePlanRevision. Backed by run_messages UNIQUE (run_id, seq).
+func (q *Queries) ListPlanRevisionStateForRuns(ctx context.Context, runIds []uuid.UUID) ([]ListPlanRevisionStateForRunsRow, error) {
+	rows, err := q.db.Query(ctx, listPlanRevisionStateForRuns, runIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPlanRevisionStateForRunsRow{}
+	for rows.Next() {
+		var i ListPlanRevisionStateForRunsRow
+		if err := rows.Scan(&i.RunID, &i.Seq, &i.Kind); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunMessagesAfter = `-- name: ListRunMessagesAfter :many
 SELECT id, run_id, seq, kind, agent, payload, created_at, agent_instance, agent_label
 FROM run_messages

--- a/api/internal/workersvc/plan_revising.go
+++ b/api/internal/workersvc/plan_revising.go
@@ -1,0 +1,57 @@
+package workersvc
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// planRevisingSet folds plan-ish message rows into the set of runs currently
+// revising: a run is revising iff its greatest-seq {plan, plan_revising} row is a
+// plan_revising (same rule as web derivePlanRevision). Runs with no plan-ish rows
+// are absent (⇒ not revising).
+//
+// Only runs that ARE revising are stored (value always true); callers index with
+// m[id], which yields false for an absent run — so a plain `plan` (a plan that was
+// never revised) and a run with no plan-ish rows both read as false without needing
+// an entry.
+func planRevisingSet(rows []store.ListPlanRevisionStateForRunsRow) map[uuid.UUID]bool {
+	// Track, per run, the greatest seq seen and the kind at that seq. The query
+	// already ORDERs BY run_id, seq, but this fold does not rely on that ordering —
+	// it takes the max explicitly so it stays correct if the ordering ever changes.
+	type winner struct {
+		seq  int32
+		kind string
+	}
+	best := make(map[uuid.UUID]winner)
+	for _, r := range rows {
+		if w, ok := best[r.RunID]; !ok || r.Seq > w.seq {
+			best[r.RunID] = winner{seq: r.Seq, kind: r.Kind}
+		}
+	}
+	out := make(map[uuid.UUID]bool)
+	for id, w := range best {
+		if w.kind == "plan_revising" {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+// PlanRevisingForRuns returns the set of runs (by id) whose latest plan-ish message
+// is a plan_revising — i.e. runs currently mid-replan, a display-only signal the
+// run list and board card render while status stays awaiting_approval (issue #750,
+// mirroring the existing is_planning precedent from #321). Runs not revising are
+// absent from the map, which the caller reads as false.
+func (s *Service) PlanRevisingForRuns(ctx context.Context, runIDs []uuid.UUID) (map[uuid.UUID]bool, error) {
+	if len(runIDs) == 0 {
+		return map[uuid.UUID]bool{}, nil
+	}
+	rows, err := s.q.ListPlanRevisionStateForRuns(ctx, runIDs)
+	if err != nil {
+		return nil, err
+	}
+	return planRevisingSet(rows), nil
+}

--- a/api/internal/workersvc/plan_revising_test.go
+++ b/api/internal/workersvc/plan_revising_test.go
@@ -1,0 +1,97 @@
+package workersvc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// row is a tiny constructor keeping the table rows readable.
+func planRow(runID uuid.UUID, seq int32, kind string) store.ListPlanRevisionStateForRunsRow {
+	return store.ListPlanRevisionStateForRunsRow{RunID: runID, Seq: seq, Kind: kind}
+}
+
+func TestPlanRevisingSet(t *testing.T) {
+	runA := uuid.New()
+	runB := uuid.New()
+
+	tests := []struct {
+		name string
+		rows []store.ListPlanRevisionStateForRunsRow
+		want map[uuid.UUID]bool // only the true entries; absent ⇒ false
+	}{
+		{
+			name: "latest plan-ish is plan_revising ⇒ revising",
+			rows: []store.ListPlanRevisionStateForRunsRow{
+				planRow(runA, 3, "plan"),
+				planRow(runA, 7, "plan_revising"),
+			},
+			want: map[uuid.UUID]bool{runA: true},
+		},
+		{
+			name: "a newer plan after a plan_revising ⇒ not revising",
+			rows: []store.ListPlanRevisionStateForRunsRow{
+				planRow(runA, 3, "plan"),
+				planRow(runA, 7, "plan_revising"),
+				planRow(runA, 12, "plan"),
+			},
+			want: map[uuid.UUID]bool{},
+		},
+		{
+			name: "only a plan, never revised ⇒ absent (not revising)",
+			rows: []store.ListPlanRevisionStateForRunsRow{
+				planRow(runA, 5, "plan"),
+			},
+			want: map[uuid.UUID]bool{},
+		},
+		{
+			name: "no plan-ish rows at all ⇒ empty set",
+			rows: nil,
+			want: map[uuid.UUID]bool{},
+		},
+		{
+			name: "multi-run, interleaved by seq ⇒ correct per-run grouping",
+			rows: []store.ListPlanRevisionStateForRunsRow{
+				// Deliberately interleaved and not globally seq-ordered, to prove the
+				// fold takes the max PER run rather than trusting arrival order.
+				planRow(runA, 1, "plan"),
+				planRow(runB, 2, "plan"),
+				planRow(runB, 9, "plan_revising"), // runB's latest ⇒ revising
+				planRow(runA, 4, "plan_revising"),
+				planRow(runA, 8, "plan"), // runA's latest ⇒ not revising
+			},
+			want: map[uuid.UUID]bool{runB: true},
+		},
+		{
+			name: "out-of-order rows for one run, plan_revising wins on max seq",
+			rows: []store.ListPlanRevisionStateForRunsRow{
+				planRow(runA, 10, "plan_revising"),
+				planRow(runA, 2, "plan"),
+			},
+			want: map[uuid.UUID]bool{runA: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planRevisingSet(tt.rows)
+			if len(got) != len(tt.want) {
+				t.Fatalf("set size = %d %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for id, wantTrue := range tt.want {
+				if got[id] != wantTrue {
+					t.Errorf("run %s: got %v, want %v", id, got[id], wantTrue)
+				}
+			}
+			// A revising run must be present with value true; a non-revising run must be
+			// absent (so the caller's m[id] yields false), never present with false.
+			for id, v := range got {
+				if !v {
+					t.Errorf("run %s stored with value false; non-revising runs must be absent", id)
+				}
+			}
+		})
+	}
+}

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -403,6 +403,9 @@ type Store interface {
 	// /runs judge badge (PRD #98 M4): per-recommendation triage facts for the runs on one
 	// page, bucketed in Go by the shared BucketOf — never counted in SQL.
 	ListJudgeTriageRowsForRuns(ctx context.Context, arg store.ListJudgeTriageRowsForRunsParams) ([]store.ListJudgeTriageRowsForRunsRow, error)
+	// /runs + board plan-revise flag (issue #750): the plan-ish message rows for a page of
+	// runs, folded into the is_revising set in Go by planRevisingSet — never in SQL.
+	ListPlanRevisionStateForRuns(ctx context.Context, runIds []uuid.UUID) ([]store.ListPlanRevisionStateForRunsRow, error)
 	ListOwnedRecommendationsForCoords(ctx context.Context, arg store.ListOwnedRecommendationsForCoordsParams) ([]store.ListOwnedRecommendationsForCoordsRow, error)
 	// The fan-out write itself: ONE multi-row upsert over the RESOLVED coordinates, so a
 	// bulk call is a single round-trip that cannot half-apply (PRD #98 M2, audit NB-A).

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -375,6 +375,12 @@ export const RUN_STATUS_TONES: Record<
   // just pre-approval. StatusPill's default label `status.replace(/_/g," ")` already
   // yields "planning", so no RUN_STATUS_LABELS entry is needed.
   planning: { tone: "plan", pulse: true },
+  // issue #750: the plan-revise phase, a derived effective status (not a real runs.status
+  // value). Calm `info` tone (NOT the awaiting warn — the run is re-planning, not waiting
+  // on the human right now), pulsing like `planning` since it IS live work. StatusPill's
+  // default label `status.replace(/_/g," ")` already yields "revising", so no
+  // RUN_STATUS_LABELS entry is needed. Kept in step with runStatusTone (agreement test).
+  revising: { tone: "info", pulse: true },
   awaiting_approval: { tone: "warning", pulse: true },
   // PRD #88: parked on a clarification question. Deliberately IDENTICAL to
   // awaiting_approval — same shape of debt (a human owes the run an action while a

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -549,6 +549,13 @@ export interface LatestRun {
   // predates the field omits the key, and an absent value reads as not-planning
   // (isPlanningRun requires `=== true`). Derived, not a real runs.status value.
   is_planning?: boolean;
+  // issue #750: server-computed plan-revise display flag (true while the run's latest
+  // {plan, plan_revising} message is a plan_revising — a "revise" replan in flight). The
+  // server does NOT status-gate it, so the client combines it with status
+  // (isRevisingRun requires status === "awaiting_approval" AND `=== true`). OPTIONAL for
+  // the SAME rollout skew as is_planning: a pre-feature api pod omits the key, and an
+  // absent value reads as not-revising. Derived, not a real runs.status value.
+  is_revising?: boolean;
   // Run-health flag (PRD #47). health + health_since are non-sensitive (like
   // stop_kind) and always present. health_reason can name owner state ("your vault
   // is locked"), so the server sends it only to the run's owner (is_mine); a
@@ -1860,6 +1867,15 @@ export interface RunListItem extends Run {
    *  appends it only when > 0. */
   judge_verdict: JudgeVerdict | null;
   judge_todo_count: number;
+
+  /** issue #750: server-computed plan-revise display flag on the LIST row (it rides
+   *  RunListItemDTO, deliberately NOT RunDTO — the detail page keeps its own
+   *  derivePlanRevision panel). True while the run's latest {plan, plan_revising} message
+   *  is a plan_revising — a "revise" replan in flight. The server does NOT status-gate
+   *  it, so a client combines it with status (isRevisingRun requires status ===
+   *  "awaiting_approval" AND `=== true`). OPTIONAL for rollout skew: a pre-feature api
+   *  pod omits the key, and an absent value reads as not-revising. */
+  is_revising?: boolean;
 
   repo_path: string;
   worker_name: string | null;

--- a/web/src/lib/favicon.test.ts
+++ b/web/src/lib/favicon.test.ts
@@ -2,9 +2,18 @@ import { describe, it, expect } from "vitest";
 import { deriveFaviconState, failedRunIds, type FaviconRun } from "./favicon";
 import type { StopKind } from "./api";
 
-// run builds a minimal FaviconRun (just the id/status/stop_kind the derivation reads).
-function run(status: string, over: { id?: string; stop_kind?: StopKind | null } = {}): FaviconRun {
-  return { id: over.id ?? `run-${status}`, status, stop_kind: over.stop_kind ?? null };
+// run builds a minimal FaviconRun (just the id/status/stop_kind/is_revising the
+// derivation reads).
+function run(
+  status: string,
+  over: { id?: string; stop_kind?: StopKind | null; is_revising?: boolean } = {},
+): FaviconRun {
+  return {
+    id: over.id ?? `run-${status}`,
+    status,
+    stop_kind: over.stop_kind ?? null,
+    is_revising: over.is_revising,
+  };
 }
 
 const NONE = new Set<string>(); // empty baseline
@@ -24,6 +33,19 @@ describe("deriveFaviconState — the four states in isolation", () => {
   // out would make the one status designed to be noticed the only one the tab ignores.
   it("attention for a run awaiting the user's ANSWER too", () => {
     expect(deriveFaviconState([run("awaiting_input")], 0, NONE)).toBe("attention");
+  });
+  // issue #750. A run re-planning after a revise keeps status === "awaiting_approval"
+  // server-side, but its is_revising flag flips the EFFECTIVE status to "revising", so it
+  // is NOT the blocker right now and must not light the attention dot — the whole point
+  // of the derived flag is to keep it out of the human-attention grouping while the
+  // planner reworks. With nothing else live it falls through to idle.
+  it("NOT attention for a run re-planning after a revise (idle instead)", () => {
+    expect(deriveFaviconState([run("awaiting_approval", { is_revising: true })], 0, NONE)).toBe("idle");
+  });
+  it("attention returns once the next plan lands (is_revising false)", () => {
+    expect(deriveFaviconState([run("awaiting_approval", { is_revising: false })], 0, NONE)).toBe("attention");
+    // Absent (rollout skew) reads as not-revising, so an ordinary awaiting_approval still lights.
+    expect(deriveFaviconState([run("awaiting_approval")], 0, NONE)).toBe("attention");
   });
   it("running for a run in flight", () => {
     expect(deriveFaviconState([run("running")], 0, NONE)).toBe("running");

--- a/web/src/lib/favicon.ts
+++ b/web/src/lib/favicon.ts
@@ -6,7 +6,7 @@
 // not unit-tested). The favicon is ALWAYS the ember brand mark, theme-independent:
 // a tab has no theme context, so it must read on any browser chrome.
 
-import { isStoppedRun, needsHumanAttention } from "./runBadge";
+import { effectiveRunStatus, isStoppedRun, needsHumanAttention } from "./runBadge";
 import type { StopKind } from "./api";
 
 // FaviconState is the derived tab signal, most-urgent first in the priority ladder.
@@ -15,7 +15,14 @@ export type FaviconState = "failed" | "attention" | "running" | "idle";
 
 // FaviconRun is the minimal run shape the derivation reads — satisfied by
 // RunListItem, so the hook can pass its poll result straight through without a map.
-export type FaviconRun = { id: string; status: string; stop_kind: StopKind | null };
+// is_revising (issue #750) rides along so the attention check can classify from the
+// EFFECTIVE status: a run re-planning after a revise must not light the attention dot.
+export type FaviconRun = {
+  id: string;
+  status: string;
+  stop_kind: StopKind | null;
+  is_revising?: boolean;
+};
 
 // The non-terminal, actively-progressing statuses that make the mark "running".
 const RUNNING_STATUSES = new Set<string>(["queued", "claimed", "running"]);
@@ -52,7 +59,11 @@ export function deriveFaviconState(
   baselineFailedIds: Set<string>,
 ): FaviconState {
   if (runs.some((r) => isFreshFailure(r, baselineFailedIds))) return "failed";
-  if (unread > 0 || runs.some((r) => needsHumanAttention(r.status))) return "attention";
+  // issue #750: classify from the EFFECTIVE status so a run re-planning after a revise
+  // (status still "awaiting_approval" server-side, but effectiveRunStatus → "revising")
+  // does NOT light the attention dot. The failure and running branches are unaffected.
+  if (unread > 0 || runs.some((r) => needsHumanAttention(effectiveRunStatus(r))))
+    return "attention";
   if (runs.some((r) => RUNNING_STATUSES.has(r.status))) return "running";
   return "idle";
 }

--- a/web/src/lib/runBadge.test.ts
+++ b/web/src/lib/runBadge.test.ts
@@ -282,6 +282,45 @@ describe("revising phase (issue #750)", () => {
     });
   });
 
+  it("runBadge: a revising run carrying a health flag still reads 'revising', NOT '⚠ needs approval'", () => {
+    // A run mid-revise keeps raw status `awaiting_approval` (so it stays health-flaggable)
+    // while is_revising is true. If it ALSO carries a non-ok health flag — the sharp case is
+    // `approval_idle`, whose label is literally "needs approval" — the health warn badge would
+    // win the short-circuit before the effective-status switch and put "⚠ needs approval" back
+    // on a card #750 deliberately calmed. Confirm healthBadge WOULD fire on this exact run
+    // (proving the case is real, not vacuous), then that runBadge suppresses it while revising.
+    const r = run({
+      status: "awaiting_approval",
+      is_revising: true,
+      health: "approval_idle",
+      health_since: "2026-07-04T12:03:00Z",
+    });
+    expect(healthBadge(r, NOW)).not.toBeNull(); // would fire without the #750 guard
+    expect(runBadge(r, NOW)).toEqual({
+      kind: "badge",
+      label: "revising",
+      tone: "info",
+      pulse: true,
+    });
+  });
+
+  it("runBadge: a NON-revising awaiting_approval run with the same health flag STILL shows the health warn", () => {
+    // The control: the #750 guard is surgical — it suppresses the health badge only while
+    // revising, never disabling health badges for an ordinary awaiting_approval run.
+    const r = run({
+      status: "awaiting_approval",
+      is_revising: false,
+      health: "approval_idle",
+      health_since: "2026-07-04T12:03:00Z",
+    });
+    expect(runBadge(r, NOW)).toMatchObject({
+      kind: "badge",
+      label: "⚠ needs approval · 1m",
+      tone: "warning",
+      pulse: true,
+    });
+  });
+
   it("runBadge: the SAME run without is_revising still reads as 'awaiting approval'", () => {
     // The revising wiring must not disturb an ordinary awaiting_approval run — is_revising
     // false OR absent both fall through to the existing warn-toned awaiting badge.

--- a/web/src/lib/runBadge.test.ts
+++ b/web/src/lib/runBadge.test.ts
@@ -12,6 +12,7 @@ import {
   isAwaitingInput,
   isHealthFlaggableStatus,
   isPlanningRun,
+  isRevisingRun,
   isStoppedRun,
   milestoneBadge,
   milestoneBadgeText,
@@ -228,6 +229,83 @@ describe("planning phase (issue #321)", () => {
 
   it("runStatusTone maps the effective 'planning' status to the indigo plan tone", () => {
     expect(runStatusTone("planning", null)).toBe("plan");
+  });
+});
+
+// issue #750. A run re-planning after a revise keeps status === "awaiting_approval"
+// server-side, but its derived is_revising flag flips it to the "revising" effective
+// status so it drops out of the human-attention grouping while the planner reworks the
+// plan. The web TRUSTS the server's is_revising boolean but — because the server does NOT
+// status-gate it — combines it with status (isRevisingRun requires awaiting_approval),
+// exactly mirroring isPlanningRun's running-guard. These pin that combination.
+describe("revising phase (issue #750)", () => {
+  it("isRevisingRun: awaiting_approval + is_revising true ⇒ revising", () => {
+    expect(isRevisingRun({ status: "awaiting_approval", is_revising: true })).toBe(true);
+  });
+
+  it("isRevisingRun: is_revising true but NOT awaiting_approval ⇒ NOT revising", () => {
+    // The server flag is not status-gated, so it can linger on a run whose status has
+    // moved. A terminal/other status must never read as revising on the strength of it.
+    expect(isRevisingRun({ status: "completed", is_revising: true })).toBe(false);
+    expect(isRevisingRun({ status: "running", is_revising: true })).toBe(false);
+    expect(isRevisingRun({ status: "failed", is_revising: true })).toBe(false);
+  });
+
+  it("isRevisingRun: awaiting_approval but is_revising false/absent ⇒ NOT revising", () => {
+    expect(isRevisingRun({ status: "awaiting_approval", is_revising: false })).toBe(false);
+    // Absent (rollout skew) reads as not-revising — the `=== true` guard.
+    expect(isRevisingRun({ status: "awaiting_approval" })).toBe(false);
+  });
+
+  it("effectiveRunStatus: 'revising' while revising, else the raw status", () => {
+    expect(effectiveRunStatus({ status: "awaiting_approval", is_revising: true })).toBe("revising");
+    // is_revising true but not awaiting_approval → its raw status, never "revising".
+    expect(effectiveRunStatus({ status: "completed", is_revising: true })).toBe("completed");
+    // A plain awaiting_approval run (no revise in flight) stays awaiting_approval.
+    expect(effectiveRunStatus({ status: "awaiting_approval", is_revising: false })).toBe("awaiting_approval");
+    expect(effectiveRunStatus({ status: "awaiting_approval" })).toBe("awaiting_approval");
+  });
+
+  it("planning and revising are mutually exclusive (distinct status guards)", () => {
+    // is_planning is only meaningful while running; is_revising only while
+    // awaiting_approval. A run cannot be both, so effectiveRunStatus never has to choose.
+    expect(effectiveRunStatus({ status: "running", is_planning: true, is_revising: true })).toBe("planning");
+    expect(effectiveRunStatus({ status: "awaiting_approval", is_planning: true, is_revising: true })).toBe("revising");
+  });
+
+  it("runBadge: a revising run → pulsing info 'revising' badge (not the awaiting warn)", () => {
+    expect(runBadge(run({ status: "awaiting_approval", is_revising: true }), NOW)).toEqual({
+      kind: "badge",
+      label: "revising",
+      tone: "info",
+      pulse: true,
+    });
+  });
+
+  it("runBadge: the SAME run without is_revising still reads as 'awaiting approval'", () => {
+    // The revising wiring must not disturb an ordinary awaiting_approval run — is_revising
+    // false OR absent both fall through to the existing warn-toned awaiting badge.
+    const off = runBadge(run({ status: "awaiting_approval", is_revising: false }), NOW);
+    expect(off).toMatchObject({ kind: "badge", label: "awaiting approval", tone: "warning" });
+    const absent = runBadge(run({ status: "awaiting_approval" }), NOW);
+    expect(absent).toMatchObject({ kind: "badge", label: "awaiting approval", tone: "warning" });
+  });
+
+  it("runStatusTone maps the effective 'revising' status to the calm info tone", () => {
+    expect(runStatusTone("revising", null)).toBe("info");
+  });
+
+  it("a revising run is NOT in the human-attention grouping (via effective status)", () => {
+    // The board strip, card ring and favicon dot all classify from effectiveRunStatus.
+    // isAwaitingApproval / needsHumanAttention on the EFFECTIVE status is what drops a
+    // revising run out — the raw status would still read awaiting_approval.
+    const revising = { status: "awaiting_approval", is_revising: true };
+    expect(isAwaitingApproval(effectiveRunStatus(revising))).toBe(false);
+    expect(needsHumanAttention(effectiveRunStatus(revising))).toBe(false);
+    // Once the next plan lands (is_revising false), it returns to the grouping.
+    const approved = { status: "awaiting_approval", is_revising: false };
+    expect(isAwaitingApproval(effectiveRunStatus(approved))).toBe(true);
+    expect(needsHumanAttention(effectiveRunStatus(approved))).toBe(true);
   });
 });
 

--- a/web/src/lib/runBadge.ts
+++ b/web/src/lib/runBadge.ts
@@ -372,11 +372,23 @@ export function runBadge(run: LatestRun, nowMs: number): RunBadge {
   if (isStoppedRun(run.status, run.stop_kind)) {
     return { kind: "badge", label: "stopped", tone: "neutral", pulse: false };
   }
+  const eff = effectiveRunStatus(run);
   // A health flag overrides the normal status label while the run is alive but looks
   // slow/stuck/looping (PRD #47). Only ever fires for a flaggable status.
+  //
+  // issue #750: EXCEPT while a run is revising. A run re-planning after a revise keeps
+  // raw status `awaiting_approval` (so it is still health-flaggable) even though
+  // is_revising is true — and the sharp flag is `approval_idle`, whose label is literally
+  // "needs approval". Letting that warn badge win would put "⚠ needs approval" back on a
+  // card that #750 deliberately calmed: the attention strip, card ring, and favicon all
+  // drop a revising run (it needs no human action during the ~90s replan), so the badge
+  // must not shout for approval either. Suppress ALL health flags while revising — the
+  // calm "revising" info badge is the more informative live-state, matching the strip/
+  // ring/favicon dropping the run entirely. Non-revising runs are byte-identical (the
+  // `eff !== "revising"` guard is a no-op unless the run is revising).
   const flagged = healthBadge(run, nowMs);
-  if (flagged) return flagged;
-  switch (effectiveRunStatus(run)) {
+  if (flagged && eff !== "revising") return flagged;
+  switch (eff) {
     case "queued":
       return { kind: "badge", label: "queued", tone: "queue", pulse: false };
     case "claimed":

--- a/web/src/lib/runBadge.ts
+++ b/web/src/lib/runBadge.ts
@@ -125,12 +125,31 @@ export function isPlanningRun(run: { status: string; is_planning?: boolean }): b
   return run.status === "running" && run.is_planning === true;
 }
 
+// isRevisingRun reports whether a run is actively RE-PLANNING after a revise (issue
+// #750). It trusts the server-computed is_revising boolean but only treats it as
+// revising while the run is still `awaiting_approval` — mirroring isPlanningRun's
+// status guard. This gate is load-bearing: the server flag is NOT status-gated (it can
+// linger on a run whose status has since moved), so combining it with the status is what
+// keeps a revising run out of the human-attention grouping while it re-plans, and returns
+// it to needs-approval the moment the next `plan` lands (is_revising flips false
+// server-side). An absent value — rollout skew — reads as not-revising (`=== true`).
+export function isRevisingRun(run: { status: string; is_revising?: boolean }): boolean {
+  return run.status === "awaiting_approval" && run.is_revising === true;
+}
+
 // effectiveRunStatus is the status a run should RENDER as: "planning" while it is in
-// its planning phase, else its raw status. This is the single seam every status
-// surface flows through so the planning phase renders consistently (board card,
-// StatusPill, list rows, issue-view history) without any surface re-deriving.
-export function effectiveRunStatus(run: { status: string; is_planning?: boolean }): string {
-  return isPlanningRun(run) ? "planning" : run.status;
+// its planning phase, "revising" while it is re-planning after a revise, else its raw
+// status. This is the single seam every status surface flows through so the planning and
+// revising phases render consistently (board card, StatusPill, list rows, issue-view
+// history) without any surface re-deriving. planning is status=running and revising is
+// status=awaiting_approval, so the two are mutually exclusive — order does not matter,
+// but each is checked explicitly against its own guard.
+export function effectiveRunStatus(
+  run: { status: string; is_planning?: boolean; is_revising?: boolean },
+): string {
+  if (isPlanningRun(run)) return "planning";
+  if (isRevisingRun(run)) return "revising";
+  return run.status;
 }
 
 // priorityBadge is the pure class→pill map for a run's queue priority (PRD #320 D8),
@@ -188,6 +207,10 @@ export function runStatusTone(
   stopKind: StopKind | null | undefined,
 ): BadgeTone {
   if (status === "planning") return "plan";
+  // issue #750: a run re-planning after a revise. Calm INFO tone (like claimed/running
+  // and the run-view VersionChip's parked state), deliberately NOT the awaiting warn:
+  // the run is not waiting on the human right now, the planner is reworking the plan.
+  if (status === "revising") return "info";
   if (status === "awaiting_approval" || status === "awaiting_input")
     return "warning";
   // PRD #517: an interactive run parked awaiting the owner's next follow-up.
@@ -363,6 +386,14 @@ export function runBadge(run: LatestRun, nowMs: number): RunBadge {
     // just pre-approval — in the indigo `plan` tone.
     case "planning":
       return { kind: "badge", label: "planning", tone: "plan", pulse: true };
+    // issue #750: a run re-planning after a revise, derived by effectiveRunStatus from
+    // the server's is_revising flag (gated on status === awaiting_approval). Calm info
+    // tone — matching the run-view VersionChip's parked/revising visual language — and
+    // pulsing like `planning` because it IS live work (the planner is reworking). This
+    // drops the run out of the awaiting-approval warn treatment while it re-plans; the
+    // next `plan` flips is_revising false server-side and it returns to awaiting_approval.
+    case "revising":
+      return { kind: "badge", label: "revising", tone: "info", pulse: true };
     case "running":
       // The running elapsed moved OUT of the badge to the uniform per-card duration
       // token (issue #256 M4, Decision 4) — the board now renders `running <elapsed>`

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -212,6 +212,11 @@ const CARD_MIRRORED_FIELDS = [
 const CARD_OWN_FIELDS = [
   "id",
   "updated_at",
+  // issue #750: is_revising is a board/list projection the server computes (it rides the
+  // card DTO and RunListItemDTO, NOT RunDTO — see api.ts), so it is deliberately absent
+  // from the Run patch type and a run patch must never write it. It lives on the OWN side
+  // of the partition, unlike is_planning (which IS on Run and so is mirrored).
+  "is_revising",
   "owner_name",
   "worker_name",
   "is_mine",

--- a/web/src/pages/Board.test.tsx
+++ b/web/src/pages/Board.test.tsx
@@ -1533,7 +1533,13 @@ describe("Board attention strip — a run appears in exactly one bucket (#182)",
 
   // Only the four fields the strip's predicates read. RunListItem extends Run and
   // carries ~30 more that no code path here touches.
-  const aRun = (over: { id: string; status: string; health: string; issue_iid: number }) =>
+  const aRun = (over: {
+    id: string;
+    status: string;
+    health: string;
+    issue_iid: number;
+    is_revising?: boolean;
+  }) =>
     // Issue #485 review FIX 2: the strip's overlay <Link> is now named by the run title
     // as well, so the fixture must carry an issue_title the way the real RunListItem does
     // (RunListItem.issue_title is a non-optional string; this cast used to omit it because
@@ -1645,6 +1651,32 @@ describe("Board attention strip — a run appears in exactly one bucket (#182)",
     renderBoard();
     await screen.findByText("1 run awaiting follow-up");
     expect(strip().textContent).toBe("1 run awaiting follow-up");
+    expect(screen.getAllByRole("link", { name: "Open run for issue #7: Fix the parser" })).toHaveLength(1);
+  });
+
+  it("drops a REVISING run out of the attention strip, then returns it (issue #750)", async () => {
+    // A run re-planning after a revise keeps status === "awaiting_approval" server-side,
+    // but its derived is_revising flag flips the EFFECTIVE status to "revising", so the
+    // strip's isAwaitingApproval(effectiveRunStatus(r)) predicate excludes it. With
+    // nothing else parked, the whole strip is absent.
+    mockApi.listRuns.mockResolvedValue({
+      runs: [aRun({ id: "run-5", status: "awaiting_approval", health: "ok", issue_iid: 7, is_revising: true })],
+    });
+    const view = renderBoard();
+    // The board card for issue #7 renders (the fixture card), so wait on it rather than the strip.
+    await screen.findByText("#7");
+    expect(
+      screen.queryByText(/needs approval|needs an answer|awaiting follow-up|looks? stuck|look stuck/),
+    ).toBeNull();
+    expect(screen.queryByRole("link", { name: "Open run for issue #7: Fix the parser" })).toBeNull();
+
+    // Once the next plan lands (is_revising false), the SAME run returns to needs-approval.
+    view.unmount();
+    mockApi.listRuns.mockResolvedValue({
+      runs: [aRun({ id: "run-5", status: "awaiting_approval", health: "ok", issue_iid: 7, is_revising: false })],
+    });
+    renderBoard();
+    await screen.findByText("1 run needs approval");
     expect(screen.getAllByRole("link", { name: "Open run for issue #7: Fix the parser" })).toHaveLength(1);
   });
 

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -22,6 +22,7 @@ import { hasAnthropicToken } from "../lib/hasToken";
 import { startRunGate, type StartRunGate } from "../lib/runStream";
 import {
   canOpenRunView,
+  effectiveRunStatus,
   hasActiveRun,
   isAwaitingApproval,
   isAwaitingFollowup,
@@ -518,7 +519,12 @@ export function Board() {
       ]);
       setHasWorker(workers.length > 0);
       setHasToken(hasAnthropicToken(secrets));
-      setAwaitingRuns(runs.filter((r) => isAwaitingApproval(r.status)));
+      // issue #750: classify from the EFFECTIVE status, not the raw one. A run
+      // re-planning after a revise keeps status === "awaiting_approval" server-side, but
+      // effectiveRunStatus returns "revising" for it (is_revising true), so
+      // isAwaitingApproval reads false and it drops out of the attention strip. The next
+      // `plan` flips is_revising false server-side and it returns to this bucket.
+      setAwaitingRuns(runs.filter((r) => isAwaitingApproval(effectiveRunStatus(r))));
       setQuestionRuns(runs.filter((r) => isAwaitingInput(r.status)));
       setFollowupRuns(runs.filter((r) => isAwaitingFollowup(r.status)));
       setStuckRuns(
@@ -1804,7 +1810,11 @@ export function IssueCard({
   // PRD #88 D-O #4 puts awaiting_input on exactly this treatment — same debt, and the
   // PRD's own framing is that it is the third human-in-the-loop channel. The ring is
   // presentation, so the two share it; the STRIP above still names them separately.
-  const loud = needsHumanAttention(run?.status ?? "");
+  // issue #750: feed the EFFECTIVE status so a run re-planning after a revise loses the
+  // loud attention ring. Such a run keeps status === "awaiting_approval" server-side, but
+  // effectiveRunStatus returns "revising" for it, so needsHumanAttention reads false. Its
+  // badge (runBadge → effectiveRunStatus) already reads "revising" in the calm info tone.
+  const loud = needsHumanAttention(effectiveRunStatus(run ?? { status: "" }));
   // The MR/PR link (PRD #65 D8): prefer the forge-supplied URL the worker persisted
   // (the only correct link on Forgejo), guarded through isHttpsUrl by preferForgeUrl
   // before it becomes an anchor. A null (rows created before it landed — all GitLab)


### PR DESCRIPTION
Implements issue #750.

Closes #750

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-750`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct **“revising”** status for runs undergoing plan changes.
  * Revising runs now display a pulsing informational badge and indigo status styling.
  * Board and approval views exclude revising runs from human-attention indicators until revision is complete.
  * Favicon notifications no longer flag runs currently being revised.

* **Bug Fixes**
  * Preserved accurate approval and attention behavior when revision activity starts or ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->