### PR TITLE
docs(uzi-watcher): coordinate with uzi mr_rework so CodeRabbit fixes don't collide

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -286,11 +286,13 @@ by anything on the PR itself.
    even though it will; if the findings are uzi-fixable (below) and the owner is opted in,
    give it a beat and re-check rather than racing in.
 3. **Let it finish, then decide from whether the head ACTUALLY moved — and read the ref
-   authoritatively.** With `BR` the PR's `agent/issue-*` branch, record its head *before*
-   the rework (`before=$(git rev-parse origin/"$BR")`), and after the run reaches terminal
-   **`git fetch origin "$BR"` FIRST** — a rework-worker push does not update your local
-   remote-tracking ref, so a bare `git rev-parse origin/"$BR"` reads the stale pre-rework
-   SHA and would call a real push "no commit". Then compare:
+   authoritatively at BOTH ends.** With `BR` the PR's `agent/issue-*` branch, **`git fetch
+   origin "$BR"` before recording** the pre-rework head (`before=$(git rev-parse
+   origin/"$BR")`) — the local remote-tracking ref can already be stale, so an unfetched
+   `before` is as unreliable as an unfetched `after`. Then, after the run reaches terminal,
+   **`git fetch origin "$BR"` AGAIN** and re-read the head: a rework-worker push does not
+   update your local remote-tracking ref on its own, so without the second fetch a real push
+   reads as "no commit". Then compare `before` to the new head:
    - **Head advanced** → REVIEW the new commit like any other diff (`git show <sha>`). uzi
      *acting* is not uzi being *right*: confirm it addressed the finding, added no
      regression, and did not "fix" a deliberate behavior. A bad rework is a
@@ -306,6 +308,16 @@ by anything on the PR itself.
    the **new head** (signal (c), the walkthrough `recent_review` range covering the new SHA
    — see *Triaging* below),
    confirm no active `mr_rework` remains and CI is green on that head, THEN merge.
+
+   **`scripts/watch-pr.sh OWNER/REPO PR [interval] [max]` runs this whole readiness poll**
+   so you do not hand-roll it each time: it exits **0** merge-ready (CI green on the head,
+   CodeRabbit reviewed that exact head with zero live inline findings, no active
+   `mr_rework`), **1** on red CI, **3** when CodeRabbit reviewed the head but left live
+   findings to triage, **4** when an `mr_rework` run is active on the MR (defer, then re-run
+   it), and **2** on timeout — where **exit 0 is trustworthy but exit 2 means inspect
+   manually, never merge**. "Reviewed this head" is the union of a review whose `commit_id`
+   is the head SHA and the walkthrough range ending at it, because a zero-actionable
+   incremental posts no new review object.
 
 **When this session still fixes locally (mr_rework will not or cannot):**
 - the owner is **opted out**, or the admin **kill-switch** is engaged
@@ -608,10 +620,11 @@ die with its session. When you close, hand any still-in-flight run ids on the sa
 
 ## Keep this skill (and its scripts) current
 
-This skill and its `scripts/` (`watch-run.sh` for uzi runs, `watch-ci.sh` for GitHub
-Actions, `pr-findings.sh` to gather CodeRabbit findings across PRs, `backup-runs.sh` /
-`backup-loop.sh` to snapshot in-flight run work from worker PVCs) are living documents —
-**update them in the same session you find them wanting.**
+This skill and its `scripts/` (`watch-run.sh` for uzi runs, `watch-ci.sh` for post-merge
+GitHub Actions, `watch-pr.sh` for a PR's merge-readiness — CI + CodeRabbit-on-head +
+mr_rework coordination in one poll — `pr-findings.sh` to gather CodeRabbit findings across
+PRs, `backup-runs.sh` / `backup-loop.sh` to snapshot in-flight run work from worker PVCs)
+are living documents — **update them in the same session you find them wanting.**
 When a run surprises you with a new failure mode, a plan trap this list does not name,
 changed merge/ruleset behaviour, a CLI verb that moved, or a poller needs a new
 stop-state/flag/exit-code: edit `SKILL.md` and/or the relevant script right then, and say

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -286,11 +286,11 @@ by anything on the PR itself.
    even though it will; if the findings are uzi-fixable (below) and the owner is opted in,
    give it a beat and re-check rather than racing in.
 3. **Let it finish, then decide from whether the head ACTUALLY moved — and read the ref
-   authoritatively.** Record the branch head *before* the rework (`before=$(git rev-parse
-   origin/<branch>)`), and after the run reaches terminal **`git fetch origin <branch>`
-   FIRST** — a rework-worker push does not update your local remote-tracking ref, so a bare
-   `git rev-parse origin/<branch>` reads the stale pre-rework SHA and would call a real push
-   "no commit". Then compare:
+   authoritatively.** With `BR` the PR's `agent/issue-*` branch, record its head *before*
+   the rework (`before=$(git rev-parse origin/"$BR")`), and after the run reaches terminal
+   **`git fetch origin "$BR"` FIRST** — a rework-worker push does not update your local
+   remote-tracking ref, so a bare `git rev-parse origin/"$BR"` reads the stale pre-rework
+   SHA and would call a real push "no commit". Then compare:
    - **Head advanced** → REVIEW the new commit like any other diff (`git show <sha>`). uzi
      *acting* is not uzi being *right*: confirm it addressed the finding, added no
      regression, and did not "fix" a deliberate behavior. A bad rework is a

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -271,7 +271,7 @@ by anything on the PR itself.
    reviewer**, and any **third-party review bot** — not just CodeRabbit, so gate the check
    on *any* finding, or a human/other-bot finding slips into the local-fix path while a
    rework is being queued and recreates the double-push collision:
-   ```
+   ```sh
    uzi run list --json | jq -r --arg repo REPO_ID --argjson pr PR \
      '.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)|{id,status}'
    ```
