### PR TITLE
MR review-watcher (mr_rework) never works: worker has no mr_rework branch-derivation case, and the claim wire never carries the mr_rework branch

### DIFF
--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -3225,6 +3225,11 @@ function mrTitle(
   // inline context's first line, so the trimmed-title branch above almost always
   // wins; this is the empty-context fallback, never `Resolve issue #null`.
   if (claim.kind === "task") return "Handoff task";
+  // An mr_rework run (PRD #700 / issue #778) is ISSUE-LESS (issue_iid is NULL): its
+  // issue_title is derived from the reworked MR's title so the trimmed-title branch
+  // above almost always wins; this is the empty-title fallback, never `Resolve issue
+  // #null` on the off-nominal path where a new MR is created.
+  if (claim.kind === "mr_rework") return "MR rework";
   return `${prefix}Resolve issue #${claim.issue_iid}`;
 }
 

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -3313,6 +3313,22 @@ function mrDescription(
       footer,
     ].join("\n");
   }
+  if (claim.kind === "mr_rework") {
+    // An mr_rework run (PRD #700 / issue #778) FOLDS review-comment fixes onto an MR's
+    // EXISTING branch; createMergeRequest is idempotent, so in the designed flow it
+    // adopts the already-open MR and this body is discarded. Like the prompt/task/
+    // self_improve arms above it is ISSUE-LESS (issue_iid is NULL), so it references the
+    // MR branch and `Closes` nothing — the issue fallback below would render `#null` on
+    // the off-nominal path where the branch exists but no open MR is found.
+    return [
+      "Automated MR rework (PRD #700). This run addressed review feedback on the existing",
+      `\`${branch}\` branch. There is no tracking issue, so this MR closes nothing.`,
+      ...repoMarker,
+      "",
+      "---",
+      footer,
+    ].join("\n");
+  }
   // PRD #634 M3: a partial delivery from an operator scope directive does NOT close the
   // issue — it delivered only the approved slice of milestones — so the closing line is
   // replaced with a partial-delivery statement and a scope-note blockquote is inserted.

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -2753,6 +2753,26 @@ export class RunRunner {
         runId,
       );
     }
