### PR TITLE
Default jobs row: copy fixes (de-duplicate "1 repo" badge; relabel "Edit cadence" tooltip)

### DIFF
--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -199,8 +199,11 @@ describe("DefaultJobs — catalog row", () => {
     // No visible count text inside the toggle button. (Scoped to the button: the green Badge
     // in the Next-run cell also matches /repo/, so a bare queryByText would find the pill.)
     expect(within(toggle).queryByText(/repo/)).toBeNull();
-    // ...but the count is still shown — in the green pill, not the toggle.
-    expect(screen.getByText(/1 repo/)).toBeTruthy();
+    // ...but the count is still shown — in the green pill, not the toggle. Scope the
+    // assertion to the Next-run table cell so it fails if the badge (or its count) is
+    // removed and the text merely reappears elsewhere in the row.
+    const nextRunCell = screen.getByRole("cell", { name: /1 repo/ });
+    expect(within(nextRunCell).getByText("1 repo")).toBeTruthy();
   });
 
   it("row Enable fans out only the actionable subset of the selection", async () => {

--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -187,6 +187,22 @@ describe("DefaultJobs — catalog row", () => {
     expect(screen.queryByRole("button", { name: /Enable/ })).toBeNull();
   });
 
+  it("the disclosure toggle shows no count text in the Default jobs tab (the green pill carries it)", () => {
+    // An enabled default row renders the disclosure toggle (repoCount > 0). The Default-jobs
+    // variant passes showDisclosureCount={false}, so the toggle degrades to a bare chevron —
+    // the "N repos" count lives only in the green Next-run pill.
+    renderTab({
+      schedules: [defRow({ id: "sch-uzi", repo_id: "repo-uzi", repo_path: "vtmocanu/uzi" })],
+    });
+
+    const toggle = screen.getByRole("button", { name: /Show repos for/ });
+    // No visible count text inside the toggle button. (Scoped to the button: the green Badge
+    // in the Next-run cell also matches /repo/, so a bare queryByText would find the pill.)
+    expect(within(toggle).queryByText(/repo/)).toBeNull();
+    // ...but the count is still shown — in the green pill, not the toggle.
+    expect(screen.getByText(/1 repo/)).toBeTruthy();
+  });
+
   it("row Enable fans out only the actionable subset of the selection", async () => {
     // The job is already enabled on repo-uzi. Picking BOTH repos should enable only the
     // actionable one (repo-atlas), never re-enable the already-materialized repo-uzi.

--- a/web/src/components/DefaultJobs.tsx
+++ b/web/src/components/DefaultJobs.tsx
@@ -244,6 +244,7 @@ function CatalogRow({
       disclosureId={`catalog-repos-${entry.slug}`}
       expandLabelName={entry.name}
       repoCount={enabledCount}
+      showDisclosureCount={false}
       description={entry.description}
       targetBadges={
         <>
@@ -411,7 +412,7 @@ function SubRow({
           <Button variant="ghost" size="sm" title="Run now" aria-label={`Run now on ${s.repo_path}`} disabled={busy} onClick={onRunNow}>
             <PlayIcon />
           </Button>
-          <Button variant="ghost" size="sm" title="Edit cadence" aria-label={`Edit ${entry.name} on ${s.repo_path}`} onClick={onEdit}>
+          <Button variant="ghost" size="sm" title="Edit settings" aria-label={`Edit ${entry.name} on ${s.repo_path}`} onClick={onEdit}>
             <PencilIcon />
           </Button>
           <Button variant="ghost" size="sm" title="Clone to an editable copy" aria-label={`Clone ${entry.name} on ${s.repo_path}`} disabled={busy} onClick={onClone}>

--- a/web/src/components/ScheduleGroupRow.test.tsx
+++ b/web/src/components/ScheduleGroupRow.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+//
+// ScheduleGroupRow disclosure-count default (issue #676): the expand toggle shows
+// the "N repos" count text by default (showDisclosureCount omitted); the Default-jobs tab
+// opts out via showDisclosureCount={false} (covered in DefaultJobs.test.tsx).
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { ScheduleGroupRow } from "./ScheduleGroupRow";
+
+afterEach(cleanup);
+
+function renderRow(showDisclosureCount?: boolean) {
+  return render(
+    <table>
+      <tbody>
+        <ScheduleGroupRow
+          name="My schedule"
+          repoCount={2}
+          showDisclosureCount={showDisclosureCount}
+          expanded={false}
+          onToggleExpand={() => {}}
+          disclosureId="disc-1"
+          expandLabelName="My schedule"
+          cols={6}
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("ScheduleGroupRow — disclosure count", () => {
+  it("shows the 'N repos' count text in the toggle by default (showDisclosureCount omitted)", () => {
+    renderRow();
+    const toggle = screen.getByRole("button", { name: /Show repos for My schedule/ });
+    expect(within(toggle).getByText(/2 repos/)).toBeTruthy();
+  });
+});

--- a/web/src/components/ScheduleGroupRow.tsx
+++ b/web/src/components/ScheduleGroupRow.tsx
@@ -34,6 +34,7 @@ export function ScheduleGroupRow({
   optionsCell,
   leadingActions,
   repoCount,
+  showDisclosureCount = true,
   expanded,
   onToggleExpand,
   disclosureId,
@@ -58,6 +59,10 @@ export function ScheduleGroupRow({
   leadingActions?: ReactNode;
   // The live member count; the expand toggle renders only when > 0.
   repoCount: number;
+  // Whether the expand toggle shows the "N repo(s)" count text. Off for callers that
+  // display the count elsewhere (Default jobs shows it in the green Next-run pill), so
+  // the toggle degrades to a bare chevron. Defaults to true.
+  showDisclosureCount?: boolean;
   expanded: boolean;
   onToggleExpand: () => void;
   // The id the expand toggle's aria-controls points at (unique per group).
@@ -101,7 +106,11 @@ export function ScheduleGroupRow({
                 aria-label={`${expanded ? "Hide" : "Show"} repos for ${expandLabelName}`}
                 className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted transition-colors hover:text-fg"
               >
-                {repoCount} repo{repoCount === 1 ? "" : "s"}
+                {showDisclosureCount && (
+                  <>
+                    {repoCount} repo{repoCount === 1 ? "" : "s"}
+                  </>
+                )}
                 <ChevronDownIcon className={cx("h-3.5 w-3.5 transition-transform", expanded && "rotate-180")} />
               </button>
             )}


### PR DESCRIPTION
Implements issue #676.

Closes #676

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-676`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Default job groups no longer display repository counts in their disclosure controls.
  * Repository counts remain visible for standard schedule groups.
  * Updated the per-repository edit tooltip to “Edit settings.”
  * Expand/collapse behavior remains unchanged.
  * Next-run repository counts continue to display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->