### PR TITLE
Owner-guidance overlay for sweep default schedules (extend #662 to sweeps)

### DIFF
--- a/api/cmd/uzi/schedule.go
+++ b/api/cmd/uzi/schedule.go
@@ -769,9 +769,9 @@ func newScheduleEditCmd(env Env, gf *globalFlags) *cobra.Command {
 	edit.Flags().StringArray("label", nil, "replace the sweep label selector (repeatable; sweep-target schedules only)")
 	edit.Flags().Bool("auto-approve", true, "set whether a fired run proceeds past the plan gate unattended")
 	edit.Flags().Bool("wait-on-limit", true, "set whether a fired run parks on the usage limit instead of failing")
-	edit.Flags().String("guidance", "", "change owner guidance injected into the run instruction (issue/sweep targets, or a prompt-target default)")
+	edit.Flags().String("guidance", "", "change owner guidance injected into the run instruction (issue/sweep targets, or a prompt-target or sweep-target default)")
 	edit.Flags().Int("max-issues", 10, "change the per-fire sweep cap, oldest-first (sweep target only)")
-	edit.Flags().Bool("clear-guidance", false, "clear stored guidance back to none (issue/sweep targets, or a prompt-target default)")
+	edit.Flags().Bool("clear-guidance", false, "clear stored guidance back to none (issue/sweep targets, or a prompt-target or sweep-target default)")
 	edit.Flags().Bool("clear-max-issues", false, "clear the sweep cap back to unlimited (sweep target only)")
 	edit.Flags().Bool("apply-model-to-agents", false, "set whether the schedule's model also overrides every subagent's model pin")
 	edit.Flags().String("repo", "", "repoint the schedule to another repo by id (sweep/prompt targets; an issue-target schedule cannot be repointed)")
@@ -957,33 +957,36 @@ func buildScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO) (apity
 // refused client-side rather than reporting a false "updated". They are still restated from
 // the fetched row so a value is never dropped should the server later honor them.
 //
-// Guidance is owner-editable on a PROMPT-target default (PRD #662 M1): --guidance sets it
-// and --clear-guidance blanks it, and the fetched value is RESTATED so a partial edit does
-// not wipe it under the server's replace-semantics. On an issue/sweep default guidance
-// stays catalog-owned, so those flags are rejected client-side. The remaining catalog-owned
-// flags (--prompt/--label/--repo/--at) are likewise rejected client-side with a usage error
-// pointing at `schedule clone`.
+// Guidance is owner-editable on a PROMPT-target default (PRD #662 M1) and a SWEEP-target
+// default (issue #675, where it is an overlay composed onto the baked catalog guidance at
+// fire time): --guidance sets it and --clear-guidance blanks it, and the fetched value is
+// RESTATED so a partial edit does not wipe it under the server's replace-semantics (for a
+// sweep default the restated value is the OVERLAY, never the baked catalog value). On an
+// issue/self_improve default guidance stays catalog-owned, so those flags are rejected
+// client-side. The remaining catalog-owned flags (--prompt/--label/--repo/--at) are likewise
+// rejected client-side with a usage error pointing at `schedule clone`.
 func buildDefaultScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO) (apitypes.ScheduleRequest, error) {
 	f := cmd.Flags()
 
 	// Catalog-owned fields cannot be edited on a default; fail fast client-side with a
 	// message naming clone, rather than forwarding to a server 400. Guidance is the one
-	// exception: on a PROMPT-target default the owner may edit it (PRD #662 M1 made the
-	// server accept an owner guidance change there), so it is handled below rather than in
-	// this blanket reject.
+	// exception: on a PROMPT-target default (PRD #662 M1) or a SWEEP-target default (issue
+	// #675) the owner may edit it, so it is handled below rather than in this blanket reject.
 	for _, flag := range []string{"prompt", "label", "repo", "at"} {
 		if f.Changed(flag) {
 			return apitypes.ScheduleRequest{}, uzicli.Exitf(uzicli.ExitUsage,
 				"--%s is catalog-owned on a default schedule; clone it first with `uzi schedule clone`", flag)
 		}
 	}
-	// Guidance is owner-editable ONLY on a prompt-target default. On an issue/sweep default
-	// it stays catalog-owned (the server still 400s a guidance edit), so reject it here.
+	// Guidance is owner-editable on a prompt-target default (issue #662) and on a sweep-target
+	// default (issue #675: an owner overlay composed onto the baked catalog guidance at fire
+	// time). On an issue/self_improve default it stays catalog-owned (the server still 400s a
+	// guidance edit), so reject it here.
 	guidanceSet := f.Changed("guidance")
 	clearGuidance := f.Changed("clear-guidance")
-	if (guidanceSet || clearGuidance) && s.Target != schedTargetPrompt {
+	if (guidanceSet || clearGuidance) && s.Target != schedTargetPrompt && s.Target != schedTargetSweep {
 		return apitypes.ScheduleRequest{}, uzicli.Exitf(uzicli.ExitUsage,
-			"--guidance/--clear-guidance are catalog-owned on an issue/sweep default schedule; clone it first with `uzi schedule clone`")
+			"--guidance/--clear-guidance are catalog-owned on this default schedule; clone it first with `uzi schedule clone`")
 	}
 	if guidanceSet && clearGuidance {
 		return apitypes.ScheduleRequest{}, uzicli.Exitf(uzicli.ExitUsage, "--guidance and --clear-guidance are mutually exclusive")
@@ -1023,14 +1026,15 @@ func buildDefaultScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO)
 	if s.Target == schedTargetSweep {
 		req.MaxIssues = s.MaxIssues
 	}
-	// Guidance on a PROMPT-target default is owner-editable and uses replace-semantics on
-	// the server, so RESTATE the fetched value — otherwise a partial edit (e.g. --cron
-	// alone) would send a nil guidance and wipe the stored value. The DTO usually surfaces a
-	// prompt default's Guidance as a non-nil pointer (possibly &""), and it is nil only in the
-	// gone-catalog-slug-with-no-stored-guidance edge; the M1 server guard accepts either for a
-	// prompt default (nil keeps NULL, no wipe). Issue/sweep defaults never reach here with a
-	// guidance flag, so they still send no guidance.
-	if s.Target == schedTargetPrompt {
+	// Guidance on a PROMPT-target (issue #662) or SWEEP-target (issue #675) default is
+	// owner-editable and uses replace-semantics on the server, so RESTATE the fetched value —
+	// otherwise a partial edit (e.g. --cron alone) would send a nil guidance and wipe the
+	// stored value. For a sweep default s.Guidance is the OVERLAY (nil when no overlay is set;
+	// the baked catalog value is in s.BakedGuidance and is NEVER restated), so this never
+	// echoes the baked value back into the column. The server guard accepts a nil guidance
+	// (keeps NULL, no wipe). Issue/self_improve defaults never reach here with a guidance flag,
+	// so they still send no guidance.
+	if s.Target == schedTargetPrompt || s.Target == schedTargetSweep {
 		req.Guidance = s.Guidance
 	}
 
@@ -1065,7 +1069,7 @@ func buildDefaultScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO)
 		req.MaxIssues = nil
 		changed = true
 	}
-	// Guidance overlay (prompt-target default only; guarded above). Restating the fetched
+	// Guidance overlay (prompt- or sweep-target default; guarded above). Restating the fetched
 	// value does NOT by itself count as a change — only an explicit flag flips `changed`.
 	if guidanceSet {
 		v, _ := f.GetString("guidance")
@@ -1298,6 +1302,12 @@ func renderScheduleDetail(p *uzicli.Printer, s apitypes.ScheduleDTO) error {
 	}
 	if s.Target == schedTargetIssue || s.Target == schedTargetSweep {
 		rows = append(rows, []string{"GUIDANCE", strOr(s.Guidance, "-")})
+	}
+	// A sweep default surfaces the read-only baked catalog guidance separately from the owner
+	// overlay (issue #675); BakedGuidance is nil for every other row, so the row is emitted
+	// only when present.
+	if s.BakedGuidance != nil {
+		rows = append(rows, []string{"BAKED_GUIDANCE", strOr(s.BakedGuidance, "-")})
 	}
 	rows = append(rows,
 		[]string{"MODEL", strOr(s.Model, "-")},

--- a/api/cmd/uzi/schedule_test.go
+++ b/api/cmd/uzi/schedule_test.go
@@ -874,29 +874,33 @@ func TestScheduleEditNotFound(t *testing.T) {
 	}
 }
 
-// editDefaultSweepFixture seeds a DEFAULT-origin sweep schedule (PRD #589) under the given
-// id. A default sweep carries a resolved catalog prompt/labels and a max_issues cap; the
-// edit path may only touch the catalog-editable fields, so these tests assert the PATCH
-// carries ONLY those (Target/Labels/Prompt/Guidance/Timing left at zero for the server guard).
+// editDefaultSweepFixture seeds a DEFAULT-origin sweep schedule (PRD #589, extended by issue
+// #675) under the given id. A default sweep carries resolved catalog labels, a max_issues cap,
+// a read-only BakedGuidance (the catalog guidance) and an owner-editable Guidance OVERLAY. The
+// edit path may touch the catalog-editable fields AND the guidance overlay (issue #675), so
+// these tests assert the PATCH restates the overlay (never the baked value) while leaving
+// Target/Labels/Prompt/Timing at zero for the server guard.
 func editDefaultSweepFixture(id string) *uzicli.FakeClient {
 	cap3 := 3
 	return &uzicli.FakeClient{
 		ScheduleByID: map[string]apitypes.ScheduleDTO{
 			id: {
-				ID:          id,
-				RepoID:      "11111111-1111-1111-1111-111111111111",
-				Origin:      "default",
-				Target:      "sweep",
-				Labels:      []string{"bug"},
-				Timing:      "recurring",
-				CronExpr:    "0 9 * * 1",
-				Timezone:    "UTC",
-				AutoApprove: true,
-				WaitOnLimit: true,
-				Enabled:     true,
-				Status:      "active",
-				MaxIssues:   &cap3,
-				Model:       sptr("fable"),
+				ID:            id,
+				RepoID:        "11111111-1111-1111-1111-111111111111",
+				Origin:        "default",
+				Target:        "sweep",
+				Labels:        []string{"bug"},
+				Timing:        "recurring",
+				CronExpr:      "0 9 * * 1",
+				Timezone:      "UTC",
+				AutoApprove:   true,
+				WaitOnLimit:   true,
+				Enabled:       true,
+				Status:        "active",
+				MaxIssues:     &cap3,
+				Guidance:      sptr("sweep overlay"),
+				BakedGuidance: sptr("baked catalog steer"),
+				Model:         sptr("fable"),
 			},
 		},
 		PatchedSchedule: apitypes.ScheduleDTO{ID: id, Origin: "default", Target: "sweep", Timing: "recurring", CronExpr: "0 9 * * 1", Enabled: true},
@@ -932,10 +936,11 @@ func editDefaultPromptFixture(id string) *uzicli.FakeClient {
 	}
 }
 
-// TestScheduleEditDefaultSendsOnlyEditableFields (PRD #589): editing a default sweep sends a
-// FRESH minimal PATCH — only the catalog-editable fields — leaving the catalog-owned ones at
-// zero so the server's patchDefaultScheduleConfig guard passes, while restating the sweep cap
-// and model under replace-semantics.
+// TestScheduleEditDefaultSendsOnlyEditableFields (PRD #589, issue #675): editing a default
+// sweep sends a FRESH minimal PATCH — only the catalog-editable fields — leaving the
+// catalog-owned ones at zero so the server's patchDefaultScheduleConfig guard passes, while
+// restating the sweep cap, model and the owner guidance OVERLAY under replace-semantics. The
+// baked catalog guidance is NEVER restated (it stays in BakedGuidance, catalog-owned).
 func TestScheduleEditDefaultSendsOnlyEditableFields(t *testing.T) {
 	fc := editDefaultSweepFixture("sch_d")
 	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_d", "--tz", "Europe/Bucharest")
@@ -952,8 +957,8 @@ func TestScheduleEditDefaultSendsOnlyEditableFields(t *testing.T) {
 	if req.Prompt != "" {
 		t.Errorf("prompt = %q, want empty (catalog-owned, left at zero)", req.Prompt)
 	}
-	if req.Guidance != nil {
-		t.Errorf("guidance = %v, want nil (catalog-owned, left at zero)", req.Guidance)
+	if req.Guidance == nil || *req.Guidance != "sweep overlay" {
+		t.Errorf("guidance = %v, want the owner overlay restated (not the baked value, not nil)", req.Guidance)
 	}
 	if req.Timing != "" {
 		t.Errorf("timing = %q, want empty (server forces recurring)", req.Timing)
@@ -1047,8 +1052,6 @@ func TestScheduleEditDefaultCatalogOwnedFlagsRejected(t *testing.T) {
 	}{
 		{"label", false, []string{"edit", "sch_d", "--label", "bug"}},
 		{"prompt", true, []string{"edit", "sch_dp", "--prompt", "x"}},
-		{"guidance", false, []string{"edit", "sch_d", "--guidance", "x"}},
-		{"clear-guidance", false, []string{"edit", "sch_d", "--clear-guidance"}},
 		{"repo", false, []string{"edit", "sch_d", "--repo", "22222222-2222-2222-2222-222222222222"}},
 		{"at", false, []string{"edit", "sch_d", "--at", "2026-08-08T09:00:00Z"}},
 		{"apply-model-to-agents", false, []string{"edit", "sch_d", "--apply-model-to-agents=true"}},
@@ -1149,9 +1152,64 @@ func TestScheduleEditDefaultPromptCronRestatesGuidance(t *testing.T) {
 	}
 }
 
-// TestScheduleEditDefaultNonPromptGuidanceRejected (PRD #662 M2): --guidance on an issue or
-// sweep default stays catalog-owned and is rejected client-side with no PATCH sent, and
-// --guidance + --clear-guidance together on a prompt default is a usage error.
+// TestScheduleEditDefaultSweepGuidance (issue #675): --guidance on a sweep default is now
+// owner-editable and builds a PATCH carrying the new overlay, leaving every catalog-owned
+// field at zero (the baked value is never restated).
+func TestScheduleEditDefaultSweepGuidance(t *testing.T) {
+	fc := editDefaultSweepFixture("sch_d")
+	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_d", "--guidance", "steer the sweep")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut)
+	}
+	if fc.LastPatchSchedID != "sch_d" {
+		t.Fatalf("patch should have been sent for sch_d, got id %q", fc.LastPatchSchedID)
+	}
+	req := fc.LastPatchSchedReq
+	if req.Guidance == nil || *req.Guidance != "steer the sweep" {
+		t.Errorf("guidance = %v, want \"steer the sweep\"", req.Guidance)
+	}
+	if req.Target != "" || req.Prompt != "" || len(req.Labels) != 0 {
+		t.Errorf("catalog-owned fields set: target=%q prompt=%q labels=%v, want all zero", req.Target, req.Prompt, req.Labels)
+	}
+}
+
+// TestScheduleEditDefaultSweepCronRestatesOverlay (issue #675): a --tz-only edit of a sweep
+// default RESTATES the stored owner overlay (replace-semantics) rather than wiping it, and
+// never restates the read-only baked catalog guidance.
+func TestScheduleEditDefaultSweepCronRestatesOverlay(t *testing.T) {
+	fc := editDefaultSweepFixture("sch_d")
+	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_d", "--tz", "UTC")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut)
+	}
+	req := fc.LastPatchSchedReq
+	if req.Guidance == nil || *req.Guidance != "sweep overlay" {
+		t.Errorf("guidance = %v, want the stored overlay restated (not wiped)", req.Guidance)
+	}
+	if req.Guidance != nil && *req.Guidance == "baked catalog steer" {
+		t.Errorf("guidance = %q, must NOT be the baked catalog value", *req.Guidance)
+	}
+}
+
+// TestScheduleEditDefaultSweepClearGuidance (issue #675): --clear-guidance on a sweep default
+// sends a non-nil empty string (the server treats blank as NULL, and the default guard
+// requires a non-nil guidance).
+func TestScheduleEditDefaultSweepClearGuidance(t *testing.T) {
+	fc := editDefaultSweepFixture("sch_d")
+	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_d", "--clear-guidance")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut)
+	}
+	if req := fc.LastPatchSchedReq; req.Guidance == nil || *req.Guidance != "" {
+		t.Errorf("guidance = %v, want a non-nil empty string", req.Guidance)
+	}
+}
+
+// TestScheduleEditDefaultNonPromptGuidanceRejected (PRD #662 M2, issue #675): --guidance on an
+// issue default stays catalog-owned and is rejected client-side with no PATCH sent, and
+// --guidance + --clear-guidance together on a prompt default is a usage error. A SWEEP default
+// is NO LONGER here — issue #675 made its guidance an owner-editable overlay (covered by
+// TestScheduleEditDefaultSweepGuidance).
 func TestScheduleEditDefaultNonPromptGuidanceRejected(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1159,7 +1217,6 @@ func TestScheduleEditDefaultNonPromptGuidanceRejected(t *testing.T) {
 		args []string
 	}{
 		{"issue default guidance", editDefaultIssueFixture("sch_di"), []string{"edit", "sch_di", "--guidance", "x"}},
-		{"sweep default guidance", editDefaultSweepFixture("sch_d"), []string{"edit", "sch_d", "--guidance", "x"}},
 		{"prompt default guidance+clear", editDefaultPromptFixture("sch_dp"), []string{"edit", "sch_dp", "--guidance", "y", "--clear-guidance"}},
 	}
 	for _, tc := range cases {

--- a/api/internal/apitypes/schedule.go
+++ b/api/internal/apitypes/schedule.go
@@ -91,8 +91,15 @@ type ScheduleDTO struct {
 	MaxIssues *int `json:"max_issues"`
 	// Guidance is optional owner-authored steering (PRD #274 M3, issue/sweep targets only):
 	// injected into the run instruction as a delineated "how" section. nil means none (NULL
-	// or empty in the DB).
+	// or empty in the DB). For a default SWEEP row (issue #675) Guidance is the owner OVERLAY
+	// composed onto the baked catalog guidance at fire time (the baked value is in
+	// BakedGuidance), not the catalog value itself.
 	Guidance *string `json:"guidance"`
+	// BakedGuidance carries the RESOLVED catalog guidance for a default SWEEP row
+	// (issue #675), shown read-only in the modal. It is nil for prompt/self_improve/user
+	// rows (a prompt default's baked content is Prompt). Guidance is reserved for the
+	// owner overlay appended at fire time.
+	BakedGuidance *string `json:"baked_guidance"`
 	// Model is the per-schedule model override (PRD #300, all targets): nil means inherit
 	// the owner's per-user Worker model (NULL or empty in the DB), a value is the model a
 	// schedule fires its runs on. Validated via agenttmpl.ValidateModel; replace-semantics

--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -546,9 +546,13 @@ func TestPatchDefaultPromptGuidanceLiveDB(t *testing.T) {
 	}
 }
 
-// TestPatchDefaultSweepGuidanceRejectedLiveDB (issue #662): guidance stays catalog-owned for
-// a SWEEP default — a guidance PATCH is a 400.
-func TestPatchDefaultSweepGuidanceRejectedLiveDB(t *testing.T) {
+// TestPatchDefaultSweepGuidanceOverlayLiveDB (issue #675) is the sweep analogue of the prompt
+// overlay flagship: a SWEEP default surfaces the catalog guidance as read-only BakedGuidance
+// with a NULL overlay (Guidance nil, not customized); accepts an owner guidance OVERLAY PATCH
+// that persists (round-trips through the DTO's Guidance while BakedGuidance stays the catalog
+// value), sets customized; rejects an oversized overlay with a 422; and a Reset clears the
+// overlay back to NULL and un-customizes, leaving BakedGuidance intact.
+func TestPatchDefaultSweepGuidanceOverlayLiveDB(t *testing.T) {
 	ctx := context.Background()
 	f := newScheduleFixture(ctx, t)
 
@@ -556,8 +560,71 @@ func TestPatchDefaultSweepGuidanceRejectedLiveDB(t *testing.T) {
 	if code != http.StatusCreated {
 		t.Fatalf("enable status = %d, want 201", code)
 	}
-	if got := f.patchStatus(t, f.owner.ID, dto.ID, `{"guidance":"owner tweak"}`); got != http.StatusBadRequest {
-		t.Fatalf("sweep guidance patch status = %d, want 400", got)
+	job, _ := schedtmpl.BySlug("bug-triage")
+	if job.Guidance == "" {
+		t.Fatal("bug-triage catalog entry has no guidance to discriminate on")
+	}
+	// A freshly enabled sweep default: the catalog guidance is the read-only BAKED value; the
+	// owner overlay column is NULL (Guidance nil), and the row is not customized.
+	if dto.BakedGuidance == nil || *dto.BakedGuidance != job.Guidance {
+		t.Fatalf("fresh sweep default baked_guidance = %v, want the catalog guidance %q", dto.BakedGuidance, job.Guidance)
+	}
+	if dto.Guidance != nil {
+		t.Fatalf("fresh sweep default overlay guidance = %v, want nil (NULL overlay)", dto.Guidance)
+	}
+	if dto.Customized {
+		t.Fatal("fresh sweep default with a NULL overlay is customized, want false")
+	}
+
+	const overlay = "prefer table-driven tests"
+	patched := f.patchDefault(t, f.owner.ID, dto.ID, `{"guidance":`+jsonString(overlay)+`}`)
+	if patched.Guidance == nil || *patched.Guidance != overlay {
+		t.Fatalf("patched overlay = %v, want the owner overlay persisted", patched.Guidance)
+	}
+	if patched.BakedGuidance == nil || *patched.BakedGuidance != job.Guidance {
+		t.Fatalf("patched baked_guidance = %v, want the catalog guidance unchanged", patched.BakedGuidance)
+	}
+	if !patched.Customized {
+		t.Fatal("overlay divergence: customized = false, want true")
+	}
+
+	// It really persisted: re-read via GET surfaces the stored overlay and the baked value.
+	got, gcode := f.getSchedule(t, f.owner.ID, dto.ID)
+	if gcode != http.StatusOK {
+		t.Fatalf("re-read status = %d, want 200", gcode)
+	}
+	if got.Guidance == nil || *got.Guidance != overlay {
+		t.Fatalf("re-read overlay = %v, want the persisted owner overlay", got.Guidance)
+	}
+	if got.BakedGuidance == nil || *got.BakedGuidance != job.Guidance {
+		t.Fatalf("re-read baked_guidance = %v, want the catalog guidance", got.BakedGuidance)
+	}
+
+	// Oversized overlay → 422.
+	huge := strings.Repeat("x", MaxGuidanceBytes+1)
+	if code := f.patchStatus(t, f.owner.ID, dto.ID, `{"guidance":`+jsonString(huge)+`}`); code != http.StatusUnprocessableEntity {
+		t.Fatalf("oversized overlay patch status = %d, want 422", code)
+	}
+
+	// Reset clears the overlay back to NULL and un-customizes; the baked value survives.
+	resetReq := userReq(http.MethodPost, "/api/schedules/"+dto.ID+"/reset", "", f.owner.ID, map[string]string{"id": dto.ID})
+	resetRec := httptest.NewRecorder()
+	f.h.ResetSchedule(resetRec, resetReq)
+	if resetRec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200 (body %s)", resetRec.Code, resetRec.Body.String())
+	}
+	var reset apitypes.ScheduleDTO
+	if err := json.Unmarshal(resetRec.Body.Bytes(), &reset); err != nil {
+		t.Fatalf("decode reset: %v", err)
+	}
+	if reset.Guidance != nil {
+		t.Fatalf("reset overlay = %v, want nil (cleared back to NULL)", reset.Guidance)
+	}
+	if reset.BakedGuidance == nil || *reset.BakedGuidance != job.Guidance {
+		t.Fatalf("reset baked_guidance = %v, want the catalog guidance intact", reset.BakedGuidance)
+	}
+	if reset.Customized {
+		t.Fatal("reset customized = true, want false")
 	}
 }
 

--- a/api/internal/handler/schedules.go
+++ b/api/internal/handler/schedules.go
@@ -791,6 +791,9 @@ func (h *Handler) CloneSchedule(w http.ResponseWriter, r *http.Request) {
 			prompt = pgtype.Text{String: job.Prompt, Valid: true}
 		case "sweep":
 			labels = marshalLabels(job.Labels)
+			// Baked-only clone (issue #675): the cloned user row carries the BAKED catalog
+			// guidance; the source row's stored owner OVERLAY (cur.Guidance, reset to empty
+			// above) is intentionally discarded, matching the prompt-clone in #662.
 			if strings.TrimSpace(job.Guidance) != "" {
 				guidance = pgtype.Text{String: job.Guidance, Valid: true}
 			}
@@ -998,18 +1001,22 @@ func cloneNextFire(cur store.RunSchedule, now time.Time) (pgtype.Timestamptz, er
 // M2). Only the catalog-inherited editable fields (cron_expr, timezone, model, auto_approve,
 // wait_on_limit, and — for a sweep — max_issues) may be edited; prompt/labels/target/repo/
 // timing are catalog-owned and a request touching them is a 400. Guidance is catalog-owned
-// for issue/sweep/self_improve defaults but owner-editable for a PROMPT default (issue #662:
-// it overlays the catalog prompt at fire time), where it takes replace-semantics under an
-// 8 KiB cap. It recomputes next_fire_at, recomputes the customized flag (any editable field
+// for issue/self_improve defaults but owner-editable for a PROMPT default (issue #662: it
+// overlays the catalog prompt at fire time) and for a SWEEP default (issue #675: an owner
+// OVERLAY composed onto the baked catalog guidance at fire time — the baked value stays
+// catalog-owned and is surfaced read-only as BakedGuidance). The editable overlay takes
+// replace-semantics under an 8 KiB cap. It recomputes next_fire_at, recomputes the customized flag (any editable field
 // diverging from the catalog default OR the row was already customized), and persists via
 // UpdateRunSchedule keeping the catalog-owned columns NULL. It writes the HTTP error itself
 // and returns done=false on any failure; on success it returns the updated row and done=true.
 func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Request, user store.User, id uuid.UUID, cur store.RunSchedule, req apitypes.ScheduleRequest) (store.RunSchedule, bool) {
-	// Owner-guidance overlay (issue #662): a DEFAULT PROMPT job carries owner-editable
-	// guidance appended to the catalog-resolved prompt at fire time, so guidance is NOT
-	// catalog-owned for a prompt default. Issue/sweep/self_improve defaults keep guidance
-	// catalog-owned (locked). All the other fields stay catalog-owned for every target.
-	guidanceEditable := cur.Target == "prompt"
+	// Owner-guidance overlay (issue #662, extended by issue #675): a DEFAULT PROMPT job
+	// carries owner-editable guidance appended to the catalog-resolved prompt at fire time,
+	// and a DEFAULT SWEEP job carries an owner OVERLAY composed onto the baked catalog
+	// guidance at fire time — so guidance is NOT catalog-owned for a prompt or sweep default.
+	// Issue/self_improve defaults keep guidance catalog-owned (locked). All the other fields
+	// stay catalog-owned for every target.
+	guidanceEditable := cur.Target == "prompt" || cur.Target == "sweep"
 	if req.Prompt != "" || req.Labels != nil || (!guidanceEditable && req.Guidance != nil) || req.Target != "" ||
 		req.RepoID != "" || req.IssueIID != nil || req.Timing != "" || req.RunAt != nil {
 		locked := "prompt, labels, guidance, target, timing and repo"
@@ -1099,10 +1106,12 @@ func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Requ
 		return store.RunSchedule{}, false
 	}
 
-	// Guidance replace-semantics (issue #662), scoped to a prompt default. A prompt catalog
-	// job carries no guidance, so any persisted non-empty owner guidance is a divergence.
-	// Empty/whitespace clears it back to NULL (an exact-restore un-customizes). For issue/
-	// sweep/self_improve defaults guidance stays NULL — catalog-owned.
+	// Guidance replace-semantics (issue #662, #675), scoped to a prompt or sweep default. The
+	// persisted column holds the owner OVERLAY (a prompt catalog job carries no guidance; a
+	// sweep default's baked guidance stays catalog-owned and is never stored here), so any
+	// persisted non-empty owner guidance is a divergence. Empty/whitespace clears it back to
+	// NULL (an exact-restore un-customizes). For issue/self_improve defaults guidance stays
+	// NULL — catalog-owned.
 	guidance := pgtype.Text{}
 	if guidanceEditable && req.Guidance != nil && strings.TrimSpace(*req.Guidance) != "" {
 		guidance = pgtype.Text{String: *req.Guidance, Valid: true}
@@ -1119,9 +1128,11 @@ func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Requ
 		customized = cur.Customized
 	}
 	// Owner guidance is not one of defaultEditableDiverges' inputs (its signature is
-	// unchanged); OR-in its divergence for a prompt default. Since the catalog prompt job
-	// carries empty guidance, any persisted non-empty guidance diverges — and clearing it
-	// back to empty leaves guidance.Valid false, so an exact-restore still un-customizes.
+	// unchanged); OR-in its divergence for a prompt or sweep default. The stored column holds
+	// only the owner overlay (the baked value is never compared), so any persisted non-empty
+	// overlay diverges — and clearing it back to empty leaves guidance.Valid false, so an
+	// exact-restore still un-customizes. A sweep default with a NULL overlay is therefore not
+	// falsely "customized".
 	if guidanceEditable {
 		customized = customized || guidance.Valid
 	}
@@ -1492,7 +1503,15 @@ func (h *Handler) scheduleDTO(s store.RunSchedule, repoPath string) apitypes.Sch
 			dto.Prompt = job.Prompt
 			dto.Labels = job.Labels
 			g := job.Guidance
-			dto.Guidance = &g
+			// Owner-guidance overlay (issue #675): for a SWEEP default the catalog guidance is
+			// the BAKED value shown read-only; Guidance is reserved for the owner overlay,
+			// populated below from the stored column. For a prompt/other default the baked value
+			// still travels through Guidance as before.
+			if s.Target == "sweep" {
+				dto.BakedGuidance = &g
+			} else {
+				dto.Guidance = &g
+			}
 		}
 	}
 	if s.IssueIid.Valid {

--- a/api/internal/schedsvc/scheduler.go
+++ b/api/internal/schedsvc/scheduler.go
@@ -348,7 +348,24 @@ func (e *Scheduler) fireSweep(ctx context.Context, sched store.RunSchedule) (Fir
 			return FireOutcome{}, fmt.Errorf("marshal catalog labels: %w", mErr)
 		}
 		sched.Labels = labelsJSON
-		sched.Guidance = pgtype.Text{String: job.Guidance, Valid: job.Guidance != ""}
+		// Owner-guidance overlay (issue #675): a default sweep's guidance column holds the
+		// owner OVERLAY (NULL today until one is set). The catalog value is the BAKED guidance.
+		// Compose baked + overlay into the single effective guidance so the one
+		// composeRunDescription call in createIssueRun emits exactly ONE guidance header. An
+		// empty overlay yields effective == baked, i.e. byte-for-byte the prior baked-only
+		// description. An over-long overlay is truncated (tail-first) by composeRunDescription,
+		// so the baked catalog text is preserved before the overlay.
+		overlay := guidanceOf(sched)
+		baked := job.Guidance
+		effective := baked
+		if strings.TrimSpace(overlay) != "" {
+			if strings.TrimSpace(baked) == "" {
+				effective = overlay
+			} else {
+				effective = baked + "\n\n" + overlay
+			}
+		}
+		sched.Guidance = pgtype.Text{String: effective, Valid: effective != ""}
 	}
 	repo, f, err := e.resolveRepoForge(ctx, sched)
 	if err != nil {

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -1942,9 +1942,10 @@ func TestFirePromptDefaultUnknownSlugParks(t *testing.T) {
 }
 
 // TestFireSweepDefaultResolvesFromCatalog is the sweep analogue of the discriminating
-// prompt test: a default-origin sweep row is POISONED with bogus labels and guidance
-// columns, and the fire MUST use the catalog labels (into the candidate query) and the
-// catalog guidance (into the composed run description), never the columns.
+// prompt test. Labels stay catalog-owned: a POISON label column MUST be ignored in favour
+// of the catalog labels driving the candidate query. Guidance is now the owner OVERLAY
+// (issue #675): the catalog guidance is the BAKED value and the guidance column is the
+// overlay, and BOTH are composed into the run description under a SINGLE guidance header.
 func TestFireSweepDefaultResolvesFromCatalog(t *testing.T) {
 	h := newHarness()
 	want, ok := schedtmpl.BySlug("bug-triage")
@@ -1954,6 +1955,7 @@ func TestFireSweepDefaultResolvesFromCatalog(t *testing.T) {
 	if want.Guidance == "" {
 		t.Fatal("bug-triage catalog entry has no guidance to discriminate on")
 	}
+	const overlay = "prefer table-driven tests"
 	h.st.sweepRows = []store.ListSweepCandidateIssuesRow{{ForgeIssueIid: 7}}
 	sched := store.RunSchedule{
 		ID:          uuid.New(),
@@ -1963,7 +1965,7 @@ func TestFireSweepDefaultResolvesFromCatalog(t *testing.T) {
 		Origin:      "default",
 		CatalogSlug: pgtype.Text{String: "bug-triage", Valid: true},
 		Labels:      []byte(`["POISON-LABEL"]`),
-		Guidance:    pgtype.Text{String: "POISON-GUIDANCE-DO-NOT-USE", Valid: true},
+		Guidance:    pgtype.Text{String: overlay, Valid: true},
 		Timing:      "recurring",
 		CronExpr:    pgtype.Text{String: "0 * * * *", Valid: true},
 		Timezone:    "UTC",
@@ -1987,16 +1989,23 @@ func TestFireSweepDefaultResolvesFromCatalog(t *testing.T) {
 	if strings.Contains(string(h.st.sweepLabelParam), "POISON") {
 		t.Fatalf("labels were read from the row column, not the catalog: %s", h.st.sweepLabelParam)
 	}
-	// The per-issue description must carry the CATALOG guidance, not the poison column.
+	// The per-issue description must carry the BAKED catalog guidance AND the owner overlay,
+	// composed under exactly ONE guidance header (baked before overlay).
 	if len(h.runs.autopilot) != 1 {
 		t.Fatalf("autopilot calls = %d, want 1", len(h.runs.autopilot))
 	}
 	desc := h.runs.autopilot[0].description
 	if !strings.Contains(desc, want.Guidance) {
-		t.Fatalf("run description missing catalog guidance; got %q", desc)
+		t.Fatalf("run description missing BAKED catalog guidance; got %q", desc)
 	}
-	if strings.Contains(desc, "POISON") {
-		t.Fatalf("guidance was read from the row column, not the catalog: %q", desc)
+	if !strings.Contains(desc, overlay) {
+		t.Fatalf("run description missing the owner overlay; got %q", desc)
+	}
+	if n := strings.Count(desc, "The guidance below was provided by the schedule owner"); n != 1 {
+		t.Fatalf("guidance header count = %d, want exactly 1: %q", n, desc)
+	}
+	if strings.Index(desc, want.Guidance) > strings.Index(desc, overlay) {
+		t.Fatalf("baked guidance must precede the overlay; got %q", desc)
 	}
 }
 
@@ -2134,6 +2143,133 @@ func TestFirePromptUserRowNoGuidanceOverlay(t *testing.T) {
 	}
 	if got := h.runs.prompts[0].prompt; got != "the user's own prompt" {
 		t.Fatalf("user-row instruction = %q, want the column verbatim (no overlay)", got)
+	}
+}
+
+// ── issue #675: owner-guidance overlay for default sweep jobs ───────────────────
+
+// newSweepDefault builds a default-origin sweep row on the bug-triage catalog slug with the
+// given owner overlay in the guidance column (empty ⇒ NULL).
+func newSweepDefault(h *harness, overlay string) store.RunSchedule {
+	s := store.RunSchedule{
+		ID:          uuid.New(),
+		UserID:      h.owner,
+		RepoID:      h.repoID,
+		Target:      "sweep",
+		Origin:      "default",
+		CatalogSlug: pgtype.Text{String: "bug-triage", Valid: true},
+		Timing:      "recurring",
+		CronExpr:    pgtype.Text{String: "0 * * * *", Valid: true},
+		Timezone:    "UTC",
+		AutoApprove: true,
+		Status:      "active",
+		Enabled:     true,
+	}
+	if overlay != "" {
+		s.Guidance = pgtype.Text{String: overlay, Valid: true}
+	}
+	return s
+}
+
+// TestFireSweepDefaultComposesBakedAndOverlay proves a default sweep with a non-empty owner
+// overlay composes the BAKED catalog guidance and the overlay into the run description under
+// a single guidance header, baked first, with a non-vacuous guard that overlay != baked.
+func TestFireSweepDefaultComposesBakedAndOverlay(t *testing.T) {
+	h := newHarness()
+	want, ok := schedtmpl.BySlug("bug-triage")
+	if !ok {
+		t.Fatal("bug-triage catalog entry missing")
+	}
+	const overlay = "prefer table-driven tests"
+	if overlay == want.Guidance {
+		t.Fatal("test is vacuous: the overlay equals the baked catalog guidance")
+	}
+	h.st.sweepRows = []store.ListSweepCandidateIssuesRow{{ForgeIssueIid: 7}}
+
+	if _, err := h.sched.fireSweep(context.Background(), newSweepDefault(h, overlay)); err != nil {
+		t.Fatalf("fireSweep: %v", err)
+	}
+	if len(h.runs.autopilot) != 1 {
+		t.Fatalf("autopilot calls = %d, want 1", len(h.runs.autopilot))
+	}
+	desc := h.runs.autopilot[0].description
+	if !strings.Contains(desc, want.Guidance) {
+		t.Fatalf("description missing baked guidance: %q", desc)
+	}
+	if !strings.Contains(desc, overlay) {
+		t.Fatalf("description missing overlay: %q", desc)
+	}
+	if n := strings.Count(desc, "The guidance below was provided by the schedule owner"); n != 1 {
+		t.Fatalf("guidance header count = %d, want exactly 1: %q", n, desc)
+	}
+	if strings.Index(desc, want.Guidance) > strings.Index(desc, overlay) {
+		t.Fatalf("baked guidance must precede the overlay: %q", desc)
+	}
+}
+
+// TestFireSweepDefaultEmptyOverlayEqualsBakedOnly proves an empty overlay yields a run
+// description byte-for-byte identical to composing the same issue body with the baked
+// catalog guidance alone — no second header, no extra bytes (effective == baked path).
+func TestFireSweepDefaultEmptyOverlayEqualsBakedOnly(t *testing.T) {
+	h := newHarness()
+	want, ok := schedtmpl.BySlug("bug-triage")
+	if !ok {
+		t.Fatal("bug-triage catalog entry missing")
+	}
+	h.st.sweepRows = []store.ListSweepCandidateIssuesRow{{ForgeIssueIid: 7}}
+
+	if _, err := h.sched.fireSweep(context.Background(), newSweepDefault(h, "")); err != nil {
+		t.Fatalf("fireSweep: %v", err)
+	}
+	if len(h.runs.autopilot) != 1 {
+		t.Fatalf("autopilot calls = %d, want 1", len(h.runs.autopilot))
+	}
+	// The harness's fake issue body is "body"; the baked-only description is exactly what
+	// composeRunDescription produces from that body and the catalog guidance.
+	wantDesc := composeRunDescription("body", want.Guidance)
+	if got := h.runs.autopilot[0].description; got != wantDesc {
+		t.Fatalf("empty-overlay description = %q, want baked-only %q", got, wantDesc)
+	}
+}
+
+// TestFireSweepUserRowUsesColumnVerbatim proves a USER-origin sweep row is unchanged by the
+// overlay work: its guidance column is the whole instruction (composed once, no baked catalog
+// composition), mirroring TestFirePromptUserRowUnchanged.
+func TestFireSweepUserRowUsesColumnVerbatim(t *testing.T) {
+	h := newHarness()
+	const columnGuidance = "the user's own sweep guidance"
+	h.st.sweepRows = []store.ListSweepCandidateIssuesRow{{ForgeIssueIid: 7}}
+	sched := store.RunSchedule{
+		ID:          uuid.New(),
+		UserID:      h.owner,
+		RepoID:      h.repoID,
+		Target:      "sweep",
+		Origin:      "user",
+		Labels:      []byte(`["bug"]`),
+		Guidance:    pgtype.Text{String: columnGuidance, Valid: true},
+		Timing:      "recurring",
+		CronExpr:    pgtype.Text{String: "0 * * * *", Valid: true},
+		Timezone:    "UTC",
+		AutoApprove: true,
+		Status:      "active",
+		Enabled:     true,
+	}
+
+	if _, err := h.sched.fireSweep(context.Background(), sched); err != nil {
+		t.Fatalf("fireSweep: %v", err)
+	}
+	if len(h.runs.autopilot) != 1 {
+		t.Fatalf("autopilot calls = %d, want 1", len(h.runs.autopilot))
+	}
+	desc := h.runs.autopilot[0].description
+	// The column is composed once as the sole guidance; no catalog composition engages for a
+	// user row, so the description equals the body composed with the column verbatim.
+	wantDesc := composeRunDescription("body", columnGuidance)
+	if desc != wantDesc {
+		t.Fatalf("user-row sweep description = %q, want the column composed verbatim %q", desc, wantDesc)
+	}
+	if n := strings.Count(desc, "The guidance below was provided by the schedule owner"); n != 1 {
+		t.Fatalf("guidance header count = %d, want exactly 1: %q", n, desc)
 	}
 }
 

--- a/api/internal/uzidocs/embed/cli.md
+++ b/api/internal/uzidocs/embed/cli.md
@@ -302,7 +302,7 @@ A few worth knowing:
   (owner steering is editable there — a partial edit restates the stored guidance
   so it is not wiped; on a sweep default the guidance is an **overlay** composed
   onto the read-only baked catalog guidance at fire time); the catalog-owned fields
-  (`--prompt`, `--label`, `--repo`, timing, and `--guidance` on an issue default)
+  (`--prompt`, `--label`, `--repo`, `--at`, and `--guidance` on an issue default)
   require `uzi schedule clone` first. Changing a sweep schedule's `--label`
   selector runs the same advisory sweep-label guardrail as `create`/`catalog
   enable`: it `WARNING`s (to stderr) on any newly-set label missing on the

--- a/api/internal/uzidocs/embed/cli.md
+++ b/api/internal/uzidocs/embed/cli.md
@@ -298,11 +298,12 @@ A few worth knowing:
   retime previously wiped the stored model. On a **default-origin** schedule only
   the catalog-editable fields (`--cron`, `--tz`, `--auto-approve`,
   `--wait-on-limit`, `--max-issues`, `--clear-max-issues`) may be edited, plus
-  `--guidance`/`--clear-guidance` on a **prompt-target default** (owner steering is
-  editable there — a partial edit restates the stored guidance so it is not wiped);
-  the catalog-owned fields
-  (`--prompt`, `--label`, `--repo`, timing, and `--guidance` on an issue/sweep
-  default) require `uzi schedule clone` first. Changing a sweep schedule's `--label`
+  `--guidance`/`--clear-guidance` on a **prompt-target or sweep-target default**
+  (owner steering is editable there — a partial edit restates the stored guidance
+  so it is not wiped; on a sweep default the guidance is an **overlay** composed
+  onto the read-only baked catalog guidance at fire time); the catalog-owned fields
+  (`--prompt`, `--label`, `--repo`, timing, and `--guidance` on an issue default)
+  require `uzi schedule clone` first. Changing a sweep schedule's `--label`
   selector runs the same advisory sweep-label guardrail as `create`/`catalog
   enable`: it `WARNING`s (to stderr) on any newly-set label missing on the
   schedule's repo, or creates it first with `--create-missing-labels`, and never

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -249,8 +249,10 @@ worker rather than the catalog — its entry is cadence and model only (see
   a fully editable copy. Cloning a default **unlocks the prompt**: the baked
   text is copied onto the new schedule as ordinary, editable content, and it
   stops tracking the catalog (a later catalog update no longer reaches it).
-  Cloning into a different repo than the source is how you replicate a
-  schedule across repos.
+  Cloning a **sweep** default instead copies the read-only baked catalog
+  guidance into the new row's editable guidance, without carrying over any
+  owner guidance overlay you had added. Cloning into a different repo than
+  the source is how you replicate a schedule across repos.
 - **Auto-approve, on by default.** Like any new schedule, a default is
   created with auto-approve and wait-on-limit both on — the point of a
   default is that it runs unattended off-hours. Every default job only opens

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -99,6 +99,9 @@ prompt text already is the instruction. The exception is a prompt-target
 **default**: its prompt is catalog-owned (and auto-tracks catalog updates), so
 owner guidance *is* offered and is overlaid onto the catalog prompt at fire
 time, the same "generic base + owner overlay" split the issue/sweep targets use.
+A **sweep default** likewise offers owner guidance as an **overlay**: its baked
+guidance stays catalog-owned (shown read-only and auto-tracking catalog updates)
+and your overlay is composed onto it at fire time, under a single guidance header.
 
 ## Managing schedules
 
@@ -234,9 +237,10 @@ worker rather than the catalog — its entry is cadence and model only (see
   already enabled the job, automatically, with nothing to re-enable. Cadence,
   model, and the run options (auto-approve, wait-on-limit, max issues) are
   yours to edit like any schedule — as is owner **guidance** on a prompt-target
-  default; a **Reset to default** action puts an edited default back to the
-  catalog's cadence/model/options in one step, and also clears any owner
-  guidance you added to a prompt default.
+  or sweep-target default (on a sweep default it is an overlay composed onto the
+  read-only baked catalog guidance); a **Reset to default** action puts an edited
+  default back to the catalog's cadence/model/options in one step, and also clears
+  any owner guidance you added to a prompt or sweep default.
 - **Enable on several repos at once.** Enabling a default (or creating a
   custom schedule) against multiple repos creates one independent schedule
   per repo — each with its own cadence, its own pause/resume, its own run

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -302,7 +302,7 @@ A few worth knowing:
   (owner steering is editable there — a partial edit restates the stored guidance
   so it is not wiped; on a sweep default the guidance is an **overlay** composed
   onto the read-only baked catalog guidance at fire time); the catalog-owned fields
-  (`--prompt`, `--label`, `--repo`, timing, and `--guidance` on an issue default)
+  (`--prompt`, `--label`, `--repo`, `--at`, and `--guidance` on an issue default)
   require `uzi schedule clone` first. Changing a sweep schedule's `--label`
   selector runs the same advisory sweep-label guardrail as `create`/`catalog
   enable`: it `WARNING`s (to stderr) on any newly-set label missing on the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -298,11 +298,12 @@ A few worth knowing:
   retime previously wiped the stored model. On a **default-origin** schedule only
   the catalog-editable fields (`--cron`, `--tz`, `--auto-approve`,
   `--wait-on-limit`, `--max-issues`, `--clear-max-issues`) may be edited, plus
-  `--guidance`/`--clear-guidance` on a **prompt-target default** (owner steering is
-  editable there — a partial edit restates the stored guidance so it is not wiped);
-  the catalog-owned fields
-  (`--prompt`, `--label`, `--repo`, timing, and `--guidance` on an issue/sweep
-  default) require `uzi schedule clone` first. Changing a sweep schedule's `--label`
+  `--guidance`/`--clear-guidance` on a **prompt-target or sweep-target default**
+  (owner steering is editable there — a partial edit restates the stored guidance
+  so it is not wiped; on a sweep default the guidance is an **overlay** composed
+  onto the read-only baked catalog guidance at fire time); the catalog-owned fields
+  (`--prompt`, `--label`, `--repo`, timing, and `--guidance` on an issue default)
+  require `uzi schedule clone` first. Changing a sweep schedule's `--label`
   selector runs the same advisory sweep-label guardrail as `create`/`catalog
   enable`: it `WARNING`s (to stderr) on any newly-set label missing on the
   schedule's repo, or creates it first with `--create-missing-labels`, and never

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -249,8 +249,10 @@ worker rather than the catalog — its entry is cadence and model only (see
   a fully editable copy. Cloning a default **unlocks the prompt**: the baked
   text is copied onto the new schedule as ordinary, editable content, and it
   stops tracking the catalog (a later catalog update no longer reaches it).
-  Cloning into a different repo than the source is how you replicate a
-  schedule across repos.
+  Cloning a **sweep** default instead copies the read-only baked catalog
+  guidance into the new row's editable guidance, without carrying over any
+  owner guidance overlay you had added. Cloning into a different repo than
+  the source is how you replicate a schedule across repos.
 - **Auto-approve, on by default.** Like any new schedule, a default is
   created with auto-approve and wait-on-limit both on — the point of a
   default is that it runs unattended off-hours. Every default job only opens

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -99,6 +99,9 @@ prompt text already is the instruction. The exception is a prompt-target
 **default**: its prompt is catalog-owned (and auto-tracks catalog updates), so
 owner guidance *is* offered and is overlaid onto the catalog prompt at fire
 time, the same "generic base + owner overlay" split the issue/sweep targets use.
+A **sweep default** likewise offers owner guidance as an **overlay**: its baked
+guidance stays catalog-owned (shown read-only and auto-tracking catalog updates)
+and your overlay is composed onto it at fire time, under a single guidance header.
 
 ## Managing schedules
 
@@ -234,9 +237,10 @@ worker rather than the catalog — its entry is cadence and model only (see
   already enabled the job, automatically, with nothing to re-enable. Cadence,
   model, and the run options (auto-approve, wait-on-limit, max issues) are
   yours to edit like any schedule — as is owner **guidance** on a prompt-target
-  default; a **Reset to default** action puts an edited default back to the
-  catalog's cadence/model/options in one step, and also clears any owner
-  guidance you added to a prompt default.
+  or sweep-target default (on a sweep default it is an overlay composed onto the
+  read-only baked catalog guidance); a **Reset to default** action puts an edited
+  default back to the catalog's cadence/model/options in one step, and also clears
+  any owner guidance you added to a prompt or sweep default.
 - **Enable on several repos at once.** Enabling a default (or creating a
   custom schedule) against multiple repos creates one independent schedule
   per repo — each with its own cadence, its own pause/resume, its own run

--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -84,7 +84,10 @@ function defRow(over: Partial<Schedule>): Schedule {
     auto_approve: true,
     wait_on_limit: true,
     max_issues: 3,
-    guidance: "Triage the bug.",
+    // A sweep default's baked catalog guidance is the read-only baked_guidance (issue #675);
+    // guidance is the owner overlay (null until set).
+    guidance: null,
+    baked_guidance: "Triage the bug.",
     model: null,
     override_subagent_model: false,
     enabled: true,

--- a/web/src/components/ScheduleModal.test.tsx
+++ b/web/src/components/ScheduleModal.test.tsx
@@ -764,7 +764,8 @@ describe("owner guidance overlay on a sweep default (issue #675)", () => {
     // A cleared overlay is sent as an EXPLICIT null, not undefined, so the server drops it.
     expect(input?.guidance).toBeNull();
     // The read-only baked catalog guidance is never round-tripped through the overlay patch.
-    expect(input?.baked_guidance).toBeUndefined();
+    // (ScheduleInput has no baked_guidance field; assert the emitted patch carries no such key.)
+    expect(Object.keys(input ?? {})).not.toContain("baked_guidance");
   });
 });
 

--- a/web/src/components/ScheduleModal.test.tsx
+++ b/web/src/components/ScheduleModal.test.tsx
@@ -142,6 +142,7 @@ function schedFixture(over: Partial<Schedule> = {}): Schedule {
     wait_on_limit: true,
     max_issues: 10,
     guidance: null,
+    baked_guidance: null,
     model: "fable",
     override_subagent_model: false,
     enabled: true,
@@ -665,31 +666,85 @@ describe("owner guidance on a prompt default (issue #662)", () => {
     expect(input?.target).toBeUndefined();
   });
 
-  it("does NOT show an editable guidance field for an issue/sweep default", () => {
-    // A sweep default: its guidance is catalog-owned (baked, read-only), so the editable
-    // guidance textarea must not appear. The sweep default's baked guidance shows read-only.
+});
+
+// ── issue #675 M2: a sweep DEFAULT gets an editable owner-guidance OVERLAY, shown
+// ── alongside its read-only baked catalog guidance (the two are separate DTO fields) ──
+describe("owner guidance overlay on a sweep default (issue #675)", () => {
+  // The baked catalog guidance (read-only) and the owner overlay (editable) MUST be
+  // DIFFERENT values here: with the old single-field shape both the read-only panel and
+  // the editable textarea were fed the same `guidance`, so equal values would let this
+  // test pass vacuously and hide that exact collision. Keeping them distinct is essential.
+  const BAKED = "Triage the bug: reproduce, root-cause, and fix if small.";
+  const OVERLAY = "prefer a failing test first, then the smallest fix";
+
+  function sweepDefault(over: Partial<Schedule> = {}): Schedule {
+    return schedFixture({
+      id: "sch-def-sweep",
+      origin: "default",
+      catalog_slug: "bug-triage",
+      target: "sweep",
+      labels: ["bug"],
+      prompt: "",
+      baked_guidance: BAKED,
+      guidance: OVERLAY,
+      model: "",
+      customized: true,
+      ...over,
+    });
+  }
+
+  it("shows the baked catalog guidance read-only (never the overlay) in the Baked guidance panel", () => {
     render(
       <MemoryRouter>
-        <ScheduleModal
-          editing={schedFixture({
-            id: "sch-def-sweep",
-            origin: "default",
-            catalog_slug: "bug-triage",
-            target: "sweep",
-            labels: ["bug"],
-            prompt: "",
-            guidance: "keep the diff small",
-          })}
-          onClose={vi.fn()}
-          onSaved={vi.fn()}
-          onCloneToEdit={vi.fn()}
-        />
+        <ScheduleModal editing={sweepDefault()} onClose={vi.fn()} onSaved={vi.fn()} onCloneToEdit={vi.fn()} />
       </MemoryRouter>,
     );
-    // No editable guidance textarea (the placeholder is unique to the editable control).
-    expect(screen.queryByPlaceholderText("always add a failing test first")).toBeNull();
-    // The catalog-owned guidance is shown read-only instead.
     expect(screen.getByText(/Baked guidance/)).toBeTruthy();
+    // The read-only panel shows the BAKED text (as static text, not a textarea), never
+    // the owner overlay — the collision the old single-field shape would have produced.
+    const bakedEl = screen.getByText(BAKED);
+    expect(bakedEl.tagName).not.toBe("TEXTAREA");
+    // The overlay does appear on screen, but ONLY in the editable textarea (not the panel).
+    const overlayEl = screen.getByText(OVERLAY);
+    expect(overlayEl.tagName).toBe("TEXTAREA");
+    expect(overlayEl).not.toBe(bakedEl);
+  });
+
+  it("shows an EDITABLE guidance textarea seeded from the owner overlay (not the baked value)", () => {
+    render(
+      <MemoryRouter>
+        <ScheduleModal editing={sweepDefault()} onClose={vi.fn()} onSaved={vi.fn()} onCloneToEdit={vi.fn()} />
+      </MemoryRouter>,
+    );
+    const guidance = screen.getByPlaceholderText("always add a failing test first") as HTMLTextAreaElement;
+    expect(guidance.hasAttribute("readonly")).toBe(false);
+    expect(guidance.hasAttribute("disabled")).toBe(false);
+    // Seeded from the OVERLAY, never the baked catalog guidance.
+    expect(guidance.value).toBe(OVERLAY);
+    expect(guidance.value).not.toBe(BAKED);
+  });
+
+  it("submitting sends the edited overlay in the patch input, never the baked value", async () => {
+    mockApi.updateSchedule.mockResolvedValue(sweepDefault());
+    render(
+      <MemoryRouter>
+        <ScheduleModal editing={sweepDefault()} onClose={vi.fn()} onSaved={vi.fn()} onCloneToEdit={vi.fn()} />
+      </MemoryRouter>,
+    );
+    fireEvent.change(screen.getByPlaceholderText("always add a failing test first"), {
+      target: { value: "keep the change tiny and reversible" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mockApi.updateSchedule).toHaveBeenCalled());
+    const input = mockApi.updateSchedule.mock.calls[0]?.[1];
+    expect(input?.guidance).toBe("keep the change tiny and reversible");
+    // The baked catalog guidance is never round-tripped through the overlay patch.
+    expect(input?.guidance).not.toBe(BAKED);
+    // Labels/target stay catalog-owned and are never sent.
+    expect(input?.labels).toBeUndefined();
+    expect(input?.target).toBeUndefined();
   });
 });
 

--- a/web/src/components/ScheduleModal.test.tsx
+++ b/web/src/components/ScheduleModal.test.tsx
@@ -746,6 +746,26 @@ describe("owner guidance overlay on a sweep default (issue #675)", () => {
     expect(input?.labels).toBeUndefined();
     expect(input?.target).toBeUndefined();
   });
+
+  it("clearing the guidance textarea sends guidance:null (explicit clear), never baked_guidance", async () => {
+    mockApi.updateSchedule.mockResolvedValue(sweepDefault({ guidance: null, customized: false }));
+    render(
+      <MemoryRouter>
+        <ScheduleModal editing={sweepDefault()} onClose={vi.fn()} onSaved={vi.fn()} onCloneToEdit={vi.fn()} />
+      </MemoryRouter>,
+    );
+    fireEvent.change(screen.getByPlaceholderText("always add a failing test first"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mockApi.updateSchedule).toHaveBeenCalled());
+    const input = mockApi.updateSchedule.mock.calls[0]?.[1];
+    // A cleared overlay is sent as an EXPLICIT null, not undefined, so the server drops it.
+    expect(input?.guidance).toBeNull();
+    // The read-only baked catalog guidance is never round-tripped through the overlay patch.
+    expect(input?.baked_guidance).toBeUndefined();
+  });
 });
 
 describe("a cloned/user schedule keeps its prompt editable (PRD #589)", () => {

--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -226,6 +226,9 @@ export function ScheduleModal({
   // a string in state ("" = none).
   // Steers HOW a run approaches the task — the issue body stays the task.
   const [guidance, setGuidance] = useState<string>(editing?.guidance ?? "");
+  // A sweep default's baked catalog guidance is read-only and travels in a SEPARATE
+  // DTO field (issue #675); the editable `guidance` state above is the owner overlay.
+  const bakedGuidance = editing?.baked_guidance ?? "";
   // Per-schedule model override; "" = inherit the owner's per-user Worker default.
   // Applies to ALL targets (unlike guidance). Injection-suspect custom IDs are gated
   // below (modelWarning) mirroring the server's ValidateModel reject.
@@ -422,10 +425,10 @@ export function ScheduleModal({
   // rejected. The catalog-owned set the server rejects is target/prompt/labels/repo_id/
   // issue_iid/timing/run_at — none of these appear below.
   //
-  // Guidance is the ONE exception, and only for a PROMPT default (issue #662): the owner
-  // can steer a prompt default's baked prompt via guidance, so it is owner-editable there
-  // and the server overlays it onto the catalog prompt at fire time. We send it with
-  // replace-semantics (value, or explicit null to clear) each time. For issue/sweep/
+  // Guidance is owner-editable for a PROMPT default (issue #662) and a SWEEP default
+  // (issue #675): the owner steers the baked prompt/guidance via an OVERLAY the server
+  // appends to the catalog value at fire time, so it is owner-editable there. We send it
+  // with replace-semantics (value, or explicit null to clear) each time. For issue/
   // self_improve defaults guidance stays catalog-owned and MUST be omitted (the server
   // 400s a default patch that carries it for those targets).
   const buildDefaultInput = (): ScheduleInput => ({
@@ -437,7 +440,12 @@ export function ScheduleModal({
     wait_on_limit: waitOnLimit,
     max_issues: target === "sweep" ? maxIssues : undefined,
     model: model.trim() === "" ? null : model,
-    guidance: target === "prompt" ? (guidance.trim() === "" ? null : guidance) : undefined,
+    guidance:
+      target === "prompt" || target === "sweep"
+        ? guidance.trim() === ""
+          ? null
+          : guidance
+        : undefined,
   });
 
   const buildInput = (): ScheduleInput => ({
@@ -541,18 +549,23 @@ export function ScheduleModal({
     }
   };
 
-  // Optional guidance textarea. Rendered for the issue and sweep targets, and
-  // for a prompt-target DEFAULT (issue #662: its baked prompt is catalog-owned,
-  // but owner guidance overlays it at fire time) — NOT for a user prompt
-  // schedule, which carries its own editable prompt text. Mirrors the prompt
-  // textarea's markup.
-  // A prompt-target default overlays this guidance on its baked catalog prompt, so the
-  // issue-centric wording ("every issue this schedule runs") does not apply there; give the
-  // prompt case its own help text stating the baked prompt stays the task.
+  // Optional guidance textarea. Rendered for the issue and sweep targets, and for a
+  // prompt-target DEFAULT (issue #662: its baked prompt is catalog-owned, but owner
+  // guidance overlays it at fire time) and a sweep-target DEFAULT (issue #675: its baked
+  // catalog guidance is read-only, but this owner OVERLAY is appended at fire time) — NOT
+  // for a user prompt schedule, which carries its own editable prompt text. Mirrors the
+  // prompt textarea's markup.
+  // A prompt-target default overlays this guidance on its baked catalog prompt, and a
+  // sweep-target default overlays it on its baked catalog guidance (issue #675), so the
+  // issue-centric wording ("every issue this schedule runs") does not apply to either;
+  // give each default case its own help text stating the baked value stays in effect. A
+  // user issue/sweep schedule keeps the issue-centric wording.
   const guidanceHelp =
     target === "prompt"
       ? "Steers how the run approaches the task. It's appended to the baked prompt each time this schedule fires; the baked prompt stays the task."
-      : "Steers how the run approaches the task, e.g. “always add a failing test first”. Applied to every issue this schedule runs; the issue itself stays the task.";
+      : isDefault && target === "sweep"
+        ? "Steers how the run approaches each swept issue. It's appended to the baked guidance each time this schedule fires; the baked guidance stays in effect."
+        : "Steers how the run approaches the task, e.g. “always add a failing test first”. Applied to every issue this schedule runs; the issue itself stays the task.";
   const guidanceField = (
     <Field label="Guidance (optional)" htmlFor="sched-guidance">
       <Textarea
@@ -686,12 +699,17 @@ export function ScheduleModal({
               editable segmented control + fields. */}
           {isDefault ? (
             <>
-              <BakedTargetDetail target={target} prompt={prompt} labels={labels} guidance={guidance} />
-              {/* A PROMPT default's guidance is owner-editable (issue #662): the baked prompt
-                  stays read-only above, but this guidance is appended to it at fire time. Only
-                  a prompt default gets this field — issue/sweep/self_improve defaults keep
-                  their guidance catalog-owned (baked, shown read-only in BakedTargetDetail). */}
-              {target === "prompt" && guidanceField}
+              <BakedTargetDetail
+                target={target}
+                prompt={prompt}
+                labels={labels}
+                bakedGuidance={bakedGuidance}
+              />
+              {/* A PROMPT default's guidance (issue #662) and a SWEEP default's guidance
+                  (issue #675) are owner-editable: the baked prompt/guidance stays read-only
+                  above, but this OVERLAY is appended to it at fire time. issue/self_improve
+                  defaults keep their guidance catalog-owned (baked, shown read-only). */}
+              {(target === "prompt" || target === "sweep") && guidanceField}
             </>
           ) : (
             <>
@@ -1058,12 +1076,12 @@ function BakedTargetDetail({
   target,
   prompt,
   labels,
-  guidance,
+  bakedGuidance,
 }: {
   target: ScheduleTarget;
   prompt: string;
   labels: string[];
-  guidance: string;
+  bakedGuidance: string;
 }) {
   return (
     <div className="space-y-3">
@@ -1117,7 +1135,7 @@ function BakedTargetDetail({
       {target !== "self_improve" && (
         <BakedBlock
           label={target === "sweep" ? "Baked guidance" : "Baked prompt"}
-          text={target === "sweep" ? guidance : prompt}
+          text={target === "sweep" ? bakedGuidance : prompt}
         />
       )}
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1209,7 +1209,13 @@ export interface Schedule {
   // Optional owner guidance steering HOW a run approaches the task (the issue body
   // stays the task); null = none. Issue and sweep targets only (null for prompt,
   // which already carries its own prompt text). Capped at 8192 bytes server-side.
+  // For a default SWEEP row (issue #675) this is the owner OVERLAY (null until set);
+  // the resolved catalog guidance for that row travels separately in `baked_guidance`.
   guidance: string | null;
+  // Resolved catalog guidance for a default SWEEP row (issue #675), shown read-only in
+  // the modal. Null for prompt/self_improve/user rows. `guidance` carries the owner
+  // overlay appended at fire time. Mirrors apitypes.ScheduleDTO.baked_guidance.
+  baked_guidance: string | null;
   // Per-schedule model override; null = inherit the owner's per-user Worker model.
   // Applies to ALL targets (prompt/issue/sweep), unlike guidance which is issue/sweep-only.
   model: string | null;

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -1089,7 +1089,10 @@ const daysFromNow = (d: number, h: number, m = 0): string => {
 // (origin='default') are appended below from the catalog fixture; keeping the two
 // lists separate lets the user rows stay free of the three origin fields, which the
 // map injects uniformly.
-const userSchedules: Omit<Schedule, "origin" | "catalog_slug" | "customized" | "sibling_group_id">[] = [
+const userSchedules: Omit<
+  Schedule,
+  "origin" | "catalog_slug" | "customized" | "sibling_group_id" | "baked_guidance"
+>[] = [
   {
     id: "sch-7kd2", repo_id: "repo-uzi", repo_path: "vtmocanu/uzi",
     target: "sweep", issue_iid: null, labels: null, prompt: "",
@@ -1315,7 +1318,10 @@ function materializeDefault(
     auto_approve: entry.auto_approve,
     wait_on_limit: entry.wait_on_limit,
     max_issues: entry.target === "sweep" ? entry.max_issues : null,
-    guidance: entry.target === "sweep" ? entry.guidance || null : null,
+    // Owner OVERLAY (issue #675): null by default; a seed sets it via `...over`.
+    guidance: null,
+    // Resolved catalog guidance for a sweep default, shown read-only (issue #675).
+    baked_guidance: entry.target === "sweep" ? entry.guidance || null : null,
     model: entry.model || null,
     override_subagent_model: false,
     enabled: true,
@@ -1363,11 +1369,28 @@ const seededDefaults: Schedule[] = [
     cron_expr: "0 6 * * 1",
     customized: true,
   }),
+  // A sweep default carrying an owner GUIDANCE OVERLAY (issue #675): its baked_guidance
+  // is the catalog planned-sweep text while `guidance` is a distinct, owner-set overlay,
+  // so the modal must show the two independently. The two values MUST differ so a test
+  // cannot pass vacuously against the old single-field shape. planned-sweep on repo-ledger
+  // is used by no other seed/test, so this adds no enablement collision.
+  materializeDefault(catalogBySlug("planned-sweep")!, "repo-ledger", "sch-def-ps-overlay", {
+    guidance: "prefer a failing test first, then the smallest fix",
+    customized: true,
+  }),
 ];
 
 let schedules: Schedule[] = [
   ...userSchedules.map(
-    (s): Schedule => ({ ...s, origin: "user", catalog_slug: null, customized: false, sibling_group_id: null }),
+    (s): Schedule => ({
+      ...s,
+      origin: "user",
+      catalog_slug: null,
+      customized: false,
+      sibling_group_id: null,
+      // Baked catalog guidance is default-sweep-only (issue #675); a user row never has it.
+      baked_guidance: null,
+    }),
   ),
   ...seededDefaults,
 ];
@@ -4414,6 +4437,8 @@ export const mockApi = {
       max_issues: target === "sweep" ? (input.max_issues ?? 10) : null,
       // Guidance on issue/sweep only; null (none) for prompt (re-nulled per target).
       guidance: target === "issue" || target === "sweep" ? (input.guidance ?? null) : null,
+      // Baked catalog guidance is a default-sweep-only field (issue #675); null for a user row.
+      baked_guidance: null,
       // Model applies to ALL targets (unlike guidance); null = inherit.
       model: input.model ?? null,
       // PRD #305: omitted ≡ false (replace-semantics), default off.
@@ -4449,13 +4474,14 @@ export const mockApi = {
     // 400s ANY default patch whose body carries a catalog-owned field. Mirror that here so
     // the mock and the server agree — the drift that hid the buildDefaultInput `timing` bug.
     // The rejected set is target/prompt/labels/timing/repo_id/issue_iid (run_at too, but the
-    // modal never sends it on a default). Guidance is the ONE exception, and only for a PROMPT
-    // default (issue #662): it is owner-editable there (overlaid on the catalog prompt at fire
-    // time), so allow it for a prompt default and keep rejecting it for issue/sweep/
-    // self_improve defaults. The 400 message mirrors the server's per-target locked-set string.
-    // Only cron/tz/model/flags/max_issues (+prompt-default guidance) edit.
+    // modal never sends it on a default). Guidance is the exception for a PROMPT default
+    // (issue #662) and a SWEEP default (issue #675): it is owner-editable there (overlaid on
+    // the catalog prompt/guidance at fire time), so allow it for prompt+sweep defaults and
+    // keep rejecting it for issue/self_improve defaults. The 400 message mirrors the server's
+    // per-target locked-set string. Only cron/tz/model/flags/max_issues (+prompt/sweep-default
+    // guidance) edit.
     if (cur.origin === "default") {
-      const guidanceEditable = cur.target === "prompt";
+      const guidanceEditable = cur.target === "prompt" || cur.target === "sweep";
       if (
         input.target !== undefined ||
         input.prompt !== undefined ||
@@ -4534,9 +4560,11 @@ export const mockApi = {
           m.auto_approve !== entry.auto_approve ||
           m.wait_on_limit !== entry.wait_on_limit ||
           (m.target === "sweep" && (m.max_issues ?? 0) !== entry.max_issues) ||
-          // Owner guidance divergence for a prompt default (issue #662): a prompt catalog
-          // entry carries empty guidance, so any non-empty stored guidance is customized.
-          (m.target === "prompt" && (m.guidance ?? "") !== "");
+          // Owner guidance-overlay divergence for a prompt default (issue #662) or a sweep
+          // default (issue #675): the OVERLAY (m.guidance) is null until the owner sets one,
+          // so any non-empty overlay flips customized. The baked catalog guidance is NOT
+          // compared (only the overlay's presence matters), matching the server.
+          ((m.target === "prompt" || m.target === "sweep") && (m.guidance ?? "") !== "");
       }
     }
     m.updated_at = new Date().toISOString();
@@ -4659,6 +4687,12 @@ export const mockApi = {
       created_at: now,
       updated_at: now,
       next_fires: [],
+      // A clone is always a user row, which never carries the read-only baked catalog
+      // guidance (issue #675). For a SWEEP default, fold the baked catalog guidance into
+      // the editable guidance and discard the owner overlay, mirroring the server clone.
+      guidance:
+        src.origin === "default" && src.target === "sweep" ? src.baked_guidance : src.guidance,
+      baked_guidance: null,
     };
     schedules = [clone, ...schedules];
     return delay(scheduleDTO(clone), 200);

--- a/web/src/mocks/scheduleCatalog.test.ts
+++ b/web/src/mocks/scheduleCatalog.test.ts
@@ -181,6 +181,39 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     expect(cleared.customized).toBe(false);
   });
 
+  it("resetSchedule clears a SWEEP default's owner overlay, keeps baked_guidance, and un-customizes (issue #675)", async () => {
+    // The RESET path (distinct from update-clear): resetSchedule re-materializes the default
+    // from the catalog, so it drops the owner overlay (guidance -> null) while keeping the
+    // read-only baked catalog guidance, and clears customized. Materialize a fresh
+    // planned-sweep default on a clean repo (repo-www already carries one from the sweep-overlay
+    // test above, so use a different owned repo) so it starts un-customized with a null overlay.
+    const def = await mockApi.enableCatalogSchedule("repo-payments", "planned-sweep");
+    expect(def.origin).toBe("default");
+    expect(def.target).toBe("sweep");
+    expect(def.customized).toBe(false);
+    expect(def.guidance).toBeNull(); // no owner overlay yet
+    expect(def.baked_guidance).toBeTruthy(); // catalog guidance baked in, read-only
+    const baked = def.baked_guidance;
+
+    const updated = await mockApi.updateSchedule(def.id, {
+      cron_expr: def.cron_expr,
+      timezone: def.timezone,
+      auto_approve: def.auto_approve,
+      wait_on_limit: def.wait_on_limit,
+      max_issues: def.max_issues,
+      model: null,
+      guidance: "prefer a failing test first, then the smallest fix",
+    });
+    expect(updated.customized).toBe(true);
+
+    // Resetting re-materializes from the catalog: the overlay is cleared, the baked catalog
+    // guidance is unchanged, and the row is no longer customized.
+    const reset = await mockApi.resetSchedule(def.id);
+    expect(reset.guidance).toBeNull();
+    expect(reset.baked_guidance).toBe(baked);
+    expect(reset.customized).toBe(false);
+  });
+
   it("REJECTS guidance over the 8 KiB cap by BYTES not chars, on both write paths (issue #662, mock == server 422)", async () => {
     // The server caps guidance at 8 KiB (MaxGuidanceBytes) and 422s an oversize value on EVERY
     // write path; the mock must reproduce that so mock-mode users hit the same error rather than

--- a/web/src/mocks/scheduleCatalog.test.ts
+++ b/web/src/mocks/scheduleCatalog.test.ts
@@ -70,8 +70,9 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     // catalog-owned field (prompt/labels/target/timing/repo_id/issue_iid, plus guidance for a
     // non-prompt default). The mock must agree — the drift that let ScheduleModal ship a
     // `timing:"recurring"` default patch that passed CI but 400s the real backend. This test is
-    // the regression fence. The `def` picked here is a SWEEP default (first seeded), so guidance
-    // is still catalog-owned for it and its rejection holds (a prompt default is covered below).
+    // the regression fence. The `def` picked here is a SWEEP default (first seeded). Guidance
+    // is NO LONGER catalog-owned for a sweep default (issue #675: it is the owner overlay,
+    // owner-editable), so guidance is covered by its own accept test below, not here.
     const def = (await mockApi.listSchedules()).find(
       (s) => s.origin === "default" && !!s.catalog_slug && s.target === "sweep",
     );
@@ -82,7 +83,6 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     await expect(mockApi.updateSchedule(def!.id, { prompt: "x" })).rejects.toMatchObject({ status: 400 });
     await expect(mockApi.updateSchedule(def!.id, { target: "prompt" })).rejects.toMatchObject({ status: 400 });
     await expect(mockApi.updateSchedule(def!.id, { labels: ["bug"] })).rejects.toMatchObject({ status: 400 });
-    await expect(mockApi.updateSchedule(def!.id, { guidance: "g" })).rejects.toMatchObject({ status: 400 });
     await expect(mockApi.updateSchedule(def!.id, { issue_iid: 5 })).rejects.toMatchObject({ status: 400 });
     await expect(mockApi.updateSchedule(def!.id, { repo_id: "repo-atlas" })).rejects.toMatchObject({ status: 400 });
 
@@ -136,14 +136,49 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     expect(cleared.customized).toBe(false);
   });
 
-  it("updateSchedule still REJECTS guidance on an issue/sweep default (issue #662, mock == server 400)", async () => {
-    // Guidance stays catalog-owned for a non-prompt default: the server 400s a patch that
-    // carries it, so the mock must too. A sweep default is the first seeded catalog default.
-    const sweepDef = (await mockApi.listSchedules()).find(
-      (s) => s.origin === "default" && !!s.catalog_slug && s.target === "sweep",
-    );
-    expect(sweepDef).toBeTruthy();
-    await expect(mockApi.updateSchedule(sweepDef!.id, { guidance: "g" })).rejects.toMatchObject({ status: 400 });
+  it("updateSchedule ACCEPTS + persists an owner guidance OVERLAY on a SWEEP default and sets customized (issue #675)", async () => {
+    // Issue #675 splits a sweep default's guidance: the catalog value is the read-only
+    // baked_guidance, and `guidance` is an owner-editable OVERLAY the server appends at fire
+    // time (like the prompt-default overlay of #662). So a sweep-default patch carrying
+    // guidance is ACCEPTED, and the OVERLAY persists while baked_guidance stays the catalog
+    // value. Materialize a fresh planned-sweep default on a clean repo so it starts
+    // un-customized with a null overlay and the catalog guidance baked in.
+    const def = await mockApi.enableCatalogSchedule("repo-www", "planned-sweep");
+    expect(def.origin).toBe("default");
+    expect(def.target).toBe("sweep");
+    expect(def.customized).toBe(false);
+    expect(def.guidance).toBeNull(); // no owner overlay yet
+    expect(def.baked_guidance).toBeTruthy(); // catalog guidance baked in, read-only
+    const baked = def.baked_guidance;
+
+    const updated = await mockApi.updateSchedule(def.id, {
+      cron_expr: def.cron_expr,
+      timezone: def.timezone,
+      auto_approve: def.auto_approve,
+      wait_on_limit: def.wait_on_limit,
+      max_issues: def.max_issues,
+      model: null,
+      guidance: "prefer a failing test first, then the smallest fix",
+    });
+    expect(updated.guidance).toBe("prefer a failing test first, then the smallest fix");
+    // The baked catalog guidance is untouched by the overlay patch (the two are independent).
+    expect(updated.baked_guidance).toBe(baked);
+    expect(updated.customized).toBe(true);
+
+    // Clearing the overlay back to none (explicit null) restores it AND un-customizes, since
+    // every editable field is back at the catalog values, and baked_guidance stays intact.
+    const cleared = await mockApi.updateSchedule(def.id, {
+      cron_expr: def.cron_expr,
+      timezone: def.timezone,
+      auto_approve: def.auto_approve,
+      wait_on_limit: def.wait_on_limit,
+      max_issues: def.max_issues,
+      model: null,
+      guidance: null,
+    });
+    expect(cleared.guidance).toBeNull();
+    expect(cleared.baked_guidance).toBe(baked);
+    expect(cleared.customized).toBe(false);
   });
 
   it("REJECTS guidance over the 8 KiB cap by BYTES not chars, on both write paths (issue #662, mock == server 422)", async () => {

--- a/web/src/pages/Schedules.test.tsx
+++ b/web/src/pages/Schedules.test.tsx
@@ -60,6 +60,7 @@ function sched(over: Partial<Schedule>): Schedule {
     wait_on_limit: true,
     max_issues: 10,
     guidance: null,
+    baked_guidance: null,
     model: null,
     override_subagent_model: false,
     enabled: true,


### PR DESCRIPTION
Implements issue #675.

Closes #675

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-675`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sweep-target default schedules support editing and clearing owner guidance overlays.
  * Catalog guidance appears separately as read-only information.
  * Effective run guidance combines catalog guidance with owner-provided overlays.
  * Cloning a sweep default transfers catalog guidance into editable guidance.

* **Bug Fixes**
  * Partial edits preserve guidance and catalog-owned fields.
  * Resetting guidance clears only the owner overlay while retaining catalog guidance.

* **Documentation**
  * Updated CLI and scheduling documentation to clarify editing, cloning, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->