+    if (claim.kind === "mr_rework") {
+      // PRD #700 / issue #778: an mr_rework run carries issue_iid = NULL and folds its
+      // work onto the MR's EXISTING branch rather than a worker-derived name. The server
+      // populates claim.branch from the run's pipeline_ref for this kind, so the MR branch
+      // (e.g. agent/issue-42) arrives here on claim.branch. runnerCloneForBranch seeds off
+      // `refs/remotes/origin/<branch>` when that branch already exists on origin — which it
+      // does for an MR under review — so the existing MR content is picked up automatically,
+      // the same mechanism the task case above relies on. A missing/empty branch is a
+      // create-time bug (an mr_rework run must carry its MR branch), so fail loudly rather
+      // than fall through to the issue path, which would throw on the NULL issue_iid.
+      const mrBranch = claim.branch?.trim();
+      if (!mrBranch)
+        throw new Error("mr_rework run claim is missing its MR branch (pipeline_ref)");
+      return this.git.runnerCloneForBranch(
+        barePath,
+        mrBranch,
+        mrBranch.replace(/\//g, "-"),
+        runId,
+      );
+    }
     if (claim.issue_iid == null)
       throw new Error("issue run claim is missing issue_iid");
     return this.git.createOrAttachRunnerClone(barePath, claim.issue_iid, runId);

--- a/agent/test/runner-mr-rework.test.ts
+++ b/agent/test/runner-mr-rework.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { makeClaim, nullLogger } from "./helpers.js";
+import { StubExecutor } from "../src/executor.js";
+import type { ClaimResponse } from "../src/protocol.js";
+import { api, fx, fakeGitlab, installHarness, runner } from "./runner-harness.js";
+
+installHarness();
+
+// An mr_rework run (PRD #700 / issue #778): kind="mr_rework", ISSUE-LESS (issue_iid
+// null), repo set, and `branch` carrying the MR's EXISTING branch, which the server
+// now sources from the run's pipeline_ref (e.g. agent/issue-42). The worker clones THAT
+// branch, folds its rework onto it, pushes back, and (openMr is true for a non-task
+// kind) idempotently adopts the existing MR.
+function mrReworkClaim(overrides: Partial<ClaimResponse> = {}): ClaimResponse {
+  const runId = (overrides.run_id as string | undefined) ?? randomUUID();
+  return makeClaim({
+    run_id: runId,
+    kind: "mr_rework",
+    issue_iid: null,
+    issue_title: "Rework: address MR review",
+    issue_description: "Apply the reviewer's feedback on the open MR.",
+    branch: "agent/issue-42",
+    base_branch: "main",
+    repo: {
+      id: "r1",
+      url: "https://gitlab.example.test/org/repo",
+      clone_url: fx.originPath,
+    },
+    last_seq: 0,
+    secrets: {
+      forge_pat: "fixture-forge-pat-000000",
+      anthropic_oauth_token: "dummy-oauth-do-not-scan",
+    },
+    ...overrides,
+  });
+}
+
+describe("RunRunner — mr_rework kind (PRD #700 / issue #778)", () => {
+  it("resolves the MR branch and does NOT throw the issue_iid error", async () => {
+    const { gitlab } = fakeGitlab();
+    const claim = mrReworkClaim();
+    await runner(new StubExecutor(nullLogger()), gitlab).execute(claim);
+
+    // The run reached completion, NOT failure — the mr_rework arm cloned claim.branch
+    // instead of falling through to the issue path that throws on a NULL issue_iid.
+    const completed = api.states.find(
+      (s) => s.runId === claim.run_id && s.body.status === "completed",
+    );
+    assert.ok(completed, "the mr_rework run completed");
+    // The StubExecutor returns ctx.branch (= the runner clone's branch), so a completion
+    // on agent/issue-42 proves the mr_rework arm cloned claim.branch, not the issue path.
+    assert.equal(completed!.body.branch, "agent/issue-42");
+
+    // The exact regression (#778): the run must NOT have failed with the issue_iid error.
+    const issueIidFailure = api.states.find(
+      (s) =>
+        s.runId === claim.run_id &&
+        s.body.status === "failed" &&
+        /issue run claim is missing issue_iid/.test(s.body.failure_reason ?? ""),
+    );
+    assert.equal(
+      issueIidFailure,
+      undefined,
+      "an mr_rework run must not fall through to the issue_iid error",
+    );
+  });
+
+  it("pushes the rework onto the MR branch on origin", async () => {
+    const { gitlab } = fakeGitlab();
+    const claim = mrReworkClaim();
+    await runner(new StubExecutor(nullLogger()), gitlab).execute(claim);
+
+    // The push landed on the MR branch — a real git push to the fixture bare origin.
+    const log = execFileSync(
+      "git",
+      ["-C", fx.originPath, "log", "--oneline", "agent/issue-42"],
+      { encoding: "utf8" },
+    );
+    assert.ok(
+      log.includes("uzi stub"),
+      "the worker's commit landed on the MR branch",
+    );
+  });
+
+  it("throws a clear error when an mr_rework claim is missing its branch", async () => {
+    const { gitlab } = fakeGitlab();
+    // An mr_rework run must always carry its MR branch (server-sourced from pipeline_ref);
+    // a missing one is a create-time bug the worker must surface rather than fall through.
+    const claim = mrReworkClaim({ branch: undefined });
+    await runner(new StubExecutor(nullLogger()), gitlab).execute(claim);
+
+    const failed = api.states.find(
+      (s) => s.runId === claim.run_id && s.body.status === "failed",
+    );
+    assert.ok(failed, "a branchless mr_rework run failed");
+    assert.match(failed!.body.failure_reason ?? "", /missing its MR branch/);
+  });
+});

--- a/agent/test/runner-mr-rework.test.ts
+++ b/agent/test/runner-mr-rework.test.ts
@@ -98,4 +98,25 @@ describe("RunRunner — mr_rework kind (PRD #700 / issue #778)", () => {
     assert.ok(failed, "a branchless mr_rework run failed");
     assert.match(failed!.body.failure_reason ?? "", /missing its MR branch/);
   });
+
+  it("opens the MR from the rework branch with no #null in title or body", async () => {
+    // openMr is true for a non-task kind, so the finalize path runs createMergeRequest.
+    // The fake returns a fresh 201 (not the 409-adopt path production usually takes), so
+    // this exercises the description builder directly — the exact path where a missing
+    // mr_rework arm would render `Implements issue #null` / `Closes #null`.
+    const { gitlab, calls } = fakeGitlab();
+    const claim = mrReworkClaim();
+    await runner(new StubExecutor(nullLogger()), gitlab).execute(claim);
+
+    assert.equal(calls.length, 1, "the mr_rework finalize opened exactly one MR");
+    const body = JSON.parse(calls[0]!.body ?? "{}");
+    assert.equal(body.source_branch, "agent/issue-42");
+    assert.ok(!String(body.title).includes("#null"), "no #null in the MR title");
+    assert.ok(!String(body.description).includes("#null"), "no #null in the MR body");
+    assert.ok(
+      !/Closes #/.test(String(body.description)),
+      "an mr_rework MR closes no issue",
+    );
+    assert.match(String(body.description), /rework/i);
+  });
 });

