### PR TITLE
web tests fail under Node >=26: built-in localStorage shadows jsdom (AuthContext.test.tsx)

### DIFF
--- a/web/src/test-setup.storage.test.ts
+++ b/web/src/test-setup.storage.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect } from "vitest";
+import { ensureWebStorage } from "./test-setup";
+
+// Node-independent regression test for issue #340: on Node >=26 the jsdom environment exposes
+// no `localStorage`, so a bare `localStorage.clear()` throws. We reproduce that "no Storage"
+// condition explicitly (rather than by Node version, since the repo pins Node 24 where jsdom
+// provides one) and assert the setup guard installs a working in-memory store.
+
+const originalLocal = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+const originalSession = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+
+afterEach(() => {
+  // Restore whatever was there before this file forced things, so no state leaks across tests.
+  if (originalLocal) Object.defineProperty(globalThis, "localStorage", originalLocal);
+  if (originalSession) Object.defineProperty(globalThis, "sessionStorage", originalSession);
+});
+
+describe("ensureWebStorage (issue #340)", () => {
+  it("installs a working Storage when the global is undefined, so bare localStorage round-trips", () => {
+    // Force the exact Node-26 shadow: no Storage at all.
+    Object.defineProperty(globalThis, "localStorage", { value: undefined, configurable: true, writable: true });
+    Object.defineProperty(globalThis, "sessionStorage", { value: undefined, configurable: true, writable: true });
+
+    ensureWebStorage();
+
+    // Bare global access (the AuthContext.test.tsx failure shape) must now work.
+    expect(typeof localStorage.clear).toBe("function");
+    localStorage.setItem("k", "v");
+    expect(localStorage.getItem("k")).toBe("v");
+    expect(localStorage.length).toBe(1);
+    expect(localStorage.key(0)).toBe("k");
+    localStorage.removeItem("k");
+    expect(localStorage.getItem("k")).toBeNull();
+    localStorage.setItem("a", "1");
+    localStorage.clear();
+    expect(localStorage.getItem("a")).toBeNull();
+    expect(localStorage.length).toBe(0);
+
+    // sessionStorage is polyfilled the same way.
+    sessionStorage.setItem("s", "1");
+    expect(sessionStorage.getItem("s")).toBe("1");
+  });
+
+  it("is a no-op when a working Storage already exists (Node 24 / real jsdom path)", () => {
+    const sentinel = {
+      getItem: () => "sentinel",
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+    Object.defineProperty(globalThis, "localStorage", { value: sentinel, configurable: true, writable: true });
+
+    ensureWebStorage();
+
+    // The guard must not replace an already-working store.
+    expect(globalThis.localStorage).toBe(sentinel);
+    expect(localStorage.getItem("anything")).toBe("sentinel");
+  });
+});

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -22,3 +22,56 @@ import { configure } from "@testing-library/dom";
 // trains everyone to re-run instead of read — which is the actual damage, and which lands in
 // CI where nobody has the context to tell it from a real regression.
 configure({ asyncUtilTimeout: 5000 });
+
+// jsdom Web Storage polyfill (issue #340).
+//
+// Node >=26 ships an EXPERIMENTAL built-in Web Storage `localStorage` global that is
+// `undefined` unless the process was started with `--localstorage-file`. Under the vitest
+// jsdom environment on Node 26, jsdom installs no Storage of its own, so BOTH the bare
+// `localStorage` global and `window.localStorage` come back `undefined` — and a bare
+// `localStorage.clear()` (e.g. AuthContext.test.tsx's beforeEach) throws
+// "TypeError: Cannot read properties of undefined (reading 'clear')".
+//
+// This repo pins Node 24 (.nvmrc), where jsdom DOES provide a working `localStorage`, so the
+// guard below is a strict no-op there: it only installs a store when one is missing or broken.
+// Several test files carry their own per-`beforeEach` `makeStorage()` shim for the same reason;
+// they redefine the (configurable) property with a fresh Map for isolation and keep working.
+function makeMemoryStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+    setItem: (k: string, v: string) => void m.set(k, String(v)),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
+
+function isWorkingStorage(s: unknown): s is Storage {
+  return (
+    !!s &&
+    typeof (s as Storage).clear === "function" &&
+    typeof (s as Storage).getItem === "function"
+  );
+}
+
+// Idempotent: install an in-memory Storage on `globalThis` only when the built-in one is
+// missing/broken. Exported so the regression test can force the "no Storage" condition and
+// re-run the guard without depending on the Node version. In jsdom `globalThis` IS `window`,
+// so this also satisfies `window.localStorage` accessors (e.g. lib/prefs.ts).
+export function ensureWebStorage(): void {
+  for (const name of ["localStorage", "sessionStorage"] as const) {
+    if (!isWorkingStorage((globalThis as Record<string, unknown>)[name])) {
+      Object.defineProperty(globalThis, name, {
+        value: makeMemoryStorage(),
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+}
+
+ensureWebStorage();


### PR DESCRIPTION
Implements issue #340.

Closes #340

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-340`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback for missing or incomplete browser storage, ensuring local and session storage remain functional in supported environments.

* **Tests**
  * Added regression coverage confirming storage fallbacks work correctly and existing working storage is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->