### PR TITLE
test(branding): replace tautological querySelector('svg') with a distinct fallback mark

### DIFF
--- a/web/src/components/AppShell.branding.test.tsx
+++ b/web/src/components/AppShell.branding.test.tsx
@@ -151,14 +151,15 @@ describe("AppShell branding — durable credit (D3)", () => {
 
 describe("AppShell branding — app mark", () => {
   it("default mode: no app-logo <img> on any surface, FactoryIcon + literals render", async () => {
-    const { container } = renderShell();
+    renderShell();
     fireEvent.click(screen.getByLabelText("Open navigation")); // co-mount the drawer
     // Literals render on every mark (name kept in default mode).
     expect((await screen.findAllByText(NAME_RE)).length).toBeGreaterThan(0);
     await waitFor(() => expect(mockApi.branding).toHaveBeenCalled());
     expect(screen.queryAllByTestId("app-logo-img")).toHaveLength(0);
-    // The trusted inline FactoryIcon SVG is what renders instead.
-    expect(container.querySelector("svg")).not.toBeNull();
+    // The trusted inline FactoryIcon fallback renders instead — assert THAT mark, not any
+    // svg on the page (nav icons make a bare querySelector("svg") tautological).
+    expect(screen.queryAllByTestId("app-mark-fallback").length).toBeGreaterThan(0);
   });
 
   it("custom + present: renders <img src='/api/branding/logo/app'>", async () => {
@@ -171,11 +172,11 @@ describe("AppShell branding — app mark", () => {
 
   it("custom + not present: renders the inline FactoryIcon, no app-logo <img>", async () => {
     mockApi.branding.mockResolvedValue(brandingWith({ app_logo_mode: "custom", app_logo_present: false }));
-    const { container } = renderShell();
+    renderShell();
     await waitFor(() => expect(mockApi.branding).toHaveBeenCalled());
     expect(screen.queryAllByTestId("app-logo-img")).toHaveLength(0);
-    // The trusted inline FactoryIcon SVG renders instead of a /brand-default.svg <img>.
-    expect(container.querySelector("svg")).not.toBeNull();
+    // The trusted inline FactoryIcon fallback renders instead of a /brand-default.svg <img>.
+    expect(screen.queryAllByTestId("app-mark-fallback").length).toBeGreaterThan(0);
   });
 
   it("preset mode (metaminds): renders <img src='/brand-presets/metaminds.svg'>", async () => {
@@ -188,10 +189,11 @@ describe("AppShell branding — app mark", () => {
 
   it("preset mode, unknown slug: renders the inline FactoryIcon, no app-logo <img>", async () => {
     mockApi.branding.mockResolvedValue(brandingWith({ app_logo_mode: "preset", app_logo_preset: "nope" }));
-    const { container } = renderShell();
+    renderShell();
     await waitFor(() => expect(mockApi.branding).toHaveBeenCalled());
     expect(screen.queryAllByTestId("app-logo-img")).toHaveLength(0);
-    expect(container.querySelector("svg")).not.toBeNull();
+    // Assert the FactoryIcon fallback mark specifically, not any svg on the page.
+    expect(screen.queryAllByTestId("app-mark-fallback").length).toBeGreaterThan(0);
   });
 });
 

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -285,7 +285,7 @@ function AppMark({ branding, className }: { branding: Branding | null; className
           className="h-full w-full object-contain"
         />
       ) : (
-        <FactoryIcon />
+        <FactoryIcon data-testid="app-mark-fallback" />
       )}
     </span>
   );


### PR DESCRIPTION
## What

The three AppShell app-mark **fallback** tests (default mode, custom+no-upload, preset+unknown-slug) asserted `container.querySelector("svg") != null` to prove the `FactoryIcon` fallback renders. That is **vacuous**: the shell always renders svgs (nav icons), so the assertion passes even if the fallback mark is removed entirely.

## Change

- `AppShell.tsx`: tag the `AppMark` fallback `FactoryIcon` with `data-testid="app-mark-fallback"`.
- `AppShell.branding.test.tsx`: assert `queryAllByTestId("app-mark-fallback")` in all three fallback tests instead of any-svg-present.

## Provenance

Salvaged from the now-closed **#795** (a stale `mr_rework` artifact on `agent/issue-780` that could not be merged — its branch was far behind main). #795's rework fixed two of the three sites; the default-mode site carried the same tautology and is fixed here too.

## Validation

`AppShell.branding.test.tsx`: 30/30 pass under node@24. `data-testid` forwards through `FactoryIcon` → `Icon` → svg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app branding fallback’s identification for more reliable rendering checks.
  * Prevented unrelated navigation icons from being mistaken for the fallback app mark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->