### PR TITLE
fix(uzi-watcher): verify backup .tgz integrity and retry on truncation

### DIFF
--- a/.claude/skills/uzi-watcher/scripts/backup-runs.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-runs.sh
@@ -194,15 +194,20 @@ for RID in "${RUNS[@]}"; do
     # earlier attempt already produced — a truncated archive is still the best
     # forensic artifact we have. Promote to $f only when the attempt produced bytes.
     rm -f "$tmp"
-    if ! "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$tmp" 2>>"$LOG"; then
-      log "WARN $RID ($LBL): exec/capture attempt $cap_try failed; see $LOG"
-      continue
+    "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$tmp" 2>>"$LOG"
+    kc_rc=$?
+    if [ "$kc_rc" -ne 0 ]; then
+      log "WARN $RID ($LBL): exec/capture attempt $cap_try exit=$kc_rc; see $LOG"
     fi
     if [ ! -s "$tmp" ]; then
-      # Empty is a missing clone, not a truncation; retrying will not help. Leave any
-      # nonempty $f from a prior attempt in place (do not clobber it with nothing).
+      # No bytes this attempt. A nonzero exit is a transient failure worth a retry;
+      # a clean exit with no output means the clone is missing (a retry won't help).
+      # Either way, leave any nonempty $f from a prior attempt in place.
+      [ "$kc_rc" -ne 0 ] && continue
       break
     fi
+    # Nonempty output — even on a nonzero exec exit, kubectl may have streamed a
+    # PARTIAL archive; keep it as the best-so-far and let the verify below decide.
     mv -f "$tmp" "$f"
     if gzip -t "$f" 2>/dev/null && tar tzf "$f" >/dev/null 2>&1; then
       cap_rc=0

--- a/.claude/skills/uzi-watcher/scripts/backup-runs.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-runs.sh
@@ -175,26 +175,47 @@ for RID in "${RUNS[@]}"; do
     continue
   fi
   if ! read -r ns pod < <(resolve_pod "$wid"); then
-    log "WARN $RID ($LBL):status saved, but no pod for worker $wid in [$NAMESPACES]"
+    log "WARN $RID ($LBL): status saved, but no pod for worker $wid in [$NAMESPACES]"
     continue
   fi
   f="$DEST/$STEM.tgz"
-  if "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$f" 2>>"$LOG"; then
-    if [ -s "$f" ]; then
-      # A nonempty archive is not enough: the git bundle carries the committed
-      # work, so if it is missing, say so (PARTIAL) rather than logging OK. The
-      # snapshot is still kept — its patch/untracked/status remain useful.
-      if tar tzf "$f" 2>/dev/null | grep -qF "$STEM.bundle"; then
-        log "OK   $RID ($LBL) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
-      else
-        log "PART $RID ($LBL):snapshot saved WITHOUT a git bundle (uncommitted/status only) -> $f; see $LOG"
-      fi
-    else
-      log "FAIL $RID ($LBL):empty artifact (clone missing?); see $LOG"
-      rm -f "$f"
+  # The capture streams a ~10-20 MB gzip out of the pod over `kubectl exec`, and
+  # that stream can be TRUNCATED mid-transfer (observed once the bundle grows past
+  # ~13 MB). A truncated .tgz still carries the bundle member's NAME in an early
+  # tar header, so the old name-only `tar tzf | grep` logged a false OK on a file
+  # whose bundle DATA was cut off. So verify the gzip END-TO-END (`gzip -t` plus a
+  # full `tar tzf` listing) and RETRY the whole capture a few times, since the
+  # truncation is transient — a re-exec usually succeeds within seconds.
+  cap_rc=1
+  for cap_try in 1 2 3; do
+    if ! "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$f" 2>>"$LOG"; then
+      log "WARN $RID ($LBL): exec/capture attempt $cap_try failed; see $LOG"
+      continue
     fi
+    if [ ! -s "$f" ]; then
+      # Empty is a missing clone, not a truncation; retrying will not help.
+      break
+    fi
+    if gzip -t "$f" 2>/dev/null && tar tzf "$f" >/dev/null 2>&1; then
+      cap_rc=0
+      break
+    fi
+    log "WARN $RID ($LBL): truncated .tgz on attempt $cap_try ($(du -h "$f" | cut -f1)); retrying"
+  done
+  if [ "$cap_rc" -eq 0 ]; then
+    # A verified-intact archive. The git bundle carries the committed work, so if
+    # it is absent, say so (PART) rather than OK — the patch/untracked/status are
+    # still useful, but there are no committed commits to restore.
+    if tar tzf "$f" 2>/dev/null | grep -qF "$STEM.bundle"; then
+      log "OK   $RID ($LBL) status=$st worker=$wid pod=$pod -> $f ($(du -h "$f" | cut -f1))"
+    else
+      log "PART $RID ($LBL): verified .tgz but WITHOUT a git bundle (uncommitted/status only) -> $f"
+    fi
+  elif [ -s "$f" ]; then
+    log "FAIL $RID ($LBL): .tgz still truncated after retries -> $f kept for forensics; see $LOG"
   else