@@ -285,17 +285,26 @@ by anything on the PR itself.
    The trigger needs a green pipeline + settled review, so the run may not have spawned yet
    even though it will; if the findings are uzi-fixable (below) and the owner is opted in,
    give it a beat and re-check rather than racing in.
-3. **Let it finish, then REVIEW its fix commit like any other diff** (`git show <sha>`).
-   uzi *acting* is not uzi being *right*: confirm the rework actually addressed the
-   finding, added no regression, and did not "fix" a deliberate behavior. A bad rework is a
-   `revise`/`follow-up` to that run or a local correction — never an automatic merge.
-   **A completed rework may push NO commit at all** — it can judge every finding invalid or
-   already handled and only reply/resolve threads, leaving the branch head unchanged. Then
-   there is nothing to `git show`: confirm the head SHA did not move (`git rev-parse
-   origin/<branch>` unchanged) and proceed on the re-review rather than hunting for a commit
-   that was never made.
-4. **Its push retriggers CodeRabbit.** Wait for the re-review on the **new head** (signal
-   (c), the walkthrough `recent_review` range covering the new SHA — see *Triaging* below),
+3. **Let it finish, then decide from whether the head ACTUALLY moved — and read the ref
+   authoritatively.** Record the branch head *before* the rework (`before=$(git rev-parse
+   origin/<branch>)`), and after the run reaches terminal **`git fetch origin <branch>`
+   FIRST** — a rework-worker push does not update your local remote-tracking ref, so a bare
+   `git rev-parse origin/<branch>` reads the stale pre-rework SHA and would call a real push
+   "no commit". Then compare:
+   - **Head advanced** → REVIEW the new commit like any other diff (`git show <sha>`). uzi
+     *acting* is not uzi being *right*: confirm it addressed the finding, added no
+     regression, and did not "fix" a deliberate behavior. A bad rework is a
+     `revise`/`follow-up` to that run or a local correction — never an automatic merge. Then
+     go to step 4 (its push retriggered CodeRabbit).
+   - **Head unchanged** → the rework pushed **no commit** (it judged every finding invalid
+     or already handled and only replied/resolved threads). There is no new head, so **no
+     re-review was triggered — do NOT wait for one** (step 4 does not apply). Instead read
+     the run's own outcome (its in-thread replies / `uzi run logs`) and confirm every
+     finding was *explicitly* skipped or resolved-without-code; if so, proceed to merge on
+     the existing green state, otherwise return it to triage or local handling.
+4. **When it pushed a commit, that push retriggers CodeRabbit.** Wait for the re-review on
+   the **new head** (signal (c), the walkthrough `recent_review` range covering the new SHA
+   — see *Triaging* below),
    confirm no active `mr_rework` remains and CI is green on that head, THEN merge.
 
 **When this session still fixes locally (mr_rework will not or cannot):**

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -67,7 +67,9 @@ Below, a run id is written `RUN` and a PR number `PR` in the example commands.
    result → diagnose (see *When a run fails*) and stop.
 6. **Get the MR and review the diff.** `uzi run get RUN --field mr_web_url`, then review
    (see *Reviewing the diff* below), plus `gh pr diff`. Verify the diff against the
-   approved plan.
+   approved plan. **Once CodeRabbit lands findings, uzi's own `mr_rework` usually fixes
+   them itself** — defer to it and review its fix before merging (see *uzi may fix the
+   CodeRabbit findings ITSELF*).
 7. **Merge** (see *Merging past branch protection*).
 8. **Watch post-merge CI and fix** (see *Post-merge CI*).
 