--- a/agent/test/runner-mr-rework.test.ts
+++ b/agent/test/runner-mr-rework.test.ts
@@ -105,7 +105,10 @@ describe("RunRunner — mr_rework kind (PRD #700 / issue #778)", () => {
     // this exercises the description builder directly — the exact path where a missing
     // mr_rework arm would render `Implements issue #null` / `Closes #null`.
     const { gitlab, calls } = fakeGitlab();
-    const claim = mrReworkClaim();
+    // Empty issue_title forces mrTitle past its trimmed-title branch to the empty-title
+    // fallback, so the "#null" title assertion below actually exercises the mr_rework arm
+    // rather than returning the fixture's non-empty title (which made it vacuous).
+    const claim = mrReworkClaim({ issue_title: "" });
     await runner(new StubExecutor(nullLogger()), gitlab).execute(claim);
 
     assert.equal(calls.length, 1, "the mr_rework finalize opened exactly one MR");

--- a/agent/test/runner-mr-rework.test.ts
+++ b/agent/test/runner-mr-rework.test.ts
@@ -114,6 +114,10 @@ describe("RunRunner — mr_rework kind (PRD #700 / issue #778)", () => {
     assert.equal(calls.length, 1, "the mr_rework finalize opened exactly one MR");
     const body = JSON.parse(calls[0]!.body ?? "{}");
     assert.equal(body.source_branch, "agent/issue-42");
+    // Pin the exact empty-title fallback mrTitle returns for an mr_rework claim; the
+    // negative `#null` checks below stay as supplementary guards but would pass for any
+    // wrong-but-not-`#null` title, so this equality is the load-bearing assertion.
+    assert.equal(body.title, "MR rework");
     assert.ok(!String(body.title).includes("#null"), "no #null in the MR title");
     assert.ok(!String(body.description).includes("#null"), "no #null in the MR body");
     assert.ok(

--- a/api/internal/workersvc/mr_rework_test.go
+++ b/api/internal/workersvc/mr_rework_test.go
@@ -96,3 +96,49 @@ func TestCreateAutoMRReworkRunRepoNotFound(t *testing.T) {
 		t.Fatalf("err = %v, want ErrRepoNotFound", err)
 	}
 }
+
+// TestMRReworkClaimBranchFromPipelineRef proves the real Claim path sources the
+// claim's Branch from pipeline_ref for an mr_rework run (PRD #700 / issue #778):
+// runs.branch is NULL for such a run and the MR branch lives in pipeline_ref, so
+// the worker gets the MR branch off the already-wired Branch field. Modeled on
+// ciFixClaimPayload / TestCIFixClaimWireContract in ci_fix_test.go.
+func TestMRReworkClaimBranchFromPipelineRef(t *testing.T) {
+	box := newBox(t)
+	sealedPAT, _ := box.Seal([]byte("FORGE-PAT-PLACEHOLDER"))
+	sealedTok, _ := box.Seal([]byte("ANTHROPIC-OAUTH-PLACEHOLDER"))
+
+	fs := &fakeStore{
+		claimRun: store.Run{
+			ID:               uuid.MustParse("44444444-4444-4444-4444-444444444444"),
+			RepoID:           pgUUID(uuid.MustParse("22222222-2222-2222-2222-222222222222")),
+			Kind:             RunKindMRRework,
+			IssueTitle:       "Rework MR: address review comments",
+			IssueDescription: "Fold the MR review-comment fixes onto the existing branch.",
+			Status:           "claimed",
+			PlanSource:       planSourceAgent,
+			// mr_rework: no issue iid; the MR branch lives in pipeline_ref, not branch.
+			PipelineRef: pgText("agent/issue-42"),
+		},
+		claimCtx: store.GetRunClaimContextRow{
+			RepoWebUrl: "https://gitlab.example.com/g/p", RepoPath: "g/p",
+			DefaultBranch: pgText("main"), ForgeType: "gitlab", BaseUrl: "https://gitlab.example.com",
+			BotUsername: "uzi-bot", TokenCiphertext: sealedPAT,
+		},
+		anthropic: sealedTok,
+	}
+	svc := New(fs, box, testParams())
+	payload, err := svc.Claim(context.Background(), worker())
+	if err != nil || payload == nil {
+		t.Fatalf("Claim: %v (payload=%v)", err, payload)
+	}
+
+	if payload.Kind != RunKindMRRework {
+		t.Fatalf("kind = %q, want mr_rework", payload.Kind)
+	}
+	if payload.IssueIID != nil {
+		t.Fatalf("an mr_rework claim must carry null issue_iid, got %v", *payload.IssueIID)
+	}
+	if payload.Branch == nil || *payload.Branch != "agent/issue-42" {
+		t.Fatalf("mr_rework claim must carry the MR branch from pipeline_ref, got %v", payload.Branch)
+	}
+}

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -2117,6 +2117,15 @@ func (s *Service) assembleClaim(ctx context.Context, wkr store.Worker, run store
 		pipeline = claimPipelineFromSnapshot(run.FailureSnapshot)
 	}
 
+	// PRD #700 / issue #778: for an mr_rework run runs.branch is NULL (the run
+	// carries no issue-run branch) and the MR's existing branch lives in
+	// pipeline_ref, so source the claim's Branch from pipeline_ref there. The
+	// worker still reads it off the already-wired Branch field; no new wire field.
+	branch := run.Branch
+	if run.Kind == RunKindMRRework {
+		branch = run.PipelineRef
+	}
+
 	// PRD #122 M1: replay the FROZEN milestone list on every claim. A malformed column
 	// degrades to nil-and-log rather than failing the claim, matching the repo_agents
 	// decode on the DTO path — the column is data a prior write left, not an invariant
@@ -2200,7 +2209,7 @@ func (s *Service) assembleClaim(ctx context.Context, wkr store.Worker, run store
 		ReviewComments: reviewComments,
 		Status:         run.Status,
 		Pipeline:       pipeline,
-		Branch:         textPtr(run.Branch),
+		Branch:         textPtr(branch),
 		SessionID:      textPtr(run.SessionID),
 		LastSeq:        run.LastSeq,
 		IterationCount: run.IterationCount,


### PR DESCRIPTION
Implements issue #778.

Closes #778

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-778`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automated merge request rework runs using the existing merge request branch.
  * Rework changes are pushed to the correct branch, even without an issue reference.
  * Merge request titles and descriptions now clearly identify automated rework runs without invalid issue references.

* **Bug Fixes**
  * Added clear validation when the requested merge request branch cannot be found.
  * Improved branch selection to ensure rework changes are applied to the intended merge request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->