### PR TITLE
board: AutoMove drag path does not EnsureLabels the target column (only write path that assumes forge state)

### DIFF
--- a/api/internal/forgesvc/service.go
+++ b/api/internal/forgesvc/service.go
@@ -67,6 +67,25 @@ var DefaultColumns = []forge.Label{
 	{Name: "Later", Color: "#999999"},
 }
 
+// DefaultColumnColor is the grey a board column label falls back to when its
+// name is not one of the DefaultColumns (a user-added custom column). It is the
+// same color ConfigureColumns creates custom columns with, so ensuring a column
+// label at drag-time never changes a column's color out from under an operator.
+const DefaultColumnColor = "#8c8c8c"
+
+// ColumnColor resolves the forge label color for a board column by name: the
+// pinned DefaultColumns color for a known default column, else DefaultColumnColor.
+// This keeps the column palette a single source of truth (the constants), so
+// AutoMove can recreate a drifted/missing column label with its correct color.
+func ColumnColor(name string) string {
+	for _, c := range DefaultColumns {
+		if c.Name == name {
+			return c.Color
+		}
+	}
+	return DefaultColumnColor
+}
+
 // prdLinkRe matches a PRD reference in an issue description: a bare or
 // blob-URL-prefixed path to a prds/.../<file>.md, allowing subdirectories
 // (e.g. prds/done/1-foo.md). Computed at fetch time; the description itself is
@@ -210,6 +229,22 @@ func (s *Service) AutoMove(ctx context.Context, f forge.Forge, forgeProjectID in
 		columnSet[c.LabelName] = struct{}{}
 	}
 	add, remove, newLabels := board.PlanLabelMove(current, columnSet, target)
+
+	// Ensure the label we are about to add exists on the forge before writing it
+	// (mirrors SetIssueLabel). AutoMove is the manual-drag / run-automation path and
+	// must not assume the forge already carries the target column's label — it can
+	// be missing or drifted (e.g. the Upcoming→Planned rename, #176). add is the
+	// target column and has at most one element; an empty add (already in the target
+	// column, or a move to Open) ensures nothing and keeps the cheap no-forge-call path.
+	if len(add) > 0 {
+		labels := make([]forge.Label, 0, len(add))
+		for _, name := range add {
+			labels = append(labels, forge.Label{Name: name, Color: ColumnColor(name)})
+		}
+		if err := f.EnsureLabels(ctx, forgeProjectID, labels); err != nil {
+			return store.Issue{}, err
+		}
+	}
 
 	// Forge-first: apply the label change remotely before touching the cache. On
 	// failure the cache is untouched (UpdateIssueLabels no-ops on empty sets, so a

--- a/api/internal/forgesvc/sync_test.go
+++ b/api/internal/forgesvc/sync_test.go
@@ -2,6 +2,7 @@ package forgesvc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -596,6 +597,107 @@ func TestIncrementalSyncZeroHWMSendsNoLowerBound(t *testing.T) {
 			assertBound(t, "open", open[0].UpdatedAfter, tc.wantOpn)
 		})
 	}