@@ -240,6 +242,65 @@ tracking ref never held: `git apply r/issue-N.uncommitted.patch` if that file is
 not-yet-added files, which the patch does not). Then `git rebase origin/main` and gate +
 PR + admin-merge as above.
 
+## uzi may fix the CodeRabbit findings ITSELF (mr_rework) — coordinate, don't collide
+
+**Before you fix a finding locally or merge, check whether uzi is already reworking the
+MR.** The **MR review-watcher** (`mr_rework`, `docs/mr-review-watcher.md`) is **on by
+default** for every opted-in user (opt-in is itself the default), with a per-user opt-out
+and an admin `mr_rework_enabled` kill-switch. On the same poll tick that watches MRs, uzi
+checks every open MR of one of your **completed issue runs** and — when the head pipeline
+is **green**, the review has **settled** (newest comment a few minutes old, written against
+the current head), there is **≥1 review comment it has not acted on**, and the MR is under
+its per-MR rework cap — queues an **auto-approved `mr_rework` run**. That run reads the
+review comments (**CodeRabbit's included**; human reviewers too; uzi's own status notes
+filtered out), reworks the branch **in place** on the same `agent/issue-*` branch, replies
+in-thread and resolves threads, and **pushes a fix commit**. It **never merges** (the four
+guardrail layers still hold), so the merge stays THIS session's job.
+
+The hazard is a **double-fix collision**: if this session also amends the same branch, the
+two pushes race and conflict, and merging under an in-flight rework throws its work away
+(or fails it against a closed MR). **Measured 2026-08-29** on PR #792 (issue #676): an
+`mr_rework` run (`3374fbf4`, `mr_iid:792`) fixed a CodeRabbit test-scoping finding in place
+while this session was about to merge — caught only by listing `kind=mr_rework` runs, not
+by anything on the PR itself.
+
+**The coordination rule, folded into the flow:**
+
+1. **When CodeRabbit lands with actionable findings, check for an `mr_rework` run on this
+   MR before touching anything:**
+   ```
+   uzi run list --json | jq -r --argjson pr PR '.[]|select(.kind=="mr_rework" and .mr_iid==$pr)|{id,status}'
+   ```
+   `mr_rework` runs carry **`mr_iid`, never `issue_iid`** (their `branch`/`mr_web_url`/
+   `source_run_id` may read null while running — do not key on those). A non-terminal one
+   means uzi is on it.
+2. **If uzi is (or is about to be) reworking, DEFER — do not fix locally, do not merge.**
+   The trigger needs a green pipeline + settled review, so the run may not have spawned yet
+   even though it will; if the findings are uzi-fixable (below) and the owner is opted in,
+   give it a beat and re-check rather than racing in.
+3. **Let it finish, then REVIEW its fix commit like any other diff** (`git show <sha>`).
+   uzi *acting* is not uzi being *right*: confirm the rework actually addressed the
+   finding, added no regression, and did not "fix" a deliberate behavior. A bad rework is a
+   `revise`/`follow-up` to that run or a local correction — never an automatic merge.
+4. **Its push retriggers CodeRabbit.** Wait for the re-review on the **new head** (signal
+   (c), the walkthrough `recent_review` range covering the new SHA — see *Triaging* below),
+   confirm no active `mr_rework` remains and CI is green on that head, THEN merge.
+
+**When this session still fixes locally (mr_rework will not or cannot):**
+- the owner is **opted out**, or the admin **kill-switch** is off, so no rework fires;
+- a **`.github/workflows` finding** — the worker lacks `workflow` scope, so uzi cannot
+  touch it (nor can a re-run); that is yours, on a CI-only PR;
+- a **base-realignment inherited finding** (a workflow file already on `main`) — not the
+  PR's to fix at all;
+- `mr_rework` **failed or hit its per-MR cap** with findings still open. Its pre-0.68.0
+  failure signature is `failure_reason: "issue run claim is missing issue_iid"` (the #784
+  branch-derivation bug, fixed in 0.68.0); on an older server every rework fails this way
+  and the old self-fix flow is the only path.
+
+This is the **first** fork of *Reviewing the diff* and *Triaging CodeRabbit findings*
+below: read those for how to verify and label a finding, but decide **who fixes** it here
+first.
+
 ## Reviewing the diff
 
 The watcher's merge-gate review is a **third** pass, not a first: uzi already ran its own
