### PR TITLE
Default-schedule parity: allow override_subagent_model on defaults + add schedule edit --model flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ through `[0.52.0]`.)
 
 ## [Unreleased]
 
+### Added
+
+- **Default schedules gain model-parity with custom schedules ([#691](https://github.com/vtmocanu/uzi/issues/691)).**
+  An owner can now set "Apply model also to agents" (`override_subagent_model`) on a default (catalog) schedule in place — via the web modal, the API, and `uzi schedule edit --apply-model-to-agents` — instead of having to clone it first; Reset restores it to the catalog baseline (off) alongside the other editable fields. `uzi schedule edit` also gains a `--model <alias|id>` flag (empty clears back to the Worker-model default) for both custom and default schedules, closing the gap where the CLI could not change a schedule's model that the web UI and API already could.
+
 ## [0.68.0] - 2026-08-29
 
 ### Changed

--- a/api/cmd/uzi/schedule.go
+++ b/api/cmd/uzi/schedule.go
@@ -774,6 +774,7 @@ func newScheduleEditCmd(env Env, gf *globalFlags) *cobra.Command {
 	edit.Flags().Bool("clear-guidance", false, "clear stored guidance back to none (issue/sweep targets, or a prompt-target or sweep-target default)")
 	edit.Flags().Bool("clear-max-issues", false, "clear the sweep cap back to unlimited (sweep target only)")
 	edit.Flags().Bool("apply-model-to-agents", false, "set whether the schedule's model also overrides every subagent's model pin")
+	edit.Flags().String("model", "", "change the model alias (opus/sonnet/haiku/fable) or custom model ID for runs this schedule fires; empty string clears it back to your Worker-model default (valid on every target)")
 	edit.Flags().String("repo", "", "repoint the schedule to another repo by id (sweep/prompt targets; an issue-target schedule cannot be repointed)")
 	edit.Flags().Bool("create-missing-labels", false, "for a sweep target: create any newly-set --label missing on the schedule's repo before saving the edit (default: warn only)")
 	return edit
@@ -920,6 +921,11 @@ func buildScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO) (apity
 		req.MaxIssues = nil
 		changed = true
 	}
+	if f.Changed("model") {
+		v, _ := f.GetString("model")
+		req.Model = &v
+		changed = true
+	}
 	if f.Changed("apply-model-to-agents") {
 		v, _ := f.GetBool("apply-model-to-agents")
 		req.OverrideSubagentModel = &v
@@ -951,11 +957,12 @@ func buildScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO) (apity
 // User-editable on a default: cron, timezone, auto_approve, wait_on_limit, and — for a
 // sweep — max_issues. For a sweep, max_issues is RESTATED from the fetched row because
 // patchDefaultScheduleConfig uses replace-semantics on it (an omitted value clears the cap
-// to unlimited). model and override_subagent_model are NOT user-editable on a default via
-// this command: there is no --model edit flag, and patchDefaultScheduleConfig never reads
-// req.OverrideSubagentModel (it keeps the seeded value), so --apply-model-to-agents is
-// refused client-side rather than reporting a false "updated". They are still restated from
-// the fetched row so a value is never dropped should the server later honor them.
+// to unlimited). model and override_subagent_model ARE now owner-editable on a default
+// (issue #691): --model sets the run model (empty string clears it back to the Worker-model
+// default) and --apply-model-to-agents sets override_subagent_model, since
+// patchDefaultScheduleConfig reads both req.Model and req.OverrideSubagentModel. Both are
+// restated from the fetched row (replace-semantics) so a partial edit does not drop them,
+// and an explicit flag overrides the restated value.
 //
 // Guidance is owner-editable on a PROMPT-target default (PRD #662 M1) and a SWEEP-target
 // default (issue #675, where it is an overlay composed onto the baked catalog guidance at
@@ -991,14 +998,6 @@ func buildDefaultScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO)
 	if guidanceSet && clearGuidance {
 		return apitypes.ScheduleRequest{}, uzicli.Exitf(uzicli.ExitUsage, "--guidance and --clear-guidance are mutually exclusive")
 	}
-	// --apply-model-to-agents (override_subagent_model) is not editable on a default: the
-	// server keeps the seeded value and never reads it from the request, so accepting the
-	// flag would report a success that did not happen. Refuse it client-side.
-	if f.Changed("apply-model-to-agents") {
-		return apitypes.ScheduleRequest{}, uzicli.Exitf(uzicli.ExitUsage,
-			"--apply-model-to-agents cannot be edited on a default schedule; clone it first with `uzi schedule clone`")
-	}
-
 	maxIssuesSet := f.Changed("max-issues")
 	clearMaxIssues := f.Changed("clear-max-issues")
 	if (maxIssuesSet || clearMaxIssues) && s.Target != schedTargetSweep {
@@ -1009,7 +1008,8 @@ func buildDefaultScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO)
 	}
 
 	// FRESH minimal request: only catalog-editable fields. Restate model/override from the
-	// fetched row (harmless; neither is user-editable here — see the doc comment). Leave
+	// fetched row so a partial edit keeps them; an explicit --model/--apply-model-to-agents
+	// overrides below (issue #691 — see the doc comment). Leave
 	// Target/Labels/Prompt/Guidance/IssueIID/Timing/RunAt/RepoID at zero so the guard passes.
 	req := apitypes.ScheduleRequest{
 		CronExpr:              s.CronExpr,
@@ -1083,9 +1083,24 @@ func buildDefaultScheduleEditRequest(cmd *cobra.Command, s apitypes.ScheduleDTO)
 		req.Guidance = &empty
 		changed = true
 	}
+	// --model is owner-editable on a default (issue #691): patchDefaultScheduleConfig reads
+	// req.Model. Restated from the fetched row above; an explicit flag overrides (empty clears).
+	if f.Changed("model") {
+		v, _ := f.GetString("model")
+		req.Model = &v
+		changed = true
+	}
+	// --apply-model-to-agents is owner-editable on a default (issue #691):
+	// patchDefaultScheduleConfig reads req.OverrideSubagentModel. Restated from the fetched
+	// row above; an explicit flag overrides.
+	if f.Changed("apply-model-to-agents") {
+		v, _ := f.GetBool("apply-model-to-agents")
+		req.OverrideSubagentModel = &v
+		changed = true
+	}
 	if !changed {
 		return apitypes.ScheduleRequest{}, uzicli.Exitf(uzicli.ExitUsage,
-			"nothing to edit (pass at least one editable field: --cron, --tz, --auto-approve, --wait-on-limit, --max-issues, --guidance)")
+			"nothing to edit (pass at least one editable field: --cron, --tz, --auto-approve, --wait-on-limit, --max-issues, --guidance, --model, --apply-model-to-agents)")
 	}
 	return req, nil
 }

