### PR TITLE
fix(uzi-watcher): back up task runs, not just issue runs

### DIFF
--- a/.claude/skills/uzi-watcher/scripts/backup-runs.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-runs.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # One-shot backup of in-flight uzi run work from hosted (k8s) worker PVCs.
 #
+# Handles BOTH run kinds: an issue run's working clone is /data/runner/<slug>/issue-N
+# (files named issue-N.*), a task run's (uzi handoff, no issue iid) is
+# /data/runner/<slug>/task-<runid> (files named task-<runid>.*). The per-run "stem"
+# below selects which; a task run's whole point here is that its work is often still
+# UNCOMMITTED, so the uncommitted.patch + untracked capture is what saves it.
+#
 # For each run id it resolves worker_id -> pod FRESH each call (so it survives a
 # worker roll or a cross-worker migration), execs into the worker container, and
-# captures from the live runner working clone /data/runner/<slug>/issue-N:
+# captures from the live runner working clone /data/runner/<slug>/<stem>:
 #   issue-N.tgz               a tarball of:
 #     issue-N.bundle            git bundle of the branch (commits not on origin/main)
 #     issue-N.uncommitted.patch git diff HEAD  (staged+unstaged tracked changes)
@@ -72,27 +78,27 @@ log(){ printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*" | tee -a "$LOG"; }
 # shellcheck disable=SC2016
 CAPTURE='
 set -u
-N="$1"
-CLONE="/data/runner/'"$REPO_SLUG"'/issue-$N"
+STEM="$1"
+CLONE="/data/runner/'"$REPO_SLUG"'/$STEM"
 [ -d "$CLONE/.git" ] || { echo "NO_CLONE $CLONE" >&2; exit 3; }
 cd "$CLONE" || exit 3
 OUT="$(mktemp -d)"
 BR="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
 HEAD="$(git rev-parse HEAD 2>/dev/null)"
 if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
-  git bundle create "$OUT/issue-$N.bundle" "$BR" --not origin/main >/dev/null 2>&1 \
-    || git bundle create "$OUT/issue-$N.bundle" "$BR" >/dev/null 2>&1 || :
+  git bundle create "$OUT/$STEM.bundle" "$BR" --not origin/main >/dev/null 2>&1 \
+    || git bundle create "$OUT/$STEM.bundle" "$BR" >/dev/null 2>&1 || :
 else
-  git bundle create "$OUT/issue-$N.bundle" "$BR" >/dev/null 2>&1 || :
+  git bundle create "$OUT/$STEM.bundle" "$BR" >/dev/null 2>&1 || :
 fi
-git diff HEAD > "$OUT/issue-$N.uncommitted.patch" 2>/dev/null || :
+git diff HEAD > "$OUT/$STEM.uncommitted.patch" 2>/dev/null || :
 git ls-files --others --exclude-standard -z > "$OUT/.untracked" 2>/dev/null || :
 if [ -s "$OUT/.untracked" ]; then
-  tar --null -T "$OUT/.untracked" -czf "$OUT/issue-$N.untracked.tar.gz" 2>/dev/null || :
+  tar --null -T "$OUT/.untracked" -czf "$OUT/$STEM.untracked.tar.gz" 2>/dev/null || :
 fi
 rm -f "$OUT/.untracked"
 {
-  echo "issue=$N head=$HEAD branch=$BR captured=$(date -u +%FT%TZ)"
+  echo "stem=$STEM head=$HEAD branch=$BR captured=$(date -u +%FT%TZ)"
   echo "clone_origin_main=$(git rev-parse origin/main 2>/dev/null)"
   echo "merge_base=$(git merge-base HEAD origin/main 2>/dev/null)"
   echo "--- new commits (origin/main..HEAD):"
@@ -101,7 +107,7 @@ rm -f "$OUT/.untracked"
   git status --porcelain 2>/dev/null
   echo "--- git diff --stat HEAD:"
   git diff --stat HEAD 2>/dev/null
-} > "$OUT/issue-$N.meta.txt" 2>&1
+} > "$OUT/$STEM.meta.txt" 2>&1
 tar czf - -C "$OUT" . 2>/dev/null
 rm -rf "$OUT"
 '