@@ -306,7 +367,11 @@ deliberate / mock-only** label, and a one-line recommendation. For each, the use
 
 - **Fix locally** — amend the PR's own `agent/issue-*` branch with your own credentials (an
   isolated worktree; `git add` only your files), re-run CI, then merge. Keeps it in the one
-  PR / review / CI cycle. The right default for small, localized findings.
+  PR / review / CI cycle. The right default for small, localized findings — **but first
+  confirm uzi's own `mr_rework` is not already fixing this MR** (see *uzi may fix the
+  CodeRabbit findings ITSELF* above); on a default-enabled instance it usually is, and a
+  local amend then collides with its push. Defer to it, review its fix, and reserve the
+  local amend for the cases it cannot handle.
 - **Skip** — record the reason (deliberate behavior, inherited code, not worth it). A skip is
   a legitimate outcome, not a failure.
 - **Send back to uzi** — as a follow-up **issue** (a full gated run → a *separate* PR to

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -67,9 +67,9 @@ Below, a run id is written `RUN` and a PR number `PR` in the example commands.
    result → diagnose (see *When a run fails*) and stop.
 6. **Get the MR and review the diff.** `uzi run get RUN --field mr_web_url`, then review
    (see *Reviewing the diff* below), plus `gh pr diff`. Verify the diff against the
-   approved plan. **Once CodeRabbit lands findings, uzi's own `mr_rework` usually fixes
-   them itself** — defer to it and review its fix before merging (see *uzi may fix the
-   CodeRabbit findings ITSELF*).
+   approved plan. **Once any review finding lands (CodeRabbit, a human reviewer, or another
+   review bot), uzi's own `mr_rework` usually fixes it itself** — defer to it and review its
+   fix before merging (see *uzi may fix the CodeRabbit findings ITSELF*).
 7. **Merge** (see *Merging past branch protection*).
 8. **Watch post-merge CI and fix** (see *Post-merge CI*).
 
@@ -266,12 +266,19 @@ by anything on the PR itself.
 
 **The coordination rule, folded into the flow:**
 
-1. **When CodeRabbit lands with actionable findings, check for an `mr_rework` run on this
-   MR before touching anything:**
+1. **When ANY review finding lands, check for an `mr_rework` run on this MR before touching
+   anything.** `mr_rework` consumes every unacted review comment — CodeRabbit, a **human
+   reviewer**, and any **third-party review bot** — not just CodeRabbit, so gate the check
+   on *any* finding, or a human/other-bot finding slips into the local-fix path while a
+   rework is being queued and recreates the double-push collision:
    ```
-   uzi run list --json | jq -r --argjson pr PR '.[]|select(.kind=="mr_rework" and .mr_iid==$pr)|{id,status}'
+   uzi run list --json | jq -r --arg repo REPO_ID --argjson pr PR \
+     '.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)|{id,status}'
    ```
-   `mr_rework` runs carry **`mr_iid`, never `issue_iid`** (their `branch`/`mr_web_url`/
+   **Filter on `repo_id` too, not `mr_iid` alone:** `mr_iid` is a per-repo MR number, so
+   across the several repos this skill may drive, two repos can each have an MR with the
+   same number — an `mr_iid`-only match can point at another repo's rework. `mr_rework`
+   runs carry **`repo_id` and `mr_iid`, never `issue_iid`** (their `branch`/`mr_web_url`/
    `source_run_id` may read null while running — do not key on those). A non-terminal one
    means uzi is on it.
 2. **If uzi is (or is about to be) reworking, DEFER — do not fix locally, do not merge.**
@@ -282,12 +289,18 @@ by anything on the PR itself.
    uzi *acting* is not uzi being *right*: confirm the rework actually addressed the
    finding, added no regression, and did not "fix" a deliberate behavior. A bad rework is a
    `revise`/`follow-up` to that run or a local correction — never an automatic merge.
+   **A completed rework may push NO commit at all** — it can judge every finding invalid or
+   already handled and only reply/resolve threads, leaving the branch head unchanged. Then
+   there is nothing to `git show`: confirm the head SHA did not move (`git rev-parse
+   origin/<branch>` unchanged) and proceed on the re-review rather than hunting for a commit
+   that was never made.
 4. **Its push retriggers CodeRabbit.** Wait for the re-review on the **new head** (signal
    (c), the walkthrough `recent_review` range covering the new SHA — see *Triaging* below),
    confirm no active `mr_rework` remains and CI is green on that head, THEN merge.
 
 **When this session still fixes locally (mr_rework will not or cannot):**
-- the owner is **opted out**, or the admin **kill-switch** is off, so no rework fires;
+- the owner is **opted out**, or the admin **kill-switch** is engaged
+  (`mr_rework_enabled=false`), so no rework fires;
 - a **`.github/workflows` finding** — the worker lacks `workflow` scope, so uzi cannot
   touch it (nor can a re-run); that is yours, on a CI-only PR;
 - a **base-realignment inherited finding** (a workflow file already on `main`) — not the

--- a/.claude/skills/uzi-watcher/scripts/watch-pr.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-pr.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# watch-pr.sh — poll a GitHub PR to merge-readiness for the uzi-watcher Auto flow.
+#
+# It combines the three signals a merge decision here actually needs, so a session
+# stops hand-rolling (and mis-writing) the same waiter each run:
+#   1. CI is settled and green on the PR's *current* head;
+#   2. CodeRabbit has reviewed that exact head and left no live (unresolved) inline
+#      findings; and
+#   3. no in-flight uzi `mr_rework` run is reworking this MR (which would race a local
+#      fix or a merge — see SKILL.md, "uzi may fix the CodeRabbit findings ITSELF").
+#
+# Usage: watch-pr.sh OWNER/REPO PR [interval_secs] [max_polls]
+#   interval_secs default 60, max_polls default 60.
+#
+# Exit codes (callers branch on these; keep them stable):
+#   0  merge-ready — CI green on head, CodeRabbit reviewed head with 0 live findings,
+#      and no active mr_rework.
+#   1  red — a required CI check failed on the head.
+#   2  timeout — readiness not reached within max_polls, or the head never resolved.
+#      NOTE: exit 0 is trustworthy; exit 2 means "inspect manually", never "merge".
+#   3  findings — CodeRabbit reviewed the head but left live inline findings to triage.
+#   4  mr_rework active — an mr_rework run is on this MR; defer, let it finish, re-run.
+#
+# "CodeRabbit reviewed this head" is the union of two robust signals, because a
+# zero-actionable incremental review can post NO new review object AND re-anchor no
+# finding (SKILL.md signal (c)): (a) a CodeRabbit review whose commit_id == the head
+# SHA, or (c) the walkthrough comment's recent_review range ending at the head SHA.
+# The script errs toward timeout (exit 2) rather than a false "ready".
+set -euo pipefail
+
+REPO=${1:?usage: watch-pr.sh OWNER/REPO PR [interval_secs] [max_polls]}
+PR=${2:?usage: watch-pr.sh OWNER/REPO PR [interval_secs] [max_polls]}
+INTERVAL=${3:-60}
+MAX=${4:-60}
+
+# uzi repo_id for the mr_rework check. Best-effort: empty when uzi is not configured or
+# the repo is not connected, in which case the mr_rework check is skipped — never a false
+# "active". mr_iid is per-repo, so the run filter matches on repo_id AND mr_iid.
+repo_id=$(uzi repo list --json 2>/dev/null \
+  | jq -r --arg p "$REPO" '.[]|select(.path_with_namespace==$p)|.id' 2>/dev/null | head -1 || true)
+
+i=0
+while [ "$i" -lt "$MAX" ]; do
+  i=$((i + 1))
+
+  head=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)
+  if [ -z "$head" ]; then
+    echo "try $i: head unresolved"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  checks=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null || true)
+  fail=$(printf '%s\n' "$checks" | awk -F'\t' '$2=="fail"{n++} END{print n + 0}')
+  # CodeRabbit's own check is excluded from the pending count — it settles on its own axis.
+  pend=$(printf '%s\n' "$checks" | grep -v -i coderabbit | awk -F'\t' '$2=="pending"{n++} END{print n + 0}')
+
+  mrw_active=0
+  if [ -n "$repo_id" ]; then
+    mrw_active=$(uzi run list --json 2>/dev/null | jq -r \
+      --arg repo "$repo_id" --argjson pr "$PR" \
+      '[.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr
+                   and ((.status|test("completed|failed|cancelled"))|not))]|length' \
+      2>/dev/null || echo 0)
+  fi
+
+  # Signal (a): a CodeRabbit review object on this exact head. Two gotchas handled here:
+  # `gh api --jq` does NOT accept jq's --arg (so the head SHA is passed to standalone jq),
+  # and `gh api --paginate --jq length` counts PER PAGE (so pages are slurped with `-s` and
+  # `.[][]` before counting). The constant bot login is inlined into the filter.
+  # shellcheck disable=SC2016  # $h is a jq var (--arg), must stay single-quoted
+  rev_on_head=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" 2>/dev/null \
+    | jq -rs --arg h "$head" \
+      '[.[][]|select(.user.login=="coderabbitai[bot]" and .commit_id==$h)]|length' \
+      2>/dev/null || echo 0)
+  # Signal (c): the walkthrough recent_review range ending at this head. gh's built-in --jq
+  # is fine here — no shell var in the filter, and per-page emission only feeds the grep.
+  wt_head=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+    --jq '.[]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' \
+    2>/dev/null | grep -oE 'and [0-9a-f]{7,40}' | tail -1 | awk '{print $2}' || true)
+  reviewed_head=0
+  [ "${rev_on_head:-0}" -gt 0 ] && reviewed_head=1
+  if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
+
+  # Live inline findings: CodeRabbit comments still anchored to current code (line != null);
+  # an addressed finding re-anchors to line == null (outdated). Slurp pages, then count once.
+  live=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null \
+    | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]" and .line!=null)]|length' \
+      2>/dev/null || echo 0)
+
+  echo "try $i: head=${head:0:8} ci_fail=$fail ci_pend=$pend mrw_active=$mrw_active reviewed_head=$reviewed_head live_findings=$live"
+
+  if [ "$fail" -gt 0 ]; then echo "RESULT=red"; exit 1; fi
+  if [ "$mrw_active" -gt 0 ]; then echo "RESULT=mr_rework_active"; exit 4; fi
+  if [ "$pend" -eq 0 ] && [ "$reviewed_head" -eq 1 ]; then
+    if [ "$live" -eq 0 ]; then echo "RESULT=ready"; exit 0; fi
+    echo "RESULT=findings live=$live"; exit 3
+  fi
+
+  sleep "$INTERVAL"
+done
+
+echo "RESULT=timeout"
+exit 2