--- a/api/cmd/uzi/schedule_test.go
+++ b/api/cmd/uzi/schedule_test.go
@@ -1054,7 +1054,6 @@ func TestScheduleEditDefaultCatalogOwnedFlagsRejected(t *testing.T) {
 		{"prompt", true, []string{"edit", "sch_dp", "--prompt", "x"}},
 		{"repo", false, []string{"edit", "sch_d", "--repo", "22222222-2222-2222-2222-222222222222"}},
 		{"at", false, []string{"edit", "sch_d", "--at", "2026-08-08T09:00:00Z"}},
-		{"apply-model-to-agents", false, []string{"edit", "sch_d", "--apply-model-to-agents=true"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1075,6 +1074,62 @@ func TestScheduleEditDefaultCatalogOwnedFlagsRejected(t *testing.T) {
 				t.Errorf("stderr = %q, want it to mention clone", errOut)
 			}
 		})
+	}
+}
+
+// TestScheduleEditDefaultApplyModelToAgents (issue #691): --apply-model-to-agents=true on a
+// default is now ACCEPTED (patchDefaultScheduleConfig reads req.OverrideSubagentModel) — the
+// positive inversion of the deleted rejection case. It exits 0, a PATCH is sent, and the
+// override lands as a non-nil true.
+func TestScheduleEditDefaultApplyModelToAgents(t *testing.T) {
+	fc := editDefaultSweepFixture("sch_d")
+	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_d", "--apply-model-to-agents=true")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut)
+	}
+	if fc.LastPatchSchedID == "" {
+		t.Fatal("patch should have been called, got empty id")
+	}
+	if req := fc.LastPatchSchedReq; req.OverrideSubagentModel == nil || !*req.OverrideSubagentModel {
+		t.Errorf("override_subagent_model = %v, want a non-nil true", req.OverrideSubagentModel)
+	}
+}
+
+// TestScheduleEditDefaultModel (issue #691): --model on a default is owner-editable
+// (patchDefaultScheduleConfig reads req.Model). It exits 0, a PATCH is sent, and the new
+// model lands as a non-nil "opus".
+func TestScheduleEditDefaultModel(t *testing.T) {
+	fc := editDefaultSweepFixture("sch_d")
+	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_d", "--model", "opus")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut)
+	}
+	if fc.LastPatchSchedID == "" {
+		t.Fatal("patch should have been called, got empty id")
+	}
+	if req := fc.LastPatchSchedReq; req.Model == nil || *req.Model != "opus" {
+		t.Errorf("model = %v, want a non-nil \"opus\"", req.Model)
+	}
+}
+
+// TestScheduleEditUserModel (issue #691, Scope B): --model on a USER schedule wires the same
+// way as the default path. It exits 0, a PATCH is sent with the new model, and the untouched
+// OverrideSubagentModel stays RESTATED from the fetch (a model edit must not disturb it).
+func TestScheduleEditUserModel(t *testing.T) {
+	fc := editModelFixture("sch_em")
+	_, errOut, code := runCLI(t, fakeEnv(fc), "schedule", "edit", "sch_em", "--model", "sonnet")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut)
+	}
+	if fc.LastPatchSchedID == "" {
+		t.Fatal("patch should have been called, got empty id")
+	}
+	req := fc.LastPatchSchedReq
+	if req.Model == nil || *req.Model != "sonnet" {
+		t.Errorf("model = %v, want a non-nil \"sonnet\"", req.Model)
+	}
+	if req.OverrideSubagentModel == nil || !*req.OverrideSubagentModel {
+		t.Errorf("override_subagent_model = %v, want the fetched true restated, not disturbed", req.OverrideSubagentModel)
 	}
 }
 

--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -194,6 +194,77 @@ func TestPatchDefaultScheduleCustomizedLiveDB(t *testing.T) {
 	}
 }
 