-    log "FAIL $RID ($LBL):exec/capture failed; see $LOG"
+    log "FAIL $RID ($LBL): empty artifact (clone missing?); see $LOG"
+    rm -f "$f"
   fi
 done
 

--- a/.claude/skills/uzi-watcher/scripts/backup-runs.sh
+++ b/.claude/skills/uzi-watcher/scripts/backup-runs.sh
@@ -187,21 +187,30 @@ for RID in "${RUNS[@]}"; do
   # full `tar tzf` listing) and RETRY the whole capture a few times, since the
   # truncation is transient — a re-exec usually succeeds within seconds.
   cap_rc=1
+  tmp="$f.part"
   for cap_try in 1 2 3; do
-    if ! "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$f" 2>>"$LOG"; then
+    # Write each attempt to a scratch path, NEVER straight to $f: a later attempt
+    # whose exec dies before emitting any stdout must not wipe a nonempty archive an
+    # earlier attempt already produced — a truncated archive is still the best
+    # forensic artifact we have. Promote to $f only when the attempt produced bytes.
+    rm -f "$tmp"
+    if ! "$KUBECTL" --context "$CTX" -n "$ns" exec "$pod" -c worker -- sh -c "$CAPTURE" _ "$STEM" > "$tmp" 2>>"$LOG"; then
       log "WARN $RID ($LBL): exec/capture attempt $cap_try failed; see $LOG"
       continue
     fi
-    if [ ! -s "$f" ]; then
-      # Empty is a missing clone, not a truncation; retrying will not help.
+    if [ ! -s "$tmp" ]; then
+      # Empty is a missing clone, not a truncation; retrying will not help. Leave any
+      # nonempty $f from a prior attempt in place (do not clobber it with nothing).
       break
     fi
+    mv -f "$tmp" "$f"
     if gzip -t "$f" 2>/dev/null && tar tzf "$f" >/dev/null 2>&1; then
       cap_rc=0
       break
     fi
     log "WARN $RID ($LBL): truncated .tgz on attempt $cap_try ($(du -h "$f" | cut -f1)); retrying"
   done
+  rm -f "$tmp"
   if [ "$cap_rc" -eq 0 ]; then
     # A verified-intact archive. The git bundle carries the committed work, so if
     # it is absent, say so (PART) rather than OK — the patch/untracked/status are


### PR DESCRIPTION
## What

The PVC backup capture streams a ~10-20 MB gzip out of the worker pod over `kubectl exec`. That stream can be **truncated mid-transfer** once the run's git bundle grows large (observed at ~13 MB). A truncated `.tgz` still carries the bundle member's **name** in an early tar header, so the previous name-only `tar tzf | grep` check logged a **false OK** on a file whose bundle *data* was cut off.

This verifies the gzip **end-to-end** (`gzip -t` + a full `tar tzf` listing) and **retries the whole capture up to 3×**, since the truncation is transient. `OK` is logged only on a verified-intact archive; a still-truncated one after retries is a loud `FAIL` kept for forensics, not a silent OK. Also restores a dropped space in the WARN/FAIL log labels.

## Why

Found while driving the #764 handoff task (a large, mostly-committed change): a manual snapshot logged `OK` but `gzip -t` failed and its bundle member was unreadable — a re-run produced a clean, **restorable** archive (verified by fetching the bundle back into the repo and recovering all commits). A backup that silently records a corrupt archive is worse than none, so the integrity gate belongs in the tool.

## Test

- `shellcheck` clean.
- Ran the hardened script against the live #764 worker: logs `OK` only after `gzip -t`+`tar` pass; a deliberately-truncated archive is re-captured and, if it cannot be made whole, reported `FAIL`.
- Restorability proven: `git bundle verify` + fetch of a verified snapshot recovered the full task branch.

Follows #789 (task-run support); skill-script only, no product code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive capture reliability by validating gzip and tar integrity.
  * Added automatic retries for failed or truncated transfers.
  * Preserved nonempty partial archives for troubleshooting and retrying, while removing empty failed captures.
  * Added clearer handling and logging for missing workloads and capture failures.
  * Distinguishes verified archives with and without Git bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->