### PR TITLE
docs(uzi-watcher): confirm CodeRabbit re-review via recent_review block

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -371,8 +371,14 @@ stayed silent. The signal that fires on *every* incremental pass is the **walkth
 comment's `recent_review` block**: CodeRabbit edits that one issue comment each pass to state
 either the new actionable count or `No actionable comments were generated in the recent
 review 🎉`, and — the load-bearing part — the exact range `Reviewing files that changed ...
-between BASE_SHA and HEAD_SHA` (two full commit SHAs). Read it from the **issue** comments, not the pulls comments:
-`gh api repos/OWNER/REPO/issues/PR/comments --jq '.[]|select(.user.login|test("coderabbit";"i"))|.body'`
+between BASE_SHA and HEAD_SHA` (two full commit SHAs). Read it from the **issue** comments, not
+the pulls comments — with `--paginate`, and select the ONE walkthrough comment CodeRabbit edits
+in place by its stable marker rather than trusting the first CodeRabbit body you find. Two
+reasons this must be deterministic: the issue-comments endpoint defaults to 30 per page (ascending
+by id), so on a PR with more than 30 comments the walkthrough can fall off the default first page;
+and CodeRabbit posts several issue comments (walkthrough, status, tips), so a bare login filter
+returns more than one body. The `<!-- walkthrough_start -->` marker uniquely identifies it:
+`gh api --paginate repos/OWNER/REPO/issues/PR/comments --jq '.[]|select(.user.login|test("coderabbit";"i"))|select(.body|contains("<!-- walkthrough_start -->"))|.body'`
 and confirm the range's second SHA is your latest push. So the reliable order is: **(c) the
 `recent_review` range covers your head SHA AND reports its actionable count** (0 → clean, merge
 on green CI; >0 → triage); (a)/(b) are corroborating detail only when actionable comments

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -362,6 +362,23 @@ for a trivial fix**, so `reviewDecision` can stay `CHANGES_REQUESTED` even after
 resolved; once (a) or (b) plus green CI confirm the current head is clean, `--admin` merges past
 that stale verdict rather than waiting for a flip that never comes.
 
+**(a) and (b) both fail on a CLEAN re-review, and that is the common case — so know signal
+(c), the one that ALWAYS fires.** Measured 2026-08-28 on PR#763: after a fix push, a poller
+keyed on (a) timed out and (b) never fired, because a **zero-actionable incremental review
+posts NO new review object and re-anchors no prior finding** — CodeRabbit had finished and
+found nothing, which is exactly the merge-ready state, yet both robust-looking checks above
+stayed silent. The signal that fires on *every* incremental pass is the **walkthrough
+comment's `recent_review` block**: CodeRabbit edits that one issue comment each pass to state
+either the new actionable count or `No actionable comments were generated in the recent
+review 🎉`, and — the load-bearing part — the exact range `Reviewing files that changed ...
+between BASE_SHA and HEAD_SHA` (two full commit SHAs). Read it from the **issue** comments, not the pulls comments:
+`gh api repos/OWNER/REPO/issues/PR/comments --jq '.[]|select(.user.login|test("coderabbit";"i"))|.body'`
+and confirm the range's second SHA is your latest push. So the reliable order is: **(c) the
+`recent_review` range covers your head SHA AND reports its actionable count** (0 → clean, merge
+on green CI; >0 → triage); (a)/(b) are corroborating detail only when actionable comments
+existed. A poller must key on (c), never on the `CodeRabbit` PR check nor on the presence of a
+new review object.
+
 **The shared `main` worktree is a multi-writer tree — never assert it is clean.** Other
 sessions leave modified files in it and advance `main` mid-review (measured 2026-08-20:
 two reviewers found unrelated `tui_*` edits and `main` moving `6fc6c5eb`→`2007cbf4` under

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -377,8 +377,12 @@ in place by its stable marker rather than trusting the first CodeRabbit body you
 reasons this must be deterministic: the issue-comments endpoint defaults to 30 per page (ascending
 by id), so on a PR with more than 30 comments the walkthrough can fall off the default first page;
 and CodeRabbit posts several issue comments (walkthrough, status, tips), so a bare login filter
-returns more than one body. The `<!-- walkthrough_start -->` marker uniquely identifies it:
-`gh api --paginate repos/OWNER/REPO/issues/PR/comments --jq '.[]|select(.user.login|test("coderabbit";"i"))|select(.body|contains("<!-- walkthrough_start -->"))|.body'`
+returns more than one body. The `<!-- walkthrough_start -->` marker uniquely identifies it. Because
+this is the signal an unattended merge keys on, match the **exact** bot login `coderabbitai[bot]`
+(id `136622811`), not `test("coderabbit";"i")` which any login *containing* "coderabbit" would
+satisfy — a spoofable author lets a crafted comment forge a clean range. Expect exactly one match
+and fail closed on zero or more than one:
+`gh api --paginate repos/OWNER/REPO/issues/PR/comments --jq '.[]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body'`
 and confirm the range's second SHA is your latest push. So the reliable order is: **(c) the
 `recent_review` range covers your head SHA AND reports its actionable count** (0 → clean, merge
 on green CI; >0 → triage); (a)/(b) are corroborating detail only when actionable comments


### PR DESCRIPTION
Extends the uzi-watcher skill's CodeRabbit re-review-confirmation note (added in #756's follow-up) with the signal that actually fires on a clean re-review.

## Problem

The existing note gives two ways to confirm a re-review landed on your latest SHA: (a) a new review object whose commit range covers it, or (b) prior findings rendering outdated. Both fail on a **zero-actionable** incremental review, which is the common case: CodeRabbit posts no new review object and re-anchors no prior finding, so a poller keyed on either waits forever on a state that is already merge-ready. Hit live on PR #763 this session (a poller keyed on (a) timed out while CodeRabbit had already finished clean).

## Fix

Add signal (c): the walkthrough comment's `recent_review` block, which CodeRabbit edits on every incremental pass with the actionable count and the exact reviewed commit range (`between BASE_SHA and HEAD_SHA`), read from the **issue** comments (not the pulls comments). A poller must key on (c); (a)/(b) are corroborating detail only when actionable comments existed.

Docs-only change to `.claude/skills/uzi-watcher/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to retrieve CodeRabbit walkthrough comments using the exact `coderabbitai[bot]` login and stable walkthrough marker.
  * Added guidance to paginate through issue comments so walkthroughs are found beyond the default comment limit.
  * Distinguished walkthrough comments from other comments authored by CodeRabbit and documented spoofing risks from broad login matching.
  * Added fail-closed handling when zero or multiple matching walkthrough comments are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->