+}
+
+// boardColumns builds the []store.BoardColumn AutoMove reads (only LabelName is
+// consulted) from the default column names plus any extra custom names a case
+// needs. AutoMove's columnSet is what makes a label a "column label", so a target
+// must appear here to be planned as a column move.
+func boardColumns(extra ...string) []store.BoardColumn {
+	names := append([]string{"Planned", "In Progress", "Human Review", "Later"}, extra...)
+	cols := make([]store.BoardColumn, 0, len(names))
+	for _, n := range names {
+		cols = append(cols, store.BoardColumn{LabelName: n})
+	}
+	return cols
+}
+
+// autoMoveIssue builds a cached issue whose Labels JSON is exactly labels, so a
+// case controls whether the target column is already present.
+func autoMoveIssue(t *testing.T, labels ...string) store.Issue {
+	t.Helper()
+	raw, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatalf("marshal labels: %v", err)
+	}
+	return store.Issue{RepoID: uuid.New(), ForgeIssueIid: 42, Title: "t", State: "opened", Labels: raw}
+}
+
+// TestAutoMoveEnsuresTargetColumnLabel proves AutoMove now EnsureLabels the
+// target column before writing it (mirroring SetIssueLabel), so a manual drag to
+// a column whose forge label is missing or drifted recreates it — with the right
+// color — instead of failing the UpdateIssueLabels write. It also pins the cheap
+// path: an empty add (already in the target column) ensures nothing.
+func TestAutoMoveEnsuresTargetColumnLabel(t *testing.T) {
+	t.Run("recreates a default column with its pinned color", func(t *testing.T) {
+		st := &fakeStore{}
+		svc := newTestService(st)
+		f := &fakeForge{}
+		issue := autoMoveIssue(t) // no cached labels: the target is absent
+
+		if _, err := svc.AutoMove(context.Background(), f, 7, issue, boardColumns(), "Planned"); err != nil {
+			t.Fatalf("AutoMove: %v", err)
+		}
+		if len(f.ensureCalls) != 1 {
+			t.Fatalf("expected exactly one EnsureLabels call, got %d: %+v", len(f.ensureCalls), f.ensureCalls)
+		}
+		got := f.ensureCalls[0]
+		if len(got) != 1 || got[0].Name != "Planned" || got[0].Color != "#6699cc" {
+			t.Fatalf("ensured label = %+v, want [{Planned #6699cc}]", got)
+		}
+		if len(f.updateCalls) != 1 || len(f.updateCalls[0].add) != 1 || f.updateCalls[0].add[0] != "Planned" {
+			t.Fatalf("update add = %+v, want [Planned]", f.updateCalls)
+		}
+	})
+
+	t.Run("custom column falls back to grey", func(t *testing.T) {
+		st := &fakeStore{}
+		svc := newTestService(st)
+		f := &fakeForge{}
+		issue := autoMoveIssue(t) // Triage not cached
+
+		if _, err := svc.AutoMove(context.Background(), f, 7, issue, boardColumns("Triage"), "Triage"); err != nil {
+			t.Fatalf("AutoMove: %v", err)
+		}
+		if len(f.ensureCalls) != 1 {
+			t.Fatalf("expected exactly one EnsureLabels call, got %d: %+v", len(f.ensureCalls), f.ensureCalls)
+		}
+		got := f.ensureCalls[0]
+		if len(got) != 1 || got[0].Name != "Triage" || got[0].Color != DefaultColumnColor {
+			t.Fatalf("ensured label = %+v, want [{Triage %s}]", got, DefaultColumnColor)
+		}
+	})
+
+	t.Run("an EnsureLabels error blocks the move", func(t *testing.T) {
+		st := &fakeStore{}
+		svc := newTestService(st)
+		f := &fakeForge{ensureErr: errors.New("forge down")}
+		issue := autoMoveIssue(t) // target absent, so EnsureLabels runs
+
+		if _, err := svc.AutoMove(context.Background(), f, 7, issue, boardColumns(), "Planned"); err == nil {
+			t.Fatal("expected AutoMove to propagate the EnsureLabels error")
+		}
+		if len(f.updateCalls) != 0 {
+			t.Fatalf("UpdateIssueLabels ran despite the ensure error: %+v", f.updateCalls)
+		}
+		if len(st.upserts) != 0 {
+			t.Fatalf("cache upsert ran despite the ensure error: %+v", st.upserts)
+		}
+	})
+
+	t.Run("no ensure when already in the target column", func(t *testing.T) {
+		st := &fakeStore{}
+		svc := newTestService(st)
+		f := &fakeForge{}
+		issue := autoMoveIssue(t, "Planned") // already in target: add is empty
+
+		if _, err := svc.AutoMove(context.Background(), f, 7, issue, boardColumns(), "Planned"); err != nil {
+			t.Fatalf("AutoMove: %v", err)
+		}
+		if len(f.ensureCalls) != 0 {
+			t.Fatalf("expected no EnsureLabels call (empty add), got %+v", f.ensureCalls)
+		}
+	})
 }
 
 // assertBound compares one fetch's UpdatedAfter against a want, where nil means

--- a/api/internal/handler/board.go
+++ b/api/internal/handler/board.go
@@ -28,7 +28,7 @@ import (
 
 // defaultColumnColor is used when a user adds a brand-new column whose label
 // does not yet exist on the forge.
-const defaultColumnColor = "#8c8c8c"
+const defaultColumnColor = forgesvc.DefaultColumnColor
 
 // maxBoardColumns caps how many columns a board may have. Each column is an
 // EnsureLabels call on the forge and a rendered lane; the cap bounds both the


### PR DESCRIPTION
Implements issue #352.

Closes #352

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-352`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Board automation now applies the correct color when creating missing default or custom column labels.
  * Issue labels and cached data remain unchanged if label setup fails.
  * Label setup is skipped when an issue is already in the target column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->