### PR TITLE
chore(uzi-watcher): worker-PVC backup scripts for in-flight runs

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -233,8 +233,11 @@ caught too, not just the checkpointed tracking ref):
   session-independent safety net; it is NOT a substitute for the pollers — keep those too.
 
 To recover from a snapshot: `tar xzf <ts>/issue-N.tgz -C r/`, then
-`git fetch r/issue-N.bundle 'agent/issue-N:refs/heads/recover/issue-N'`, worktree it,
-`git apply r/issue-N.uncommitted.patch` if present, `git rebase origin/main`, then gate +
+`git fetch r/issue-N.bundle 'agent/issue-N:refs/heads/recover/issue-N'` and
+`git worktree add DIR recover/issue-N`. In `DIR`, restore the uncommitted state the
+tracking ref never held: `git apply r/issue-N.uncommitted.patch` if that file is present,
+**and `tar xzf r/issue-N.untracked.tar.gz -C DIR` if that one is** (it carries new,
+not-yet-added files, which the patch does not). Then `git rebase origin/main` and gate +
 PR + admin-merge as above.
 
 ## Reviewing the diff

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -208,6 +208,35 @@ The remote `refs/uzi-checkpoints/agent/issue-N` ref is the other recovery source
 behind-on-workflows run leaves none (its checkpoint push hit the same rejection). The PVC
 tracking ref is the reliable source.
 
+### Proactive backups (before anything goes wrong)
+
+The recovery above is reactive — after a push rejection or a lost run. When you are
+driving runs through a shaky window (a rate-limited Anthropic token that keeps parking at
+`limit_wait`, an edge-case being hardened, anything where a resume might not come back
+cleanly), snapshot the in-flight work on a timer so a fallback always exists. Two bundled
+scripts do this, capturing from the **live runner working clone** (so uncommitted work is
+caught too, not just the checkpointed tracking ref):
+
+- **`scripts/backup-runs.sh <RUN_ID>...`** — one snapshot per run into
+  `$UZI_BACKUP_DIR` (default `/tmp/uzi-backups/<ts>/`): `issue-N.tgz` (git **bundle** of
+  commits not on `origin/main` + `uncommitted.patch` + `untracked.tar.gz` + `meta.txt`),
+  plus a self-describing status set (`run.json`, `plan.md`, `progress.txt` with milestones
+  DONE vs LEFT, `log-tail.ndjson`). It resolves worker→pod FRESH each call, so it follows a
+  worker roll or a cross-worker migration. Deployment coordinates come from env
+  (`UZI_CTX`, `UZI_WORKER_NS`, `UZI_REPO_SLUG` — the last derived from `origin` if unset),
+  never hard-coded.
+- **`scripts/backup-loop.sh <RUN_ID>...`** — runs `backup-runs.sh` every
+  `UZI_BACKUP_INTERVAL` (default 900s), **detached** so it outlives the session (`setsid`
+  on Linux, a `( nohup … & )` subshell on macOS). It self-terminates when every run is
+  terminal, after `UZI_BACKUP_MAX_HOURS` (default 12), or on `touch $UZI_BACKUP_DIR/STOP`.
+  It rides through `limit_wait` (keeps snapshotting while a run is parked). This is a
+  session-independent safety net; it is NOT a substitute for the pollers — keep those too.
+
+To recover from a snapshot: `tar xzf <ts>/issue-N.tgz -C r/`, then
+`git fetch r/issue-N.bundle 'agent/issue-N:refs/heads/recover/issue-N'`, worktree it,
+`git apply r/issue-N.uncommitted.patch` if present, `git rebase origin/main`, then gate +
+PR + admin-merge as above.
+
 ## Reviewing the diff
 
 The watcher's merge-gate review is a **third** pass, not a first: uzi already ran its own