+// TestPatchDefaultOverrideSubagentModelLiveDB (issue #691): override_subagent_model is a run
+// option owner-editable on a default. A config PATCH toggling it persists AND flips
+// customized (its catalog baseline is always false, so any toggled-on value diverges); an
+// exact-restore back to false un-customizes; and Reset restores the catalog baseline (false)
+// and clears customized.
+func TestPatchDefaultOverrideSubagentModelLiveDB(t *testing.T) {
+	ctx := context.Background()
+	f := newScheduleFixture(ctx, t)
+
+	dto, code := f.enableCatalog(t, f.owner.ID, f.repoID, "docs-hygiene")
+	if code != http.StatusCreated {
+		t.Fatalf("enable status = %d, want 201", code)
+	}
+	// Fresh default: the override is at the catalog baseline (false) and the row is not customized.
+	if dto.OverrideSubagentModel == nil || *dto.OverrideSubagentModel {
+		t.Fatalf("fresh default override = %v, want a non-nil false (catalog baseline)", dto.OverrideSubagentModel)
+	}
+	if dto.Customized {
+		t.Fatal("fresh default customized = true, want false")
+	}
+
+	// Toggling override on persists and flips customized.
+	on := f.patchDefault(t, f.owner.ID, dto.ID, `{"override_subagent_model":true}`)
+	if on.OverrideSubagentModel == nil || !*on.OverrideSubagentModel {
+		t.Fatalf("patched override = %v, want a non-nil true (persisted)", on.OverrideSubagentModel)
+	}
+	if !on.Customized {
+		t.Fatal("override-on divergence: customized = false, want true")
+	}
+
+	// It really persisted: re-read via GET surfaces the toggled-on override.
+	got, gcode := f.getSchedule(t, f.owner.ID, dto.ID)
+	if gcode != http.StatusOK {
+		t.Fatalf("re-read status = %d, want 200", gcode)
+	}
+	if got.OverrideSubagentModel == nil || !*got.OverrideSubagentModel {
+		t.Fatalf("re-read override = %v, want the persisted true", got.OverrideSubagentModel)
+	}
+
+	// Toggling it back off is an exact-restore: override false AND customized cleared.
+	off := f.patchDefault(t, f.owner.ID, dto.ID, `{"override_subagent_model":false}`)
+	if off.OverrideSubagentModel == nil || *off.OverrideSubagentModel {
+		t.Fatalf("restored override = %v, want a non-nil false", off.OverrideSubagentModel)
+	}
+	if off.Customized {
+		t.Fatal("exact-restore: customized = true, want false (un-customizes)")
+	}
+
+	// Toggle on again, then Reset drops it back to the catalog baseline and un-customizes.
+	reon := f.patchDefault(t, f.owner.ID, dto.ID, `{"override_subagent_model":true}`)
+	if reon.OverrideSubagentModel == nil || !*reon.OverrideSubagentModel {
+		t.Fatalf("re-toggled override = %v, want a non-nil true", reon.OverrideSubagentModel)
+	}
+	resetReq := userReq(http.MethodPost, "/api/schedules/"+dto.ID+"/reset", "", f.owner.ID, map[string]string{"id": dto.ID})
+	resetRec := httptest.NewRecorder()
+	f.h.ResetSchedule(resetRec, resetReq)
+	if resetRec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200 (body %s)", resetRec.Code, resetRec.Body.String())
+	}
+	var reset apitypes.ScheduleDTO
+	if err := json.Unmarshal(resetRec.Body.Bytes(), &reset); err != nil {
+		t.Fatalf("decode reset: %v", err)
+	}
+	if reset.OverrideSubagentModel == nil || *reset.OverrideSubagentModel {
+		t.Fatalf("reset override = %v, want the catalog baseline false restored", reset.OverrideSubagentModel)
+	}
+	if reset.Customized {
+		t.Fatal("reset customized = true, want false")
+	}
+}
+
 // cloneSchedule POSTs to /api/schedules/{id}/clone with the given (possibly empty) body and
 // returns the decoded DTO plus the status code.
 func (f scheduleFixture) cloneSchedule(t *testing.T, user uuid.UUID, id, body string) (apitypes.ScheduleDTO, int) {

--- a/api/internal/handler/schedules.go
+++ b/api/internal/handler/schedules.go
@@ -1117,6 +1117,15 @@ func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Requ
 		guidance = pgtype.Text{String: *req.Guidance, Valid: true}
 	}
 
+	// override_subagent_model is a run option (not a catalog field), owner-editable on a
+	// default (issue #691). It takes replace-semantics from the request like the other run
+	// options — an omitted value keeps the stored one. Its catalog baseline is always false,
+	// so any toggled-on value OR-s into customized (see the recompute below).
+	ov := cur.OverrideSubagentModel
+	if req.OverrideSubagentModel != nil {
+		ov = *req.OverrideSubagentModel
+	}
+
 	// customized latches on divergence but the reset endpoint clears it; a patch that puts
 	// every editable field back to the catalog default also clears it (recomputed fresh, not
 	// OR-ed with a stale true — Reset and an exact-restore patch both un-customize).
@@ -1136,6 +1145,10 @@ func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Requ
 	if guidanceEditable {
 		customized = customized || guidance.Valid
 	}