--- a/.claude/skills/uzi-watcher/scripts/watch-pr.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-pr.sh
@@ -34,66 +34,112 @@ PR=${2:?usage: watch-pr.sh OWNER/REPO PR [interval_secs] [max_polls]}
 INTERVAL=${3:-60}
 MAX=${4:-60}
 
-# uzi repo_id for the mr_rework check. Best-effort: empty when uzi is not configured or
-# the repo is not connected, in which case the mr_rework check is skipped — never a false
-# "active". mr_iid is per-repo, so the run filter matches on repo_id AND mr_iid.
-repo_id=$(uzi repo list --json 2>/dev/null \
-  | jq -r --arg p "$REPO" '.[]|select(.path_with_namespace==$p)|.id' 2>/dev/null | head -1 || true)
+# uzi repo_id for the mr_rework check, resolved lazily inside the loop. THREE states are
+# kept distinct so a failed lookup never masquerades as "not connected" (which would skip
+# the rework check and risk a false ready): `repo_known=1` + non-empty id = connected, run
+# the check; `repo_known=1` + empty id = genuinely not connected, safe to skip; `repo_known=0`
+# = the `uzi repo list` never succeeded, an UNKNOWN that blocks readiness. mr_iid is per-repo,
+# so the run filter matches on repo_id AND mr_iid.
+repo_id=""
+repo_known=0
 
 i=0
 while [ "$i" -lt "$MAX" ]; do
   i=$((i + 1))