@@ -124,59 +130,71 @@ for RID in "${RUNS[@]}"; do
     continue
   fi
   iid="$(printf '%s' "$J" | "$JQ" -r '.issue_iid // .issue // ""' 2>/dev/null)"
+  kind="$(printf '%s' "$J" | "$JQ" -r '.kind // ""' 2>/dev/null)"
   wid="$(printf '%s' "$J" | "$JQ" -r '.worker_id // ""' 2>/dev/null)"
   mr="$(printf '%s' "$J" | "$JQ" -r '.mr_web_url // ""' 2>/dev/null)"
 
+  # The "stem" is BOTH the on-pod working-clone dir name and the output-file prefix.
+  # An issue run keeps its historical issue-N.* naming; a task/chat run (no issue iid)
+  # is task-<runid>.* / <kind>-<runid>.*, matching /data/runner/<slug>/task-<runid>.
+  if [ -n "$iid" ]; then
+    STEM="issue-$iid"; LBL="#$iid"
+  elif [ -n "$kind" ] && [ "$kind" != "issue" ]; then
+    STEM="$kind-$RID"; LBL="$kind ${RID%%-*}"
+  else
+    STEM="run-$RID";  LBL="run ${RID%%-*}"
+  fi
+
   # --- status/progress snapshot (ALWAYS, even if parked or terminal: what was
   #     done, what is left, so a backup is self-describing without the code) ---
-  printf '%s' "$J" | "$JQ" . > "$DEST/issue-$iid.run.json" 2>/dev/null || :
+  printf '%s' "$J" | "$JQ" . > "$DEST/$STEM.run.json" 2>/dev/null || :
   TL="$(mktemp)"
   if "$UZI" run logs "$RID" --json > "$TL" 2>/dev/null; then
     "$JQ" -rs 'map(select(.kind=="plan"))|last|.payload.plan_md // empty' "$TL" \
-      > "$DEST/issue-$iid.plan.md" 2>/dev/null || :
-    tail -n 80 "$TL" > "$DEST/issue-$iid.log-tail.ndjson" 2>/dev/null || :
+      > "$DEST/$STEM.plan.md" 2>/dev/null || :
+    tail -n 80 "$TL" > "$DEST/$STEM.log-tail.ndjson" 2>/dev/null || :
   fi
   rm -f "$TL"
   {
-    echo "issue=#$iid  run=$RID  captured=$(date -u +%FT%TZ)"
+    echo "run=$RID  stem=$STEM  captured=$(date -u +%FT%TZ)"
     printf '%s' "$J" | "$JQ" -r '"status=\(.status)  health=\(.health_reason//"ok")  worker=\(.worker_id//"-")  token=\(.anthropic_secret_label//"-")/\(.anthropic_bind_mode//"-")  mr=\(.mr_web_url//"none")"' 2>/dev/null
     echo "--- milestones_completed (DONE):"
     printf '%s' "$J" | "$JQ" -r '(.milestones_completed//[])[]' 2>/dev/null
     echo "--- milestones (plan-frozen; status/title if present = what is LEFT):"
     printf '%s' "$J" | "$JQ" -r '(.milestones//[])[] | if type=="object" then "  \(.id//.key//.number//"?")\t\(.status//"?")\t\(.title//.name//"")" else "  \(tostring)" end' 2>/dev/null
-    echo "(full plan: issue-$iid.plan.md ; recent transcript: issue-$iid.log-tail.ndjson)"
-  } > "$DEST/issue-$iid.progress.txt" 2>/dev/null || :
+    echo "(full plan: $STEM.plan.md ; recent transcript: $STEM.log-tail.ndjson)"
+  } > "$DEST/$STEM.progress.txt" 2>/dev/null || :
 
   case "$st" in
     completed|failed|cancelled)