+	// override_subagent_model is a run option (not a catalog field, so not in
+	// defaultEditableDiverges' inputs); its catalog baseline is always false, so any
+	// toggled-on value diverges (issue #691). Mirrors the guidance precedent above.
+	customized = customized || ov
 
 	final, err := h.q.UpdateRunSchedule(r.Context(), store.UpdateRunScheduleParams{
 		Target:                cur.Target,
@@ -1153,7 +1166,7 @@ func (h *Handler) patchDefaultScheduleConfig(w http.ResponseWriter, r *http.Requ
 		MaxIssues:             maxIssues,
 		Guidance:              guidance,
 		Model:                 model,
-		OverrideSubagentModel: cur.OverrideSubagentModel,
+		OverrideSubagentModel: ov,
 		Customized:            customized,
 		ID:                    id,
 		UserID:                user.ID,

--- a/api/internal/store/queries/schedules.sql
+++ b/api/internal/store/queries/schedules.sql
@@ -60,8 +60,11 @@ WHERE user_id = @user_id AND repo_id = @repo_id AND catalog_slug = @catalog_slug
 -- row can never be reset through this path (the handler 409s that case before calling).
 -- The prompt/labels stay NULL (catalog-owned); guidance is explicitly cleared to NULL here
 -- because a prompt default can carry owner-editable guidance (issue #662) and a Reset must
--- drop it back to the catalog baseline. next_fire_at is recomputed in Go from the catalog
--- cron+timezone and passed in.
+-- drop it back to the catalog baseline. override_subagent_model is likewise reset to the
+-- catalog baseline (false) because a default now carries it as an owner-editable run option
+-- (issue #691). Both are written as SQL literals rather than left to the column's DB DEFAULT:
+-- a Reset is an UPDATE, so the DEFAULT never re-applies and the field must be set explicitly.
+-- next_fire_at is recomputed in Go from the catalog cron+timezone and passed in.
 UPDATE run_schedules
 SET cron_expr     = @cron_expr,
     timezone      = @timezone,
@@ -70,6 +73,7 @@ SET cron_expr     = @cron_expr,
     wait_on_limit = @wait_on_limit,
     max_issues    = sqlc.narg('max_issues'),
     guidance      = NULL,
+    override_subagent_model = false,
     next_fire_at  = @next_fire_at,
     customized    = false,
     status        = 'active',

--- a/api/internal/store/schedules.sql.go
+++ b/api/internal/store/schedules.sql.go
@@ -901,6 +901,7 @@ SET cron_expr     = $1,
     wait_on_limit = $5,
     max_issues    = $6,
     guidance      = NULL,
+    override_subagent_model = false,
     next_fire_at  = $7,
     customized    = false,
     status        = 'active',
@@ -926,8 +927,11 @@ type ResetDefaultScheduleParams struct {
 // row can never be reset through this path (the handler 409s that case before calling).
 // The prompt/labels stay NULL (catalog-owned); guidance is explicitly cleared to NULL here
 // because a prompt default can carry owner-editable guidance (issue #662) and a Reset must
-// drop it back to the catalog baseline. next_fire_at is recomputed in Go from the catalog
-// cron+timezone and passed in.
+// drop it back to the catalog baseline. override_subagent_model is likewise reset to the
+// catalog baseline (false) because a default now carries it as an owner-editable run option
+// (issue #691). Both are written as SQL literals rather than left to the column's DB DEFAULT:
+// a Reset is an UPDATE, so the DEFAULT never re-applies and the field must be set explicitly.
+// next_fire_at is recomputed in Go from the catalog cron+timezone and passed in.
 func (q *Queries) ResetDefaultSchedule(ctx context.Context, arg ResetDefaultScheduleParams) (RunSchedule, error) {
 	row := q.db.QueryRow(ctx, resetDefaultSchedule,
 		arg.CronExpr,

--- a/api/internal/uzicli/skill/SKILL.md
+++ b/api/internal/uzicli/skill/SKILL.md
@@ -162,7 +162,7 @@ uzi run resume-now <run-id>
 uzi schedule create --repo <repo-id> [--repo <repo-id>]... (--issue <iid> | --sweep [--label <l>]... [--create-missing-labels] | --prompt <text>) (--at <rfc3339> | --cron <expr>) [--tz <iana>] [--enabled[=false]] [--auto-approve[=false]] [--wait-on-limit]
 uzi schedule list
 uzi schedule get <schedule-id>
-uzi schedule edit <schedule-id> [--repo <repo-id>] [--cron <expr> | --at <rfc3339>] [--tz <iana>] [--prompt <text>] [--label <l>]... [--create-missing-labels] [--guidance <text> | --clear-guidance] [--max-issues <n> | --clear-max-issues] [--auto-approve[=false]] [--wait-on-limit[=false]]
+uzi schedule edit <schedule-id> [--repo <repo-id>] [--cron <expr> | --at <rfc3339>] [--tz <iana>] [--prompt <text>] [--label <l>]... [--create-missing-labels] [--guidance <text> | --clear-guidance] [--max-issues <n> | --clear-max-issues] [--auto-approve[=false]] [--wait-on-limit[=false]] [--model <alias|id>] [--apply-model-to-agents]
 uzi schedule pause <schedule-id>
 uzi schedule resume <schedule-id>
 uzi schedule run-now <schedule-id>
@@ -565,10 +565,12 @@ nothing a manual start cannot.
   (enabled=false) schedule, which stays off until `resume`. Retime with `--cron` or `--at`
   (switching timing accordingly), adjust `--tz`, and — scoped to the target — `--prompt`,
   `--label`, `--guidance`/`--clear-guidance`, `--max-issues`/`--clear-max-issues`,
-  `--auto-approve`, `--wait-on-limit`, `--apply-model-to-agents` (toggle the subagent
-  model override). At least one field is required. `edit` does NOT change the model
-  itself, but it now preserves the stored `--model` and `--apply-model-to-agents` across
-  any partial edit (previously a plain retime silently wiped the stored model). Changing a
+  `--auto-approve`, `--wait-on-limit`, `--model <alias|id>` (change the run model in
+  place; an empty string clears it back to the Worker-model default; valid on every
+  target and origin), `--apply-model-to-agents` (toggle the subagent model override). At
+  least one field is required. `edit` preserves the stored `--model` and
+  `--apply-model-to-agents` across any partial edit that does not pass those flags
+  (previously a plain retime silently wiped the stored model). Changing a
   sweep schedule's `--label` selector runs the same advisory sweep-label guardrail as
   `create`/`catalog enable` (`WARNING` on a newly-set label missing on the repo, or
   `--create-missing-labels` to create it first); it never blocks the edit, and an edit that
@@ -604,9 +606,9 @@ nothing a manual start cannot.
   failed label check or create prints a `WARNING` and proceeds (the enable otherwise reads
   nothing from the forge).
 - `uzi schedule reset <schedule-id>` — restore a **default** schedule's edited fields (cron,
-  timezone, model, auto-approve, wait-on-limit, max-issues) to the builtin catalog values and
-  clear its customized flag. Only a default-origin schedule can be reset; a user-origin one is
-  a `409`.
+  timezone, model, apply-model-to-agents, auto-approve, wait-on-limit, max-issues) to the
+  builtin catalog values — `apply-model-to-agents` resets to `false` — and clear its
+  customized flag. Only a default-origin schedule can be reset; a user-origin one is a `409`.
 - `uzi schedule clone <schedule-id> [--repo <repo-id>]` — copy a schedule into a new, fully
   editable schedule you own. Cloning a **default** schedule lifts its catalog prompt lock (the
   baked prompt, or a sweep's labels/guidance, is copied into the new row, which becomes a

--- a/api/internal/uzicli/skill/SKILL.md
+++ b/api/internal/uzicli/skill/SKILL.md
@@ -162,7 +162,7 @@ uzi run resume-now <run-id>
 uzi schedule create --repo <repo-id> [--repo <repo-id>]... (--issue <iid> | --sweep [--label <l>]... [--create-missing-labels] | --prompt <text>) (--at <rfc3339> | --cron <expr>) [--tz <iana>] [--enabled[=false]] [--auto-approve[=false]] [--wait-on-limit]
 uzi schedule list
 uzi schedule get <schedule-id>
-uzi schedule edit <schedule-id> [--repo <repo-id>] [--cron <expr> | --at <rfc3339>] [--tz <iana>] [--prompt <text>] [--label <l>]... [--create-missing-labels] [--guidance <text> | --clear-guidance] [--max-issues <n> | --clear-max-issues] [--auto-approve[=false]] [--wait-on-limit[=false]] [--model <alias|id>] [--apply-model-to-agents]
+uzi schedule edit <schedule-id> [--repo <repo-id>] [--cron <expr> | --at <rfc3339>] [--tz <iana>] [--prompt <text>] [--label <l>]... [--create-missing-labels] [--guidance <text> | --clear-guidance] [--max-issues <n> | --clear-max-issues] [--auto-approve[=false]] [--wait-on-limit[=false]] [--model <alias|id>] [--apply-model-to-agents[=false]]
 uzi schedule pause <schedule-id>
 uzi schedule resume <schedule-id>
 uzi schedule run-now <schedule-id>

--- a/api/internal/uzidocs/embed/cli.md
+++ b/api/internal/uzidocs/embed/cli.md
@@ -108,7 +108,7 @@ uzi schedule edit <id> [--cron <expr> | --at <rfc3339>] [--tz <iana>]
                    [--auto-approve[=false]] [--wait-on-limit[=false]]
                    [--guidance <text> | --clear-guidance]
                    [--max-issues <n> | --clear-max-issues]
-                   [--apply-model-to-agents] [--repo <id>]
+                   [--model <alias|id>] [--apply-model-to-agents] [--repo <id>]
 uzi schedule catalog list
 uzi schedule catalog enable <slug> --repo <id> [--repo <id> ...] [--create-missing-labels]
 uzi schedule reset <id>
@@ -292,18 +292,24 @@ A few worth knowing:
   (`--clear-guidance`)/`--max-issues` (`--clear-max-issues`)/`--auto-approve`/
   `--wait-on-limit`/`--apply-model-to-agents` (toggle the subagent model
   override) — without churning the id or
-  run history the way delete-and-recreate would; `edit` does not change the
-  model itself (there is no `--model` edit flag), but it now preserves the
-  stored `--model` and `--apply-model-to-agents` across a partial edit — a plain
-  retime previously wiped the stored model. On a **default-origin** schedule only
+  run history the way delete-and-recreate would; `edit` now accepts
+  `--model <alias|id>` to change the run model in place, valid on every
+  target and origin (an empty string clears it back to the Worker-model
+  default), and it preserves the stored `--model` and `--apply-model-to-agents`
+  across a partial edit that does not pass those flags — a plain retime no
+  longer wipes the stored model. On a **default-origin** schedule only
   the catalog-editable fields (`--cron`, `--tz`, `--auto-approve`,
-  `--wait-on-limit`, `--max-issues`, `--clear-max-issues`) may be edited, plus
+  `--wait-on-limit`, `--max-issues`, `--clear-max-issues`, `--model`,
+  `--apply-model-to-agents`) may be edited — no clone needed — plus
   `--guidance`/`--clear-guidance` on a **prompt-target or sweep-target default**
   (owner steering is editable there — a partial edit restates the stored guidance
   so it is not wiped; on a sweep default the guidance is an **overlay** composed
-  onto the read-only baked catalog guidance at fire time); the catalog-owned fields
-  (`--prompt`, `--label`, `--repo`, `--at`, and `--guidance` on an issue default)
-  require `uzi schedule clone` first. Changing a sweep schedule's `--label`
+  onto the read-only baked catalog guidance at fire time); a **Reset** restores
+  `--apply-model-to-agents` to its catalog baseline of `false` alongside the
+  other catalog fields. The catalog-owned fields (`--prompt`, `--label`,
+  `--repo`, `--at`, and `--guidance` on an issue default) still require
+  `uzi schedule clone` first — the subagent-model toggle is not among them.
+  Changing a sweep schedule's `--label`
   selector runs the same advisory sweep-label guardrail as `create`/`catalog
   enable`: it `WARNING`s (to stderr) on any newly-set label missing on the
   schedule's repo, or creates it first with `--create-missing-labels`, and never
@@ -351,8 +357,9 @@ A few worth knowing:
   an enable (which otherwise reads nothing from the forge, computing the next fire
   from the catalog cron).
 - **`schedule reset <id>`** restores a **default** schedule's edited fields (cron,
-  timezone, model, auto-approve, wait-on-limit, max-issues) to the builtin catalog
-  values and clears its customized flag. Only a default-origin schedule can be
+  timezone, model, apply-model-to-agents, auto-approve, wait-on-limit,
+  max-issues) to the builtin catalog values — `apply-model-to-agents` resets to
+  `false` — and clears its customized flag. Only a default-origin schedule can be
   reset; a user-origin one is a `409`.
 - **`schedule clone <id> [--repo <id>]`** copies a schedule into a new, fully
   editable schedule you own. Cloning a **default** schedule lifts its catalog

--- a/api/internal/uzidocs/embed/cli.md
+++ b/api/internal/uzidocs/embed/cli.md
@@ -101,14 +101,14 @@ uzi schedule create --repo <id> [--repo <id> ...] (--issue <iid> | --sweep [--la
                     (--at <rfc3339> | --cron <expr>) [--tz <iana>]
                     [--auto-approve[=false]] [--wait-on-limit[=false]]
                     [--max-issues <n>] [--guidance <text>]
-                    [--model <alias|id>] [--apply-model-to-agents]
+                    [--model <alias|id>] [--apply-model-to-agents[=false]]
 uzi schedule list | get <id> | pause <id> | resume <id> | run-now <id> | delete <id>
 uzi schedule edit <id> [--cron <expr> | --at <rfc3339>] [--tz <iana>]
                    [--prompt <text> | --label <l> ... [--create-missing-labels]]
                    [--auto-approve[=false]] [--wait-on-limit[=false]]
                    [--guidance <text> | --clear-guidance]
                    [--max-issues <n> | --clear-max-issues]
-                   [--model <alias|id>] [--apply-model-to-agents] [--repo <id>]
+                   [--model <alias|id>] [--apply-model-to-agents[=false]] [--repo <id>]
 uzi schedule catalog list
 uzi schedule catalog enable <slug> --repo <id> [--repo <id> ...] [--create-missing-labels]
 uzi schedule reset <id>

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -235,12 +235,16 @@ worker rather than the catalog — its entry is cadence and model only (see
   from the shipped catalog every time the job fires, not copied onto your
   schedule, so a prompt improvement uzi ships later reaches every repo that
   already enabled the job, automatically, with nothing to re-enable. Cadence,
-  model, and the run options (auto-approve, wait-on-limit, max issues) are
-  yours to edit like any schedule — as is owner **guidance** on a prompt-target
-  or sweep-target default (on a sweep default it is an overlay composed onto the
-  read-only baked catalog guidance); a **Reset to default** action puts an edited
-  default back to the catalog's cadence/model/options in one step, and also clears
-  any owner guidance you added to a prompt or sweep default.
+  model, and the run options (auto-approve, wait-on-limit, max issues, and
+  whether the model is also applied to agents — the "apply model also to
+  agents" toggle, `override_subagent_model`) are yours to edit like any
+  schedule — as is owner **guidance** on a prompt-target or sweep-target
+  default (on a sweep default it is an overlay composed onto the read-only
+  baked catalog guidance); a **Reset to default** action puts an edited
+  default back to the catalog's cadence/model/options in one step — including
+  clearing `override_subagent_model` back to its catalog baseline of `false`
+  — and also clears any owner guidance you added to a prompt or sweep
+  default.
 - **Enable on several repos at once.** Enabling a default (or creating a
   custom schedule) against multiple repos creates one independent schedule
   per repo — each with its own cadence, its own pause/resume, its own run

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,7 +108,7 @@ uzi schedule edit <id> [--cron <expr> | --at <rfc3339>] [--tz <iana>]
                    [--auto-approve[=false]] [--wait-on-limit[=false]]
                    [--guidance <text> | --clear-guidance]
                    [--max-issues <n> | --clear-max-issues]
-                   [--apply-model-to-agents] [--repo <id>]
+                   [--model <alias|id>] [--apply-model-to-agents] [--repo <id>]
 uzi schedule catalog list
 uzi schedule catalog enable <slug> --repo <id> [--repo <id> ...] [--create-missing-labels]
 uzi schedule reset <id>
@@ -292,18 +292,24 @@ A few worth knowing:
   (`--clear-guidance`)/`--max-issues` (`--clear-max-issues`)/`--auto-approve`/
   `--wait-on-limit`/`--apply-model-to-agents` (toggle the subagent model
   override) — without churning the id or
-  run history the way delete-and-recreate would; `edit` does not change the
-  model itself (there is no `--model` edit flag), but it now preserves the
-  stored `--model` and `--apply-model-to-agents` across a partial edit — a plain
-  retime previously wiped the stored model. On a **default-origin** schedule only
+  run history the way delete-and-recreate would; `edit` now accepts
+  `--model <alias|id>` to change the run model in place, valid on every
+  target and origin (an empty string clears it back to the Worker-model
+  default), and it preserves the stored `--model` and `--apply-model-to-agents`
+  across a partial edit that does not pass those flags — a plain retime no
+  longer wipes the stored model. On a **default-origin** schedule only
   the catalog-editable fields (`--cron`, `--tz`, `--auto-approve`,
-  `--wait-on-limit`, `--max-issues`, `--clear-max-issues`) may be edited, plus
+  `--wait-on-limit`, `--max-issues`, `--clear-max-issues`, `--model`,
+  `--apply-model-to-agents`) may be edited — no clone needed — plus
   `--guidance`/`--clear-guidance` on a **prompt-target or sweep-target default**
   (owner steering is editable there — a partial edit restates the stored guidance
   so it is not wiped; on a sweep default the guidance is an **overlay** composed
-  onto the read-only baked catalog guidance at fire time); the catalog-owned fields
-  (`--prompt`, `--label`, `--repo`, `--at`, and `--guidance` on an issue default)
-  require `uzi schedule clone` first. Changing a sweep schedule's `--label`
+  onto the read-only baked catalog guidance at fire time); a **Reset** restores
+  `--apply-model-to-agents` to its catalog baseline of `false` alongside the
+  other catalog fields. The catalog-owned fields (`--prompt`, `--label`,
+  `--repo`, `--at`, and `--guidance` on an issue default) still require
+  `uzi schedule clone` first — the subagent-model toggle is not among them.
+  Changing a sweep schedule's `--label`
   selector runs the same advisory sweep-label guardrail as `create`/`catalog
   enable`: it `WARNING`s (to stderr) on any newly-set label missing on the
   schedule's repo, or creates it first with `--create-missing-labels`, and never
@@ -351,8 +357,9 @@ A few worth knowing:
   an enable (which otherwise reads nothing from the forge, computing the next fire
   from the catalog cron).
 - **`schedule reset <id>`** restores a **default** schedule's edited fields (cron,
-  timezone, model, auto-approve, wait-on-limit, max-issues) to the builtin catalog
-  values and clears its customized flag. Only a default-origin schedule can be
+  timezone, model, apply-model-to-agents, auto-approve, wait-on-limit,
+  max-issues) to the builtin catalog values — `apply-model-to-agents` resets to
+  `false` — and clears its customized flag. Only a default-origin schedule can be
   reset; a user-origin one is a `409`.
 - **`schedule clone <id> [--repo <id>]`** copies a schedule into a new, fully
   editable schedule you own. Cloning a **default** schedule lifts its catalog

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,14 +101,14 @@ uzi schedule create --repo <id> [--repo <id> ...] (--issue <iid> | --sweep [--la
                     (--at <rfc3339> | --cron <expr>) [--tz <iana>]
                     [--auto-approve[=false]] [--wait-on-limit[=false]]
                     [--max-issues <n>] [--guidance <text>]
-                    [--model <alias|id>] [--apply-model-to-agents]
+                    [--model <alias|id>] [--apply-model-to-agents[=false]]
 uzi schedule list | get <id> | pause <id> | resume <id> | run-now <id> | delete <id>
 uzi schedule edit <id> [--cron <expr> | --at <rfc3339>] [--tz <iana>]
                    [--prompt <text> | --label <l> ... [--create-missing-labels]]
                    [--auto-approve[=false]] [--wait-on-limit[=false]]
                    [--guidance <text> | --clear-guidance]
                    [--max-issues <n> | --clear-max-issues]
-                   [--model <alias|id>] [--apply-model-to-agents] [--repo <id>]
+                   [--model <alias|id>] [--apply-model-to-agents[=false]] [--repo <id>]
 uzi schedule catalog list
 uzi schedule catalog enable <slug> --repo <id> [--repo <id> ...] [--create-missing-labels]
 uzi schedule reset <id>

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -235,12 +235,16 @@ worker rather than the catalog — its entry is cadence and model only (see
   from the shipped catalog every time the job fires, not copied onto your
   schedule, so a prompt improvement uzi ships later reaches every repo that
   already enabled the job, automatically, with nothing to re-enable. Cadence,
-  model, and the run options (auto-approve, wait-on-limit, max issues) are
-  yours to edit like any schedule — as is owner **guidance** on a prompt-target
-  or sweep-target default (on a sweep default it is an overlay composed onto the
-  read-only baked catalog guidance); a **Reset to default** action puts an edited
-  default back to the catalog's cadence/model/options in one step, and also clears
-  any owner guidance you added to a prompt or sweep default.
+  model, and the run options (auto-approve, wait-on-limit, max issues, and
+  whether the model is also applied to agents — the "apply model also to
+  agents" toggle, `override_subagent_model`) are yours to edit like any
+  schedule — as is owner **guidance** on a prompt-target or sweep-target
+  default (on a sweep default it is an overlay composed onto the read-only
+  baked catalog guidance); a **Reset to default** action puts an edited
+  default back to the catalog's cadence/model/options in one step — including
+  clearing `override_subagent_model` back to its catalog baseline of `false`
+  — and also clears any owner guidance you added to a prompt or sweep
+  default.
 - **Enable on several repos at once.** Enabling a default (or creating a
   custom schedule) against multiple repos creates one independent schedule
   per repo — each with its own cadence, its own pause/resume, its own run

--- a/web/src/components/ScheduleModal.test.tsx
+++ b/web/src/components/ScheduleModal.test.tsx
@@ -560,7 +560,7 @@ describe("editing a catalog default (PRD #589)", () => {
     expect(onCloneToEdit).toHaveBeenCalledWith(fixture);
   });
 
-  it("saving a default sends only the editable fields — not the catalog-owned prompt/target/subagent flag", async () => {
+  it("saving a default sends the editable fields including the subagent flag — not the catalog-owned prompt/target", async () => {
     mockApi.updateSchedule.mockResolvedValue(defaultFixture());
     render(
       <MemoryRouter>
@@ -585,7 +585,12 @@ describe("editing a catalog default (PRD #589)", () => {
     // (a blank textarea clears owner guidance back to none). Not omitted like the rest.
     expect(input && "guidance" in input).toBe(true);
     expect(input?.guidance).toBeNull();
-    expect(input?.override_subagent_model).toBeUndefined();
+    // override_subagent_model is NO LONGER catalog-owned (issue #691): the server now
+    // accepts it on a default patch, so buildDefaultInput sends it with replace-semantics.
+    // The fixture leaves the flag unset, so the toggle defaults to false — assert both that
+    // the value is false AND that the KEY is present (sent, not omitted like the fields below).
+    expect(input?.override_subagent_model).toBe(false);
+    expect(input && "override_subagent_model" in input).toBe(true);
     // timing is catalog-owned too: the server keeps timing="recurring" itself and 400s ANY
     // default patch that carries it, so buildDefaultInput must NOT send it. This is the field
     // that actually broke the real backend — assert its key is absent, not merely its value.
@@ -595,6 +600,27 @@ describe("editing a catalog default (PRD #589)", () => {
     expect(input?.repo_id).toBeUndefined();
     expect(input?.issue_iid).toBeUndefined();
     expect(input?.run_at).toBeUndefined();
+  });
+
+  it("renders the 'Apply model also to agents' toggle on a default, and submits override_subagent_model:true when turned on (issue #691)", async () => {
+    mockApi.updateSchedule.mockResolvedValue(defaultFixture({ override_subagent_model: true }));
+    render(
+      <MemoryRouter>
+        <ScheduleModal editing={defaultFixture()} onClose={vi.fn()} onSaved={vi.fn()} onCloneToEdit={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    // The toggle is now rendered for a DEFAULT (it was previously hidden on defaults). The
+    // fixture leaves the flag unset, so it starts off.
+    const toggle = screen.getByRole("switch", { name: "Apply model also to agents" });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+
+    // Turn it on and save — the flag flows through buildDefaultInput.
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(mockApi.updateSchedule).toHaveBeenCalled());
+    expect(mockApi.updateSchedule.mock.calls[0]?.[1]?.override_subagent_model).toBe(true);
   });
 });
 

--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -167,9 +167,9 @@ export function ScheduleModal({
   const { uziLabel } = useAuth();
   const isEdit = !!editing;
   // A catalog default (PRD #589) is catalog-owned: its target/prompt/labels/guidance are
-  // read-only (shown as the baked, sealed values) and only the cadence, model, and run
-  // flags are editable. override_subagent_model is non-editable on a default too. To get
-  // the full editable set, the owner clones it to a user row (origin='user').
+  // read-only (shown as the baked, sealed values) and the cadence, model, run flags, and
+  // override_subagent_model (issue #691) are editable. To get the full editable set
+  // (including target/prompt/labels/guidance), the owner clones it to a user row (origin='user').
   const isDefault = editing?.origin === "default";
 
   const [repos, setRepos] = useState<Repo[]>([]);
@@ -440,6 +440,9 @@ export function ScheduleModal({
     wait_on_limit: waitOnLimit,
     max_issues: target === "sweep" ? maxIssues : undefined,
     model: model.trim() === "" ? null : model,
+    // PRD #305: apply the run model to every subagent. Editable on a default too
+    // (issue #691) — always sent with replace-semantics.
+    override_subagent_model: overrideSubagentModel,
     guidance:
       target === "prompt" || target === "sweep"
         ? guidance.trim() === ""
@@ -954,23 +957,22 @@ export function ScheduleModal({
           {modelWarning && <Alert message={modelWarning} tone="warning" />}
 
           {/* PRD #305: apply the run model to every subagent. Always enabled — first-class
-              on Inherit (the applied model is the same one the lead resolves). Hidden on a
-              catalog default (PRD #589): the server treats it as non-editable there. */}
-          {!isDefault && (
-            <div className="flex items-start gap-3">
-              <Toggle
-                checked={overrideSubagentModel}
-                onChange={setOverrideSubagentModel}
-                label="Apply model also to agents"
-              />
-              <span className="text-[13px] text-fg">
-                Apply model also to agents
-                <span className="block text-[11px] text-faint">
-                  Subagents run on the same model as the lead — overrides each agent's own model.
-                </span>
+              on Inherit (the applied model is the same one the lead resolves). Editable on a
+              catalog default too (issue #691): the server now accepts it on a default patch,
+              so it is a first-class run option on every schedule. */}
+          <div className="flex items-start gap-3">
+            <Toggle
+              checked={overrideSubagentModel}
+              onChange={setOverrideSubagentModel}
+              label="Apply model also to agents"
+            />
+            <span className="text-[13px] text-fg">
+              Apply model also to agents
+              <span className="block text-[11px] text-faint">
+                Subagents run on the same model as the lead — overrides each agent's own model.
               </span>
-            </div>
-          )}
+            </span>
+          </div>
 
           {/* Options */}
           <div className="space-y-3">


### PR DESCRIPTION
Implements issue #691.

Closes #691

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-691`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Edit the model assigned to custom and default schedules without cloning.
  - Enable or disable applying the selected model to agents on default schedules.
  - Clear model overrides by providing an empty model value.
  - Partial edits preserve existing model-related settings.
- **Bug Fixes**
  - Resetting a default schedule now restores model and agent-application settings to catalog defaults.
- **Documentation**
  - Updated CLI and scheduling documentation with the new editing and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->