+  # Any lookup that FAILS (network/API error) sets unknown=1 for this iteration, so the
+  # decision is deferred to the next poll rather than made on a masked zero. A failed lookup
+  # is not the same as a zero result.
+  unknown=0
+
+  if [ "$repo_known" -eq 0 ]; then
+    if rl=$(uzi repo list --json 2>/dev/null); then
+      repo_id=$(printf '%s' "$rl" | jq -r --arg p "$REPO" '.[]|select(.path_with_namespace==$p)|.id' 2>/dev/null | head -1 || true)
+      repo_known=1
+    fi
+  fi
 
   head=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)
   if [ -z "$head" ]; then
-    echo "try $i: head unresolved"
+    echo "try $i: head unresolved (retrying)"
     sleep "$INTERVAL"
     continue
   fi
 
-  checks=$(gh pr checks "$PR" --repo "$REPO" 2>/dev/null || true)
-  fail=$(printf '%s\n' "$checks" | awk -F'\t' '$2=="fail"{n++} END{print n + 0}')
-  # CodeRabbit's own check is excluded from the pending count — it settles on its own axis.
-  pend=$(printf '%s\n' "$checks" | grep -v -i coderabbit | awk -F'\t' '$2=="pending"{n++} END{print n + 0}')
+  # CI: only REQUIRED checks gate (an optional failure must not force red), and `cancel` is
+  # a non-ready state (a cancelled required check = supersession, not green). Parse the JSON
+  # by validity, NOT by gh's exit code — `gh pr checks` exits non-zero merely for pending.
+  fail=0; pend=0; cancel=0
+  cj=$(gh pr checks "$PR" --repo "$REPO" --required --json bucket 2>/dev/null || true)
+  if printf '%s' "$cj" | jq -e . >/dev/null 2>&1; then
+    fail=$(printf '%s' "$cj" | jq '[.[]|select(.bucket=="fail")]|length')
+    pend=$(printf '%s' "$cj" | jq '[.[]|select(.bucket=="pending")]|length')
+    cancel=$(printf '%s' "$cj" | jq '[.[]|select(.bucket=="cancel")]|length')
+  else
+    unknown=1
+  fi
 