-      log "SNAP $RID (#$iid) status=$st mr=${mr:-none} (status saved; no worker capture)"
+      log "SNAP $RID ($LBL) status=$st mr=${mr:-none} (status saved; no worker capture)"
       continue ;;
   esac
   if [ -z "$wid" ]; then
-    log "SNAP $RID (#$iid) status=$st: no worker_id, parked/unclaimed (status saved)"
+    log "SNAP $RID ($LBL) status=$st: no worker_id, parked/unclaimed (status saved)"
     continue
   fi
   if ! read -r ns pod < <(resolve_pod "$wid"); then
-    log "WARN $RID (#$iid): status saved, but no pod for worker $wid in [$NAMESPACES]"
+    log "WARN $RID ($LBL):status saved, but no pod for worker $wid in [$NAMESPACES]"
     continue
   fi
-  f="$DEST/issue-$iid.tgz"
-  if "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$iid" > "$f" 2>>"$LOG"; then
+  f="$DEST/$STEM.tgz"
+  if "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$f" 2>>"$LOG"; then
     if [ -s "$f" ]; then
       # A nonempty archive is not enough: the git bundle carries the committed
       # work, so if it is missing, say so (PARTIAL) rather than logging OK. The
       # snapshot is still kept — its patch/untracked/status remain useful.
-      if tar tzf "$f" 2>/dev/null | grep -qF "issue-$iid.bundle"; then
-        log "OK   $RID (#$iid) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
+      if tar tzf "$f" 2>/dev/null | grep -qF "$STEM.bundle"; then
+        log "OK   $RID ($LBL) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
       else
-        log "PART $RID (#$iid): snapshot saved WITHOUT a git bundle (uncommitted/status only) -> $f; see $LOG"
+        log "PART $RID ($LBL):snapshot saved WITHOUT a git bundle (uncommitted/status only) -> $f; see $LOG"
       fi
     else
-      log "FAIL $RID (#$iid): empty artifact (clone missing?); see $LOG"
+      log "FAIL $RID ($LBL):empty artifact (clone missing?); see $LOG"
       rm -f "$f"
     fi
   else
-    log "FAIL $RID (#$iid): exec/capture failed; see $LOG"
+    log "FAIL $RID ($LBL):exec/capture failed; see $LOG"
   fi
 done
 


### PR DESCRIPTION
## What

`backup-runs.sh` keyed every path and filename on the issue iid (`issue-N.*` files, on-pod clone `/data/runner/<slug>/issue-N`), so a **task run** (`uzi handoff`: no issue iid, clone `/data/runner/<slug>/task-<runid>`) produced `issue-.*` files and a `NO_CLONE` miss — capturing only the status snapshot and **none of the code**.

This introduces a per-run **stem** that selects both the on-pod clone dir and the output prefix:
- an **issue** run keeps its historical `issue-N.*` naming byte-for-byte;
- a **task** (or other non-issue) run becomes `<kind>-<runid>.*`, matching its real working-clone dir.

`backup-loop.sh` already worked run-kind-agnostically and needs no change.

## Why

Found while driving the #764 handoff task to merge: its **96-file, 9205-line** M4/M5 change was entirely **uncommitted** in the worker PVC, so the old script could not back it up. Task runs are exactly the case where the `uncommitted.patch` + untracked capture is what would otherwise be lost on a worker death.

## Test

- `shellcheck` clean.
- Ran the improved script against the live #764 task run: 13.6M snapshot with `task-<id>.bundle` + `uncommitted.patch` (96 files) + `untracked.tar.gz` + status snapshot, correctly resolving the worker pod and `task-<runid>` clone path.
- Issue-run naming unchanged (`issue-N.*`).

Skill-script change only; no product code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup processing now supports both issue runs and task/chat runs.
  * Task working trees and run-specific artifacts are captured with clear labels.
  * Status, progress, and worker-capture records now consistently identify each run.

* **Bug Fixes**
  * Improved handling of terminal, parked, missing-worker, partial, and failed backup states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->