@@ -463,7 +492,8 @@ die with its session. When you close, hand any still-in-flight run ids on the sa
 ## Keep this skill (and its scripts) current
 
 This skill and its `scripts/` (`watch-run.sh` for uzi runs, `watch-ci.sh` for GitHub
-Actions, `pr-findings.sh` to gather CodeRabbit findings across PRs) are living documents —
+Actions, `pr-findings.sh` to gather CodeRabbit findings across PRs, `backup-runs.sh` /
+`backup-loop.sh` to snapshot in-flight run work from worker PVCs) are living documents —
 **update them in the same session you find them wanting.**
 When a run surprises you with a new failure mode, a plan trap this list does not name,
 changed merge/ruleset behaviour, a CLI verb that moved, or a poller needs a new

--- a/.claude/skills/uzi-watcher/scripts/backup-loop.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-loop.sh
@@ -30,6 +30,14 @@ if [ "$#" -eq 0 ]; then
 fi
 RUNS=("$@")
 
+# Reject a nonpositive/non-integer interval or window: sleep 0 would spin the
+# loop with no delay and flood the uzi + k8s APIs until MAX_HOURS.
+for pair in "INTERVAL:$INTERVAL" "MAX_HOURS:$MAX_HOURS"; do
+  name="${pair%%:*}"; val="${pair#*:}"
+  case "$val" in ''|*[!0-9]*) echo "error: UZI_BACKUP_$name must be a positive integer (got '$val')" >&2; exit 2;; esac
+  [ "$val" -ge 1 ] || { echo "error: UZI_BACKUP_$name must be >= 1 (got '$val')" >&2; exit 2; }
+done
+
 mkdir -p "$ROOT"
 echo "$$" > "$ROOT/backup-loop.pid"
 END=$(( $(date +%s) + MAX_HOURS * 3600 ))

--- a/.claude/skills/uzi-watcher/scripts/backup-loop.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-loop.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Detached backup loop: runs backup-runs.sh every INTERVAL seconds for the given
+# run ids, independent of any Claude/terminal session. Self-terminates when every
+# target run is terminal, when MAX_HOURS elapses, or when a STOP file appears.
+#
+# Launch it DETACHED so it outlives the launching shell:
+#   Linux:  setsid bash backup-loop.sh <RUN_ID>... </dev/null >>/tmp/uzi-backups/loop.log 2>&1 &
+#   macOS:  ( nohup bash backup-loop.sh <RUN_ID>... </dev/null >>/tmp/uzi-backups/loop.log 2>&1 & )
+#           (no setsid on macOS; the subshell double-fork orphans it to init)
+#
+# Stop it:  touch "$UZI_BACKUP_DIR/STOP"   (default /tmp/uzi-backups/STOP)
+#     or:   kill "$(cat "$UZI_BACKUP_DIR/backup-loop.pid")"
+#
+# Env: UZI_BACKUP_INTERVAL (default 900s), UZI_BACKUP_MAX_HOURS (default 12),
+#      UZI_BACKUP_DIR (default /tmp/uzi-backups), UZI_BIN (uzi path).
+#      All backup-runs.sh env vars (UZI_CTX, UZI_WORKER_NS, UZI_REPO_SLUG, ...)
+#      are inherited and honored.
+set -u
+export PATH="${PATH:-/usr/local/bin:/usr/bin:/bin}"
+UZI="${UZI_BIN:-uzi}"
+ROOT="${UZI_BACKUP_DIR:-/tmp/uzi-backups}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNS_SCRIPT="$HERE/backup-runs.sh"
+INTERVAL="${UZI_BACKUP_INTERVAL:-900}"
+MAX_HOURS="${UZI_BACKUP_MAX_HOURS:-12}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: backup-loop.sh <RUN_ID> [RUN_ID ...]" >&2
+  exit 2
+fi
+RUNS=("$@")
+
+mkdir -p "$ROOT"
+echo "$$" > "$ROOT/backup-loop.pid"
+END=$(( $(date +%s) + MAX_HOURS * 3600 ))
+
+llog(){ printf '%s [loop] %s\n' "$(date -u +%FT%TZ)" "$*"; }
+llog "started pid=$$ interval=${INTERVAL}s max=${MAX_HOURS}h runs=${RUNS[*]}"
+
+while :; do
+  [ -e "$ROOT/STOP" ] && { llog "STOP file present; exiting"; break; }
+  bash "$RUNS_SCRIPT" "${RUNS[@]}"
+
+  # exit once every run is definitively terminal (empty status = keep going)
+  active=0
+  for RID in "${RUNS[@]}"; do
+    s="$("$UZI" run get "$RID" --field status 2>/dev/null)"
+    case "$s" in
+      completed|failed|cancelled) ;;
+      *) active=1 ;;
+    esac
+  done
+  [ "$active" -eq 0 ] && { llog "all runs terminal; exiting"; break; }
+  [ "$(date +%s)" -ge "$END" ] && { llog "max runtime reached; exiting"; break; }
+
+  llog "sleep ${INTERVAL}s"
+  sleep "$INTERVAL"
+done
+rm -f "$ROOT/backup-loop.pid"
+llog "loop ended"