+  # mr_rework: an active (non-terminal) run on this (repo_id, mr_iid). Only skip the check on
+  # a KNOWN-not-connected repo; an unresolved repo_id or a failed run-list is unknown.
   mrw_active=0
-  if [ -n "$repo_id" ]; then
-    mrw_active=$(uzi run list --json 2>/dev/null | jq -r \
-      --arg repo "$repo_id" --argjson pr "$PR" \
-      '[.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr
-                   and ((.status|test("completed|failed|cancelled"))|not))]|length' \
-      2>/dev/null || echo 0)
+  if [ "$repo_known" -eq 0 ]; then
+    unknown=1
+  elif [ -n "$repo_id" ]; then
+    if rl2=$(uzi run list --json 2>/dev/null); then
+      mrw_active=$(printf '%s' "$rl2" | jq -r --arg repo "$repo_id" --argjson pr "$PR" \
+        '[.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr
+                     and ((.status|test("completed|failed|cancelled"))|not))]|length' 2>/dev/null || echo 0)
+    else
+      unknown=1
+    fi
   fi
 
   # Signal (a): a CodeRabbit review object on this exact head. Two gotchas handled here:
   # `gh api --jq` does NOT accept jq's --arg (so the head SHA is passed to standalone jq),
-  # and `gh api --paginate --jq length` counts PER PAGE (so pages are slurped with `-s` and
-  # `.[][]` before counting). The constant bot login is inlined into the filter.
-  # shellcheck disable=SC2016  # $h is a jq var (--arg), must stay single-quoted
-  rev_on_head=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" 2>/dev/null \
-    | jq -rs --arg h "$head" \
-      '[.[][]|select(.user.login=="coderabbitai[bot]" and .commit_id==$h)]|length' \
-      2>/dev/null || echo 0)
-  # Signal (c): the walkthrough recent_review range ending at this head. gh's built-in --jq
-  # is fine here — no shell var in the filter, and per-page emission only feeds the grep.
-  wt_head=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-    --jq '.[]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' \
-    2>/dev/null | grep -oE 'and [0-9a-f]{7,40}' | tail -1 | awk '{print $2}' || true)
+  # and `gh api --paginate` emits one array PER PAGE (so pages are slurped with `-s`/`.[][]`
+  # before counting). The constant bot login is inlined into the filter.
   reviewed_head=0
-  [ "${rev_on_head:-0}" -gt 0 ] && reviewed_head=1
-  if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
+  if rev_raw=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" 2>/dev/null); then
+    # shellcheck disable=SC2016  # $h is a jq var (--arg), must stay single-quoted
+    rev_on_head=$(printf '%s' "$rev_raw" | jq -rs --arg h "$head" \
+      '[.[][]|select(.user.login=="coderabbitai[bot]" and .commit_id==$h)]|length' 2>/dev/null || echo 0)
+    [ "${rev_on_head:-0}" -gt 0 ] && reviewed_head=1
+  else
+    unknown=1
+  fi
+  # Signal (c): the walkthrough recent_review range ending at this head — covers the
+  # zero-actionable incremental case, which posts no review object.
+  if issue_c=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null); then
+    wt_head=$(printf '%s' "$issue_c" | jq -rs '.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' 2>/dev/null \
+      | grep -oE 'and [0-9a-f]{7,40}' | tail -1 | awk '{print $2}' || true)
+    if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
+  else
+    unknown=1
+  fi
 
   # Live inline findings: CodeRabbit comments still anchored to current code (line != null);
-  # an addressed finding re-anchors to line == null (outdated). Slurp pages, then count once.
-  live=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null \
-    | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]" and .line!=null)]|length' \
-      2>/dev/null || echo 0)
+  # an addressed finding re-anchors to line == null (outdated).
+  live=0
+  if pull_c=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null); then
+    live=$(printf '%s' "$pull_c" | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]" and .line!=null)]|length' 2>/dev/null || echo 0)
+  else
+    unknown=1
+  fi
 
