### PR TITLE
Worker seeds runs off a stale, disjoint remote ref: prune the fetch and reject a base with no common history

### DIFF
--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -439,18 +439,65 @@ export class GitCache {
       // necessarily carry the default branch), so the resolution happens here.
       const originRef = `refs/remotes/origin/${branch}`;
       const trackingRef = runnerTrackingRef(branch);
-      const originExists = await this.refExists(barePath, originRef);
+      // issue #781 — disjoint-history guard. Resolve the default ref ONCE up front, then
+      // qualify EACH candidate base ref: it counts as existing only if it also shares
+      // history with the default branch. A candidate that exists but is disjoint from
+      // default (a stale ref whose remote counterpart was rebuilt from an orphan root, or
+      // a leftover from an unrelated branch reused) is treated as ABSENT, so the seed falls
+      // back cleanly to the default tip instead of seeding off unrelated history. The guard
+      // qualifies up front (not a post-override): each candidate's downstream logic below is
+      // unchanged for a candidate that DOES share history.
+      // Best-effort: if the default cannot be resolved we cannot prove disjointness, so
+      // every candidate is kept (byte-identical to pre-#781 behaviour on this leg). The
+      // not-ownedHere/no-origin else leg still resolves the default authoritatively for its
+      // floor below, and throws there if truly unresolvable — unchanged.
+      let defaultRef: string | undefined;
+      try {
+        defaultRef = await this.defaultBranchRef(barePath);
+      } catch {
+        defaultRef = undefined;
+      }
+      const originExistsRaw = await this.refExists(barePath, originRef);
+      const originDisjoint = originExistsRaw && defaultRef !== undefined
+        && !(await this.sharesHistory(barePath, originRef, defaultRef));
+      if (originDisjoint) {
+        this.log.warn(
+          "runner clone: origin branch ref is disjoint from default — ignoring, seeding off default tip",
+          { branch, originRef },
+        );
+      }
+      const originExists = originExistsRaw && !originDisjoint;
       // The tracking ref is consulted ONLY when its stamp says THIS run wrote it — the
-      // run-identity anchor that gates the whole consideration (see the doc comment).
-      const trackingExists = await this.refExists(barePath, trackingRef);
+      // run-identity anchor that gates the whole consideration (see the doc comment). A
+      // disjoint tracking ref is treated as absent so it cannot make `ownedHere` true.
+      const trackingExistsRaw = await this.refExists(barePath, trackingRef);
+      const trackingDisjoint = trackingExistsRaw && defaultRef !== undefined
+        && !(await this.sharesHistory(barePath, trackingRef, defaultRef));
+      if (trackingDisjoint) {
+        this.log.warn(
+          "runner clone: tracking ref is disjoint from default — ignoring, seeding off default tip",
+          { branch, trackingRef },
+        );
+      }
+      const trackingExists = trackingExistsRaw && !trackingDisjoint;
       const owner = trackingExists
         ? await this.tryGitStdout(barePath, ["config", "--get", runnerTrackingOwnerKey(branch)])
         : "";
       const ownedHere = trackingExists && runId !== undefined && owner === runId;
       // PRD #122 M8 cross-worker candidate: origin's checkpoint ref, mirrored into the bare
-      // by fetch(). Consulted ONLY on the not-ownedHere legs (see the doc comment).
+      // by fetch(). Consulted ONLY on the not-ownedHere legs (see the doc comment). A
+      // disjoint checkpoint is treated as absent (so no checkpointSetAside is emitted for it).
       const checkpointRef = `refs/uzi-checkpoints/${branch}`;
-      const checkpointExists = await this.refExists(barePath, checkpointRef);
+      const checkpointExistsRaw = await this.refExists(barePath, checkpointRef);
+      const checkpointDisjoint = checkpointExistsRaw && defaultRef !== undefined
+        && !(await this.sharesHistory(barePath, checkpointRef, defaultRef));
+      if (checkpointDisjoint) {
+        this.log.warn(
+          "runner clone: checkpoint ref is disjoint from default — ignoring, seeding off default tip",
+          { branch, checkpointRef },
+        );
+      }
+      const checkpointExists = checkpointExistsRaw && !checkpointDisjoint;
 
       let baseRef: string;
       let seededFrom: RunnerClone["seededFrom"];
@@ -1431,7 +1478,15 @@ export class GitCache {
   }
 
   private async fetch(barePath: string, pat?: string, scope?: string, username?: string): Promise<void> {
-    await this.runGit(barePath, ["fetch", "origin"], pat, scope, username);
+    // issue #781 — the `--prune` FLAG (NOT the config form `fetch.prune` /
+    // `remote.origin.prune`) prunes only the ref namespace of this fetch's configured
+    // refspec `+refs/heads/*:refs/remotes/origin/*` — i.e. `refs/remotes/origin/*` — so a
+    // remote branch deleted upstream stops seeding stale disjoint bases while
+    // `refs/uzi-runner/*` and the separate checkpoint mirror fetch's `refs/uzi-checkpoints/*`
+    // stay intact. The config form would additionally prune the locally-mirrored checkpoint
+    // refs on the separate mirror fetch just below (whose origin has no `refs/uzi-checkpoints/*`
+    // to match), degrading PRD #122 M8 cross-worker recovery.
+    await this.runGit(barePath, ["fetch", "--prune", "origin"], pat, scope, username);
     // Refresh origin/HEAD so a remote default-branch change takes effect. Best
     // effort: defaultBranchRef has fallbacks if this symref is absent.
     await this.tryGit(barePath, ["remote", "set-head", "origin", "--auto"]);
@@ -1492,6 +1547,16 @@ export class GitCache {
    *  wins the "strictly descends" branch. */
   private async isAncestor(barePath: string, ancestorRef: string, descendantRef: string): Promise<boolean> {
     return (await this.tryGit(barePath, ["merge-base", "--is-ancestor", ancestorRef, descendantRef])) === 0;
+  }
+
+  /** issue #781 — true when `ref` shares any history with the default branch, i.e.
+   *  plain `git merge-base <ref> <default>` prints a commit (exit 0). Distinct from
+   *  isAncestor (merge-base --is-ancestor), which returns non-zero for BOTH a disjoint
+   *  AND a merely-diverged base — so it cannot be reused here without false-rejecting a
+   *  legitimately far-ahead resume/first-park base. Only plain merge-base discriminates
+   *  disjoint (empty, exit 1) from diverged (a common ancestor exists, exit 0). */
+  private async sharesHistory(barePath: string, ref: string, defaultRef: string): Promise<boolean> {
+    return (await this.tryGit(barePath, ["merge-base", ref, defaultRef])) === 0;
   }
 
   /** PRD #759 M2 — is the commit `sha` a `wip(park):` marker (WIP_PARK_COMMIT_PREFIX)?

--- a/agent/test/git.test.ts
+++ b/agent/test/git.test.ts
@@ -1031,3 +1031,137 @@ describe("worktreeStatus (issue #281 / CodeRabbit #655)", () => {
     assert.strictEqual(result, null);
   });
 });
+
+// Issue #781 — the worker must not seed a run off a STALE, DISJOINT remote ref, and a
+// remote branch deleted upstream must stop seeding stale bases (fetch --prune). Two
+// independent guards, both proven here against real local git.
+describe("issue #781 — disjoint-ref seed guard + fetch --prune", () => {
+  const IDENT = ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false"];
+  function refInBare(bare: string, ref: string): boolean {
+    try {
+      gitIn(bare, ["rev-parse", "--verify", "--quiet", ref]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it("rejects a disjoint origin branch ref and seeds off the default tip instead", async () => {
+    // Build a DISJOINT branch at origin matching the seed branch name for issue 55 — an
+    // orphan root, so it shares no history (and no content) with main.
+    gitIn(fx.originPath, ["checkout", "--orphan", "agent/issue-55"]);
+    gitIn(fx.originPath, ["rm", "-rf", "."]);
+    fs.writeFileSync(path.join(fx.originPath, "ORPHAN.txt"), "x\n");
+    gitIn(fx.originPath, ["add", "."]);
+    gitIn(fx.originPath, [...IDENT, "commit", "-m", "orphan disjoint history"]);
+    gitIn(fx.originPath, ["checkout", "main"]);
+
+    // ensureClone fetches refs/remotes/origin/agent/issue-55 into the bare.
+    const bare = await git.ensureClone(fx.originPath);
+    assert.strictEqual(
+      refInBare(bare, "refs/remotes/origin/agent/issue-55"),
+      true,
+      "precondition: the disjoint ref is fetched into the bare",
+    );
+    // …and it genuinely shares NO history with default: plain merge-base prints nothing and
+    // exits non-zero (gitIn throws on non-zero, hence the try/catch).
+    let disjoint = false;
+    try {
+      disjoint = gitIn(bare, ["merge-base", "refs/remotes/origin/agent/issue-55", "refs/remotes/origin/main"]) === "";
+    } catch {
+      disjoint = true;
+    }
+    assert.strictEqual(disjoint, true, "precondition: the ref is genuinely disjoint from default");
+
+    const disjointTip = gitIn(bare, ["rev-parse", "refs/remotes/origin/agent/issue-55"]);
+    const defaultTip = gitIn(bare, ["rev-parse", "refs/remotes/origin/main"]);
+
+    const rc = await git.createOrAttachRunnerClone(bare, 55);
+    assert.strictEqual(rc.seededFrom, "default", "a disjoint origin ref is ignored; the seed falls back to default");
+    assert.strictEqual(rc.priorCommits, 0, "a default seed carries no prior commits");
+    assert.strictEqual(rc.baseCommit, defaultTip, "seeded off the fresh default tip");
+    assert.notStrictEqual(rc.baseCommit, disjointTip, "…explicitly NOT the disjoint ref tip");
+  });
+
+  it("keeps a far-ahead owned tracking ref that merely diverges from default (guard is not over-aggressive)", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    // Seed a first runner clone off the initial default and build a tracking ref several
+    // commits ahead, owned by run-far. It forks off main's initial commit — so it merely
+    // DIVERGES from default; it is not disjoint.
+    const first = await git.createOrAttachRunnerClone(bare, 66, "run-far");
+    for (const f of ["F1.txt", "F2.txt", "F3.txt"]) {
+      fs.writeFileSync(path.join(first.path, f), `${f}\n`);
+      gitIn(first.path, ["add", f]);
+      gitIn(first.path, [...IDENT, "commit", "-m", `work ${f}`]);
+    }
+    const tip = gitIn(first.path, ["rev-parse", "HEAD"]);
+    await git.fetchAgentBranch(bare, first.path, "agent/issue-66", "run-far"); // tracking owned by run-far
+    await git.removeRunnerClone(first.path);
+
+    // Advance origin's main on its OWN line so the tracking ref genuinely diverges (their
+    // only common ancestor is the initial commit — neither descends the other).
+    fs.writeFileSync(path.join(fx.originPath, "MAIN.txt"), "m\n");
+    gitIn(fx.originPath, ["add", "MAIN.txt"]);
+    gitIn(fx.originPath, [...IDENT, "commit", "-m", "advance main on its own line"]);
+    await git.ensureClone(fx.originPath); // bare learns the fresh divergent main
+
+    // PRECONDITION: the tracking ref shares history with default (a common ancestor exists)
+    // but is NOT an ancestor of it — the exact case merge-base --is-ancestor would reject,
+    // and the reason sharesHistory uses plain merge-base rather than isAncestor.
+    assert.doesNotThrow(
+      () => gitIn(bare, ["merge-base", "refs/uzi-runner/agent/issue-66", "refs/remotes/origin/main"]),
+      "precondition: tracking ref shares history with default (plain merge-base succeeds)",
+    );
+    assert.throws(
+      () => gitIn(bare, ["merge-base", "--is-ancestor", "refs/uzi-runner/agent/issue-66", "refs/remotes/origin/main"]),
+      "precondition: the far-ahead tracking ref is NOT an ancestor of default (is-ancestor would reject it)",
+    );
+
+    // Reseed as the SAME run: the guard KEEPS the diverged tracking ref, so it seeds off it.
+    const rc = await git.createOrAttachRunnerClone(bare, 66, "run-far");
+    assert.strictEqual(rc.seededFrom, "tracking", "a merely-diverged owned tracking ref must be kept, not rejected");
+    assert.strictEqual(rc.baseCommit, tip, "…and seeded off the tracking tip");
+  });
+
+  it("prunes a deleted origin branch's tracking ref while leaving refs/uzi-runner/* and refs/uzi-checkpoints/* intact", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    // Create a throwaway branch at origin and fetch it into the bare.
+    gitIn(fx.originPath, ["branch", "throwaway-781", "main"]);
+    await git.ensureClone(fx.originPath);
+    assert.strictEqual(
+      refInBare(bare, "refs/remotes/origin/throwaway-781"),
+      true,
+      "precondition: the throwaway branch's tracking ref is fetched",
+    );
+
+    // Differential setup (catches a config-form regression): plant two custom refs whose
+    // origin counterparts do NOT exist. The config form (fetch.prune / remote.origin.prune)
+    // would sweep refs/uzi-checkpoints/* on the separate checkpoint mirror fetch; the
+    // --prune FLAG confines pruning to refs/remotes/origin/*, so both must survive.
+    const mainSha = gitIn(bare, ["rev-parse", "refs/remotes/origin/main"]);
+    gitIn(bare, ["update-ref", "refs/uzi-runner/agent/issue-999", mainSha]);
+    gitIn(bare, ["update-ref", "refs/uzi-checkpoints/agent/issue-999", mainSha]);
+
+    // Delete the branch at origin, then refetch: --prune removes the now-dangling tracking ref.
+    gitIn(fx.originPath, ["branch", "-D", "throwaway-781"]);
+    await git.ensureClone(fx.originPath);
+
+    assert.strictEqual(
+      refInBare(bare, "refs/remotes/origin/throwaway-781"),
+      false,
+      "the deleted origin branch's tracking ref must be pruned (#781)",
+    );
+    // The differential assertion: custom refs with no origin counterpart SURVIVE the prune —
+    // the config form would drop refs/uzi-checkpoints/agent/issue-999 on the mirror fetch.
+    assert.strictEqual(
+      refInBare(bare, "refs/uzi-runner/agent/issue-999"),
+      true,
+      "refs/uzi-runner/* must survive the prune (#781)",
+    );
+    assert.strictEqual(
+      refInBare(bare, "refs/uzi-checkpoints/agent/issue-999"),
+      true,
+      "refs/uzi-checkpoints/* must survive the prune (#781)",
+    );
+  });
+});


### PR DESCRIPTION
Implements issue #781.

Closes #781

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-781`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch handling when existing references have unrelated history, preventing invalid references from being used.
  * Preserved valid divergent tracking references.
  * Removed deleted remote-tracking branches during fetches while preserving runner and checkpoint references.
* **Tests**
  * Added regression coverage for unrelated histories, divergent branches, and safe pruning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->