--- a/.claude/skills/uzi-watcher/scripts/backup-loop.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-loop.sh
@@ -35,8 +35,11 @@ RUNS=("$@")
 for pair in "INTERVAL:$INTERVAL" "MAX_HOURS:$MAX_HOURS"; do
   name="${pair%%:*}"; val="${pair#*:}"
   case "$val" in ''|*[!0-9]*) echo "error: UZI_BACKUP_$name must be a positive integer (got '$val')" >&2; exit 2;; esac
-  [ "$val" -ge 1 ] || { echo "error: UZI_BACKUP_$name must be >= 1 (got '$val')" >&2; exit 2; }
+  # 10# forces base-10 so a leading-zero value (e.g. 08, 09) is not read as
+  # invalid octal here or in the arithmetic below.
+  [ "$((10#$val))" -ge 1 ] || { echo "error: UZI_BACKUP_$name must be >= 1 (got '$val')" >&2; exit 2; }
 done
+INTERVAL=$((10#$INTERVAL)); MAX_HOURS=$((10#$MAX_HOURS))
 
 mkdir -p "$ROOT"
 echo "$$" > "$ROOT/backup-loop.pid"

--- a/.claude/skills/uzi-watcher/scripts/backup-runs.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-runs.sh
@@ -59,6 +59,9 @@ fi
 RUNS=("$@")
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 DEST="$OUTROOT/$TS"
+# Backups hold unpushed repo work + run transcripts; keep them owner-only (0700
+# dirs / 0600 files) rather than inheriting a lax 022 umask on a shared host.
+umask 077
 mkdir -p "$DEST"
 LOG="$DEST/backup.log"
 log(){ printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*" | tee -a "$LOG"; }
@@ -160,7 +163,14 @@ for RID in "${RUNS[@]}"; do
   f="$DEST/issue-$iid.tgz"
   if "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$iid" > "$f" 2>>"$LOG"; then
     if [ -s "$f" ]; then
-      log "OK   $RID (#$iid) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
+      # A nonempty archive is not enough: the git bundle carries the committed
+      # work, so if it is missing, say so (PARTIAL) rather than logging OK. The
+      # snapshot is still kept — its patch/untracked/status remain useful.
+      if tar tzf "$f" 2>/dev/null | grep -qF "issue-$iid.bundle"; then
+        log "OK   $RID (#$iid) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
+      else
+        log "PART $RID (#$iid): snapshot saved WITHOUT a git bundle (uncommitted/status only) -> $f; see $LOG"
+      fi
     else
       log "FAIL $RID (#$iid): empty artifact (clone missing?); see $LOG"
       rm -f "$f"

--- a/.claude/skills/uzi-watcher/scripts/backup-runs.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-runs.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# One-shot backup of in-flight uzi run work from hosted (k8s) worker PVCs.
+#
+# For each run id it resolves worker_id -> pod FRESH each call (so it survives a
+# worker roll or a cross-worker migration), execs into the worker container, and
+# captures from the live runner working clone /data/runner/<slug>/issue-N:
+#   issue-N.tgz               a tarball of:
+#     issue-N.bundle            git bundle of the branch (commits not on origin/main)
+#     issue-N.uncommitted.patch git diff HEAD  (staged+unstaged tracked changes)
+#     issue-N.untracked.tar.gz  new, non-ignored untracked files
+#     issue-N.meta.txt          HEAD sha, branch, new-commit log, status, diffstat
+#   issue-N.run.json          full `uzi run get --json`
+#   issue-N.plan.md           the latest approved plan (milestone breakdown)
+#   issue-N.progress.txt      status/health/token + milestones DONE vs LEFT
+#   issue-N.log-tail.ndjson   last 80 transcript messages
+# Together these fully reconstruct a worker's working tree + run state locally, so
+# work is recoverable even if the run is lost before it pushes an MR. See this
+# skill's "Recovering a failed run's work from the worker PVC" section.
+#
+# Usage:  bash backup-runs.sh <RUN_ID> [RUN_ID ...]
+# Env (all optional except where noted):
+#   UZI_CTX         kube context (default: current `kubectl config current-context`)
+#   UZI_WORKER_NS   space-separated worker namespaces to search
+#                   (default: "uzi-workers uzi-workers-docker")
+#   UZI_REPO_SLUG   worker bare/clone dir stem host+org+repo
+#                   (default: derived from this checkout's origin remote)
+#   UZI_BACKUP_DIR  output root (default: /tmp/uzi-backups)
+#   UZI_KUBECTL / UZI_BIN / UZI_JQ   tool overrides (default: from PATH)
+set -u
+
+KUBECTL="${UZI_KUBECTL:-kubectl}"
+UZI="${UZI_BIN:-uzi}"
+JQ="${UZI_JQ:-jq}"
+
+CTX="${UZI_CTX:-$("$KUBECTL" config current-context 2>/dev/null)}"
+NAMESPACES="${UZI_WORKER_NS:-uzi-workers uzi-workers-docker}"
+OUTROOT="${UZI_BACKUP_DIR:-/tmp/uzi-backups}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: backup-runs.sh <RUN_ID> [RUN_ID ...]" >&2
+  exit 2
+fi
+if [ -z "$CTX" ]; then
+  echo "error: no kube context (set UZI_CTX or a current-context)" >&2
+  exit 2
+fi
+
+# Worker dir stem, e.g. github.com+org+repo. Derive from origin unless overridden.
+REPO_SLUG="${UZI_REPO_SLUG:-}"
+if [ -z "$REPO_SLUG" ]; then
+  origin="$(git remote get-url origin 2>/dev/null || true)"
+  REPO_SLUG="$(printf '%s' "$origin" | sed -E 's#^[a-z]+://##; s#^[^@]+@##; s#\.git$##; s#[:/]#+#g')"
+fi
+if [ -z "$REPO_SLUG" ]; then
+  echo "error: could not derive UZI_REPO_SLUG (not in a checkout? set it explicitly)" >&2
+  exit 2
+fi
+
+RUNS=("$@")
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+DEST="$OUTROOT/$TS"
+mkdir -p "$DEST"
+LOG="$DEST/backup.log"
+log(){ printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*" | tee -a "$LOG"; }
+
+# --- on-pod capture: emits a tar.gz of the artifacts on stdout, noise on stderr.
+# This string runs REMOTELY (`sh -c` in the worker pod); only $REPO_SLUG is
+# spliced in here at build time, every other $VAR expands pod-side on purpose.
+# shellcheck disable=SC2016
+CAPTURE='
+set -u
+N="$1"
+CLONE="/data/runner/'"$REPO_SLUG"'/issue-$N"
+[ -d "$CLONE/.git" ] || { echo "NO_CLONE $CLONE" >&2; exit 3; }
+cd "$CLONE" || exit 3
+OUT="$(mktemp -d)"
+BR="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+HEAD="$(git rev-parse HEAD 2>/dev/null)"
+if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+  git bundle create "$OUT/issue-$N.bundle" "$BR" --not origin/main >/dev/null 2>&1 \
+    || git bundle create "$OUT/issue-$N.bundle" "$BR" >/dev/null 2>&1 || :
+else
+  git bundle create "$OUT/issue-$N.bundle" "$BR" >/dev/null 2>&1 || :
+fi
+git diff HEAD > "$OUT/issue-$N.uncommitted.patch" 2>/dev/null || :
+git ls-files --others --exclude-standard -z > "$OUT/.untracked" 2>/dev/null || :
+if [ -s "$OUT/.untracked" ]; then
+  tar --null -T "$OUT/.untracked" -czf "$OUT/issue-$N.untracked.tar.gz" 2>/dev/null || :
+fi
+rm -f "$OUT/.untracked"
+{
+  echo "issue=$N head=$HEAD branch=$BR captured=$(date -u +%FT%TZ)"
+  echo "clone_origin_main=$(git rev-parse origin/main 2>/dev/null)"
+  echo "merge_base=$(git merge-base HEAD origin/main 2>/dev/null)"
+  echo "--- new commits (origin/main..HEAD):"
+  git log --oneline origin/main..HEAD 2>/dev/null
+  echo "--- git status --porcelain:"
+  git status --porcelain 2>/dev/null
+  echo "--- git diff --stat HEAD:"
+  git diff --stat HEAD 2>/dev/null
+} > "$OUT/issue-$N.meta.txt" 2>&1
+tar czf - -C "$OUT" . 2>/dev/null
+rm -rf "$OUT"
+'
+
+resolve_pod(){   # $1=worker_id ; prints "ns pod" if found
+  local wid="$1" ns pod
+  for ns in $NAMESPACES; do
+    pod="$("$KUBECTL" --context "$CTX" -n "$ns" get pods -o name 2>/dev/null \
+           | grep -m1 "uzi-hw-$wid" | sed 's#pod/##')"
+    [ -n "$pod" ] && { printf '%s %s\n' "$ns" "$pod"; return 0; }
+  done
+  return 1
+}
+
+for RID in "${RUNS[@]}"; do
+  J="$("$UZI" run get "$RID" --json 2>/dev/null)"
+  st="$(printf '%s' "$J" | "$JQ" -r '.status // ""' 2>/dev/null)"
+  if [ -z "${st:-}" ]; then
+    log "WARN $RID: status unreadable (CLI/API); skipping this cycle"
+    continue
+  fi
+  iid="$(printf '%s' "$J" | "$JQ" -r '.issue_iid // .issue // ""' 2>/dev/null)"
+  wid="$(printf '%s' "$J" | "$JQ" -r '.worker_id // ""' 2>/dev/null)"
+  mr="$(printf '%s' "$J" | "$JQ" -r '.mr_web_url // ""' 2>/dev/null)"
+
+  # --- status/progress snapshot (ALWAYS, even if parked or terminal: what was
+  #     done, what is left, so a backup is self-describing without the code) ---
+  printf '%s' "$J" | "$JQ" . > "$DEST/issue-$iid.run.json" 2>/dev/null || :
+  TL="$(mktemp)"
+  if "$UZI" run logs "$RID" --json > "$TL" 2>/dev/null; then
+    "$JQ" -rs 'map(select(.kind=="plan"))|last|.payload.plan_md // empty' "$TL" \
+      > "$DEST/issue-$iid.plan.md" 2>/dev/null || :
+    tail -n 80 "$TL" > "$DEST/issue-$iid.log-tail.ndjson" 2>/dev/null || :
+  fi
+  rm -f "$TL"
+  {
+    echo "issue=#$iid  run=$RID  captured=$(date -u +%FT%TZ)"
+    printf '%s' "$J" | "$JQ" -r '"status=\(.status)  health=\(.health_reason//"ok")  worker=\(.worker_id//"-")  token=\(.anthropic_secret_label//"-")/\(.anthropic_bind_mode//"-")  mr=\(.mr_web_url//"none")"' 2>/dev/null
+    echo "--- milestones_completed (DONE):"
+    printf '%s' "$J" | "$JQ" -r '(.milestones_completed//[])[]' 2>/dev/null
+    echo "--- milestones (plan-frozen; status/title if present = what is LEFT):"
+    printf '%s' "$J" | "$JQ" -r '(.milestones//[])[] | if type=="object" then "  \(.id//.key//.number//"?")\t\(.status//"?")\t\(.title//.name//"")" else "  \(tostring)" end' 2>/dev/null
+    echo "(full plan: issue-$iid.plan.md ; recent transcript: issue-$iid.log-tail.ndjson)"
+  } > "$DEST/issue-$iid.progress.txt" 2>/dev/null || :
+
+  case "$st" in
+    completed|failed|cancelled)
+      log "SNAP $RID (#$iid) status=$st mr=${mr:-none} (status saved; no worker capture)"
+      continue ;;
+  esac
+  if [ -z "$wid" ]; then
+    log "SNAP $RID (#$iid) status=$st: no worker_id, parked/unclaimed (status saved)"
+    continue
+  fi
+  if ! read -r ns pod < <(resolve_pod "$wid"); then
+    log "WARN $RID (#$iid): status saved, but no pod for worker $wid in [$NAMESPACES]"
+    continue
+  fi
+  f="$DEST/issue-$iid.tgz"
+  if "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$iid" > "$f" 2>>"$LOG"; then
+    if [ -s "$f" ]; then
+      log "OK   $RID (#$iid) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
+    else
+      log "FAIL $RID (#$iid): empty artifact (clone missing?); see $LOG"
+      rm -f "$f"
+    fi
+  else
+    log "FAIL $RID (#$iid): exec/capture failed; see $LOG"
+  fi
+done
+
+ln -sfn "$DEST" "$OUTROOT/latest"
+log "DONE -> $DEST  (latest -> $OUTROOT/latest)"


### PR DESCRIPTION
Adds two scripts to the `uzi-watcher` skill for snapshotting in-flight uzi run work from hosted worker PVCs, so work survives a lost or rate-limit-parked run.

## What

- **`scripts/backup-runs.sh <RUN_ID>...`** — one snapshot per run into `$UZI_BACKUP_DIR` (default `/tmp/uzi-backups/<ts>/`): `issue-N.tgz` (git bundle of commits not on `origin/main` + `uncommitted.patch` + `untracked.tar.gz` + `meta.txt`) plus a self-describing status set (`run.json`, `plan.md`, `progress.txt` with milestones done vs left, `log-tail.ndjson`). Captures from the live runner working clone, so uncommitted work is caught too, not just the checkpointed tracking ref. Resolves worker to pod fresh each call, so it follows a worker roll or cross-worker migration.
- **`scripts/backup-loop.sh <RUN_ID>...`** — runs `backup-runs.sh` every `UZI_BACKUP_INTERVAL` (default 900s), detached so it outlives the session. Rides through `limit_wait`; self-terminates when all runs are terminal, after `UZI_BACKUP_MAX_HOURS` (default 12), or on a STOP file.

## Why

Driving runs through a shaky window (a rate-limited token that keeps parking at `limit_wait`, an edge case being hardened) needs a periodic fallback in case a resume does not come back cleanly. Complements the existing reactive PVC recovery already documented in the skill.

## Notes

- Deployment coordinates come from env (`UZI_CTX`, `UZI_WORKER_NS`, `UZI_REPO_SLUG`, the last derived from `origin`), never hard-coded, so nothing cluster-specific lands in the public repo.
- Both pass `shellcheck` clean (default severity, stricter than the `lint:shell` gate's `severity=warning`).
- Documented in the skill's recovery section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-time backups for in-progress runs, including Git changes, untracked files, metadata, plans, progress snapshots, and recent logs.
  * Added recurring background backups with configurable intervals, runtime limits, storage locations, and completion detection.
  * Added restoration guidance and safeguards for stopped, completed, unavailable, or invalid runs.
  * Organized backup artifacts by timestamp with convenient access to the latest snapshot.
  * Improved backup validation and secure file permissions to identify incomplete captures and protect stored artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->