-  echo "try $i: head=${head:0:8} ci_fail=$fail ci_pend=$pend mrw_active=$mrw_active reviewed_head=$reviewed_head live_findings=$live"
+  echo "try $i: head=${head:0:8} req_fail=$fail req_pend=$pend req_cancel=$cancel mrw_active=$mrw_active reviewed_head=$reviewed_head live_findings=$live${unknown:+ unknown=$unknown}"
+
+  # A failed lookup this iteration: defer, do not decide on masked values.
+  if [ "$unknown" -ne 0 ]; then sleep "$INTERVAL"; continue; fi
 
   if [ "$fail" -gt 0 ]; then echo "RESULT=red"; exit 1; fi
   if [ "$mrw_active" -gt 0 ]; then echo "RESULT=mr_rework_active"; exit 4; fi
-  if [ "$pend" -eq 0 ] && [ "$reviewed_head" -eq 1 ]; then
+  if [ "$pend" -eq 0 ] && [ "$cancel" -eq 0 ] && [ "$reviewed_head" -eq 1 ]; then
+    # Revalidate the head right before deciding (TOCTOU): a push during this iteration would
+    # otherwise let an exit 0 describe an unreviewed head.
+    head2=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)
+    if [ -n "$head2" ] && [ "$head2" != "$head" ]; then
+      echo "try $i: head moved ${head:0:8} -> ${head2:0:8}, re-polling"
+      sleep "$INTERVAL"; continue
+    fi
     if [ "$live" -eq 0 ]; then echo "RESULT=ready"; exit 0; fi
     echo "RESULT=findings live=$live"; exit 3
   fi

--- a/.claude/skills/uzi-watcher/scripts/watch-pr.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-pr.sh
@@ -134,10 +134,11 @@ while [ "$i" -lt "$MAX" ]; do
   if [ "$mrw_active" -gt 0 ]; then echo "RESULT=mr_rework_active"; exit 4; fi
   if [ "$pend" -eq 0 ] && [ "$cancel" -eq 0 ] && [ "$reviewed_head" -eq 1 ]; then
     # Revalidate the head right before deciding (TOCTOU): a push during this iteration would
-    # otherwise let an exit 0 describe an unreviewed head.
+    # otherwise let an exit 0 describe an unreviewed head. Proceed to ready ONLY when the
+    # re-read succeeds AND matches; an empty (failed) re-read is unknown, not a match — defer.
     head2=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)
-    if [ -n "$head2" ] && [ "$head2" != "$head" ]; then
-      echo "try $i: head moved ${head:0:8} -> ${head2:0:8}, re-polling"
+    if [ -z "$head2" ] || [ "$head2" != "$head" ]; then
+      echo "try $i: head unconfirmed (${head:0:8} -> ${head2:0:8}), re-polling"
       sleep "$INTERVAL"; continue
     fi
     if [ "$live" -eq 0 ]; then echo "RESULT=ready"; exit 0; fi


### PR DESCRIPTION
## What

uzi's MR review-watcher (`mr_rework`, `docs/mr-review-watcher.md`) is **on by default** and, on a completed issue run's MR, reworks the branch in place against CodeRabbit (and human) review findings and pushes a fix commit. It never merges. The `uzi-watcher` skill previously assumed *this session* fixes CodeRabbit findings locally, which races that push and can throw the rework away at merge.

## Change

`.claude/skills/uzi-watcher/SKILL.md` gains a coordination section:

- **Detect** an in-flight `mr_rework` run on the MR before fixing or merging (`kind=mr_rework`, `mr_iid==PR`; it carries no `issue_iid`).
- **Defer** to it: don't fix locally, don't merge under it.
- **Review its fix commit** before merging (acting is not the same as being right), then wait for the CodeRabbit re-review of its push on the new head.
- Enumerate when the session **still** fixes locally: `.github/workflows` findings the worker can't push, base-realignment inherited findings, kill-switch off / owner opted out, or a rework that failed (`issue run claim is missing issue_iid`, the pre-0.68.0 #784 bug) or hit its per-MR cap.

Pointers added to loop step 6 and the "Fix locally" triage option.

## Evidence

Measured 2026-08-29 on PR #792 (issue #676): an `mr_rework` run (`3374fbf4`, `mr_iid:792`) fixed a CodeRabbit test-scoping finding in place while this session was about to merge, caught only by listing `kind=mr_rework` runs.

Docs-only; `agnix` validates 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pull request readiness checker that monitors required CI checks, automated review coverage, live findings, and active rework.
  * Added clear outcomes for ready, failed or cancelled checks, unresolved updates, outstanding findings, active rework, and API lookup issues.
  * Automatically rechecks the pull request after head changes to ensure readiness and findings reflect the latest updates.
* **Documentation**
  * Clarified pushed-fix detection, no-commit outcomes, local-fix guidance, readiness polling, and maintenance procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->