### PR TITLE
Auto-set an enabled default job's timezone from the user's detected timezone

### DIFF
--- a/api/internal/apitypes/schedule.go
+++ b/api/internal/apitypes/schedule.go
@@ -227,6 +227,14 @@ type ScheduleCloneRequest struct {
 	RepoID *string `json:"repo_id"`
 }
 
+// EnableCatalogRequest is the OPTIONAL body for POST /api/repos/{id}/schedule-catalog/{slug}
+// (issue #660). Timezone, when present and a valid IANA name, overrides the catalog's baked
+// zone so an enabled default fires in the caller's detected zone from the first fire; an
+// absent/empty body keeps the catalog zone (UTC) — CLI/headless and older clients send none.
+type EnableCatalogRequest struct {
+	Timezone string `json:"timezone"`
+}
+
 // AddScheduleRepoRequest is the body for POST /api/schedules/{id}/add-repo (PRD #636 M1,
 // Decision 5): the id of another repo the caller owns to replicate the source schedule's
 // current config onto as a new sibling in the source's group. RepoID is required and

--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -197,9 +197,17 @@ func TestEnableCatalogScheduleTimezoneOverrideLiveDB(t *testing.T) {
 	}
 
 	// An invalid IANA name is a 400 (on a third repo so the check is independent of state).
+	// A 400 short-circuits before CreateDefaultSchedule, so repoC stays unmaterialized and
+	// the "Local" check below can reuse it.
 	repoC := f.insertRepo(ctx, t, f.owner, 3, "g/sched-tz-c")
 	if _, code := f.enableCatalogBody(t, f.owner.ID, repoC, "docs-hygiene", `{"timezone":"Not/AZone"}`); code != http.StatusBadRequest {
 		t.Fatalf("invalid timezone enable status = %d, want 400", code)
+	}
+
+	// The "Local" sentinel is rejected too: time.LoadLocation("Local") would otherwise
+	// resolve to the server's local zone, making the schedule fire in the deployment's zone.
+	if _, code := f.enableCatalogBody(t, f.owner.ID, repoC, "docs-hygiene", `{"timezone":"Local"}`); code != http.StatusBadRequest {
+		t.Fatalf("\"Local\" timezone enable status = %d, want 400", code)
 	}
 }
 

--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/vtmocanu/uzi/api/internal/apitypes"
+	"github.com/vtmocanu/uzi/api/internal/schedsvc"
 	"github.com/vtmocanu/uzi/api/internal/schedtmpl"
 )
 
@@ -22,6 +24,24 @@ import (
 func (f scheduleFixture) enableCatalog(t *testing.T, user, repoID uuid.UUID, slug string) (apitypes.ScheduleDTO, int) {
 	t.Helper()
 	req := userReq(http.MethodPost, "/api/repos/"+repoID.String()+"/schedule-catalog/"+slug, "",
+		user, map[string]string{"id": repoID.String(), "slug": slug})
+	rec := httptest.NewRecorder()
+	f.h.EnableCatalogSchedule(rec, req)
+	var dto apitypes.ScheduleDTO
+	if rec.Code == http.StatusCreated || rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+			t.Fatalf("decode enable response: %v (body %s)", err, rec.Body.String())
+		}
+	}
+	return dto, rec.Code
+}
+
+// enableCatalogBody is enableCatalog with a caller-supplied request body (issue #660): it
+// POSTs `body` (e.g. a `{"timezone":...}` override) instead of the empty body enableCatalog
+// sends, and returns the decoded DTO plus the status code.
+func (f scheduleFixture) enableCatalogBody(t *testing.T, user, repoID uuid.UUID, slug, body string) (apitypes.ScheduleDTO, int) {
+	t.Helper()
+	req := userReq(http.MethodPost, "/api/repos/"+repoID.String()+"/schedule-catalog/"+slug, body,
 		user, map[string]string{"id": repoID.String(), "slug": slug})
 	rec := httptest.NewRecorder()
 	f.h.EnableCatalogSchedule(rec, req)
@@ -108,6 +128,64 @@ func TestEnableCatalogScheduleIdempotentLiveDB(t *testing.T) {
 	_, code = f.enableCatalog(t, f.owner.ID, f.repoID, "no-such-slug")
 	if code != http.StatusNotFound {
 		t.Fatalf("unknown slug enable status = %d, want 404", code)
+	}
+}
+
+// TestEnableCatalogScheduleTimezoneOverrideLiveDB (issue #660) pins the optional timezone
+// override on enable: a `{"timezone":...}` body makes the enabled default fire in that zone
+// from the first fire (both the stored Timezone and the computed next_fire_at), an
+// empty/absent body keeps the catalog zone (UTC), and an invalid IANA name is a 400.
+func TestEnableCatalogScheduleTimezoneOverrideLiveDB(t *testing.T) {
+	ctx := context.Background()
+	f := newScheduleFixture(ctx, t)
+
+	// A fixed clock so the handler's NextFire and the test's NextFire compute from the same
+	// instant (the fixture leaves h.now nil → time.Now, which two calls could straddle).
+	clock := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	f.h.now = func() time.Time { return clock }
+
+	job, _ := schedtmpl.BySlug("docs-hygiene") // cron "0 3 * * 1": a fixed wall-clock hour, so UTC vs Bucharest differ.
+
+	// A valid override zone is stored on the row and drives next_fire_at.
+	dto, code := f.enableCatalogBody(t, f.owner.ID, f.repoID, "docs-hygiene", `{"timezone":"Europe/Bucharest"}`)
+	if code != http.StatusCreated {
+		t.Fatalf("enable with tz override status = %d, want 201", code)
+	}
+	if dto.Timezone != "Europe/Bucharest" {
+		t.Fatalf("override dto timezone = %q, want Europe/Bucharest", dto.Timezone)
+	}
+	wantNext, err := schedsvc.NextFire(job.Cron, "Europe/Bucharest", clock)
+	if err != nil {
+		t.Fatalf("compute expected Bucharest next fire: %v", err)
+	}
+	utcNext, err := schedsvc.NextFire(job.Cron, "UTC", clock)
+	if err != nil {
+		t.Fatalf("compute UTC next fire: %v", err)
+	}
+	if wantNext.Equal(utcNext) {
+		t.Fatal("Bucharest and UTC next fires are the same instant; pick a cron whose wall-clock hour differs per zone")
+	}
+	if dto.NextFireAt == nil || !dto.NextFireAt.Equal(wantNext) {
+		t.Fatalf("override next_fire_at = %v, want the Bucharest instant %v", dto.NextFireAt, wantNext)
+	}
+
+	// An empty body keeps the catalog zone (UTC) on a second repo (the first is now enabled).
+	repoB := f.insertRepo(ctx, t, f.owner, 2, "g/sched-tz-b")
+	base, code := f.enableCatalogBody(t, f.owner.ID, repoB, "docs-hygiene", "")
+	if code != http.StatusCreated {
+		t.Fatalf("enable with empty body status = %d, want 201", code)
+	}
+	if base.Timezone != schedtmpl.DefaultTimezone {
+		t.Fatalf("empty-body dto timezone = %q, want the catalog default %q", base.Timezone, schedtmpl.DefaultTimezone)
+	}
+	if base.NextFireAt == nil || !base.NextFireAt.Equal(utcNext) {
+		t.Fatalf("empty-body next_fire_at = %v, want the UTC instant %v", base.NextFireAt, utcNext)
+	}
+
+	// An invalid IANA name is a 400 (on a third repo so the check is independent of state).
+	repoC := f.insertRepo(ctx, t, f.owner, 3, "g/sched-tz-c")
+	if _, code := f.enableCatalogBody(t, f.owner.ID, repoC, "docs-hygiene", `{"timezone":"Not/AZone"}`); code != http.StatusBadRequest {
+		t.Fatalf("invalid timezone enable status = %d, want 400", code)
 	}
 }
 

--- a/api/internal/handler/default_schedules_livedb_test.go
+++ b/api/internal/handler/default_schedules_livedb_test.go
@@ -169,6 +169,20 @@ func TestEnableCatalogScheduleTimezoneOverrideLiveDB(t *testing.T) {
 		t.Fatalf("override next_fire_at = %v, want the Bucharest instant %v", dto.NextFireAt, wantNext)
 	}
 
+	// Idempotent re-enable of the SAME repo with a DIFFERENT tz must not clobber the stored
+	// zone (issue #660 AC: no regression to idempotent re-enable). The override feeds only the
+	// initial insert; ON CONFLICT DO NOTHING returns the existing row untouched with 200.
+	reenabled, code := f.enableCatalogBody(t, f.owner.ID, f.repoID, "docs-hygiene", `{"timezone":"America/New_York"}`)
+	if code != http.StatusOK {
+		t.Fatalf("re-enable status = %d, want 200 (idempotent)", code)
+	}
+	if reenabled.ID != dto.ID {
+		t.Fatalf("re-enable returned a different schedule: %s vs %s", reenabled.ID, dto.ID)
+	}
+	if reenabled.Timezone != "Europe/Bucharest" {
+		t.Fatalf("re-enable clobbered the stored tz = %q, want the original Europe/Bucharest", reenabled.Timezone)
+	}
+
 	// An empty body keeps the catalog zone (UTC) on a second repo (the first is now enabled).
 	repoB := f.insertRepo(ctx, t, f.owner, 2, "g/sched-tz-b")
 	base, code := f.enableCatalogBody(t, f.owner.ID, repoB, "docs-hygiene", "")

--- a/api/internal/handler/schedules.go
+++ b/api/internal/handler/schedules.go
@@ -623,7 +623,23 @@ func (h *Handler) EnableCatalogSchedule(w http.ResponseWriter, r *http.Request) 
 		httpx.Error(w, http.StatusNotFound, "unknown catalog slug")
 		return
 	}
+	// Optional body: a timezone override (issue #660). An empty/absent body decodes to
+	// io.EOF and keeps the catalog zone (CLI/headless and older clients send none); a
+	// present, valid IANA name overrides it so the first fire lands in the caller's detected
+	// zone. Any other decode error is a malformed request (400).
+	var req apitypes.EnableCatalogRequest
+	if derr := httpx.DecodeJSONLimited(w, r, &req); derr != nil && !errors.Is(derr, io.EOF) {
+		httpx.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
 	tz := catalogTimezone(job)
+	if override := strings.TrimSpace(req.Timezone); override != "" {
+		if _, lerr := time.LoadLocation(override); lerr != nil {
+			httpx.Error(w, http.StatusBadRequest, "invalid timezone")
+			return
+		}
+		tz = override
+	}
 	next, err := schedsvc.NextFire(job.Cron, tz, h.clock())
 	if err != nil {
 		slog.Error("enable default schedule: next fire", "slug", slug, "error", err)

--- a/api/internal/handler/schedules.go
+++ b/api/internal/handler/schedules.go
@@ -634,6 +634,13 @@ func (h *Handler) EnableCatalogSchedule(w http.ResponseWriter, r *http.Request) 
 	}
 	tz := catalogTimezone(job)
 	if override := strings.TrimSpace(req.Timezone); override != "" {
+		// Reject the "Local" sentinel: time.LoadLocation("Local") succeeds and resolves to
+		// the server's time.Local, which would make the schedule fire in the deployment's
+		// zone instead of a real IANA one. Any other invalid name fails LoadLocation below.
+		if override == "Local" {
+			httpx.Error(w, http.StatusBadRequest, "invalid timezone")
+			return
+		}
 		if _, lerr := time.LoadLocation(override); lerr != nil {
 			httpx.Error(w, http.StatusBadRequest, "invalid timezone")
 			return

--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -35,6 +35,7 @@ import { LockIcon } from "./icons";
 import { XIcon, TrashIcon, CopyIcon } from "./icons";
 import { ModelSelect } from "./ModelSelect";
 import { modelFieldWarning } from "../lib/agentTemplates";
+import { browserTimezone } from "../lib/timezone";
 import {
   cronFromPreset,
   DEFAULT_PRESET_STATE,
@@ -67,14 +68,6 @@ const TIMING_OPTIONS: { value: ScheduleTiming; title: string; desc: string }[] =
 ];
 
 const COMMON_TIMEZONES = ["UTC", "Europe/Bucharest", "America/New_York", "Europe/London"];
-
-function browserTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-  } catch {
-    return "UTC";
-  }
-}
 
 // toLocalInput / fromLocalInput bridge an ISO instant and a <input type="datetime-local">
 // value (which is a wall-clock string with no zone). We treat the picker as the

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3849,8 +3849,16 @@ const realApi = {
   listScheduleCatalog: () => request<ScheduleCatalog>("GET", "/schedule-catalog"),
   // Enable a catalog default on one repo (idempotent: 201 new / 200 already-enabled,
   // including a paused row returned untouched). Client fans out one call per repo.
-  enableCatalogSchedule: (repoId: string, slug: string) =>
-    request<Schedule>("POST", `/repos/${repoId}/schedule-catalog/${slug}`),
+  // An optional detected browser timezone (issue #660) seeds the new schedule's zone; it
+  // is sent as the body ONLY when non-empty, so the no-tz path sends no body and stays
+  // byte-identical to before (the server keeps the catalog/UTC zone on an absent tz, and
+  // ignores the override on the idempotent re-enable path).
+  enableCatalogSchedule: (repoId: string, slug: string, timezone?: string) =>
+    request<Schedule>(
+      "POST",
+      `/repos/${repoId}/schedule-catalog/${slug}`,
+      timezone ? { timezone } : undefined,
+    ),
   // Restore a default row's editable fields to the catalog values and clear the
   // customized flag; a no-op-shaped 200 otherwise.
   resetSchedule: (id: string) => request<Schedule>("POST", `/schedules/${id}/reset`),

--- a/web/src/lib/timezone.test.ts
+++ b/web/src/lib/timezone.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+//
+// browserTimezone (issue #660): returns the browser's resolved IANA zone when Intl can
+// detect one, and falls back to "UTC" when detection yields an empty string or throws.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { browserTimezone } from "./timezone";
+
+// Force Intl.DateTimeFormat().resolvedOptions().timeZone to a chosen value (or make the
+// constructor throw) so each case is deterministic regardless of the host's real zone.
+function stubResolvedZone(timeZone: string) {
+  return vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+    () => ({ resolvedOptions: () => ({ timeZone }) }) as unknown as Intl.DateTimeFormat,
+  );
+}
+
+describe("browserTimezone", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the resolved IANA zone when Intl reports one", () => {
+    stubResolvedZone("Europe/Bucharest");
+    expect(browserTimezone()).toBe("Europe/Bucharest");
+  });
+
+  it("falls back to 'UTC' when the resolved zone is empty", () => {
+    stubResolvedZone("");
+    expect(browserTimezone()).toBe("UTC");
+  });
+
+  it("falls back to 'UTC' when detection throws", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
+      throw new Error("Intl unavailable");
+    });
+    expect(browserTimezone()).toBe("UTC");
+  });
+});

--- a/web/src/lib/timezone.ts
+++ b/web/src/lib/timezone.ts
@@ -1,0 +1,12 @@
+// browserTimezone resolves the browser's IANA timezone (e.g. "Europe/Bucharest") so
+// the schedule create modal and the default-job enable fan-out (issue #660) can seed a
+// schedule's zone from where the user actually is. It falls back to "UTC" when the
+// runtime cannot resolve a zone (an empty string) or Intl throws, so a caller always
+// gets a valid IANA name it can send or display.
+export function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -4641,8 +4641,18 @@ export const mockApi = {
     if (existing) return delay(scheduleDTO(existing));
     const s = materializeDefault(entry, repoId, nextScheduleId());
     // On the fresh-materialize path only, an optional detected browser timezone (issue
-    // #660) overrides the catalog zone; an empty/absent tz keeps the catalog zone.
-    if (timezone) s.timezone = timezone;
+    // #660) overrides the catalog zone; an empty/absent tz keeps the catalog zone. Mirror
+    // the production handler: trim, and reject an invalid IANA name (Intl throws a
+    // RangeError on both a bogus name and the "Local" sentinel) with a 400.
+    const tz = timezone?.trim();
+    if (tz) {
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone: tz });
+      } catch {
+        throw new ApiError(400, "invalid timezone");
+      }
+      s.timezone = tz;
+    }
     schedules = [s, ...schedules];
     return delay(scheduleDTO(s), 200);
   },

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -4626,19 +4626,23 @@ export const mockApi = {
       }));
     return delay({ entries: scheduleCatalog.map((e) => ({ ...e, labels: [...e.labels] })), enablements });
   },
-  enableCatalogSchedule: async (repoId: string, slug: string) => {
+  enableCatalogSchedule: async (repoId: string, slug: string, timezone?: string) => {
     requireSession();
     const repo = repos.find((r) => r.id === repoId);
     if (!repo) throw new ApiError(404, "repo not found");
     const entry = catalogBySlug(slug);
     if (!entry) throw new ApiError(404, "catalog entry not found");
     // Idempotent (server 200): an already-materialized (repo, slug) — even paused —
-    // returns its existing row untouched, never a fresh enable.
+    // returns its existing row untouched, never a fresh enable. Mirroring the server's
+    // ON CONFLICT DO NOTHING, a re-enable ignores any timezone override (issue #660).
     const existing = schedules.find(
       (s) => s.origin === "default" && s.catalog_slug === slug && s.repo_id === repoId,
     );
     if (existing) return delay(scheduleDTO(existing));
     const s = materializeDefault(entry, repoId, nextScheduleId());
+    // On the fresh-materialize path only, an optional detected browser timezone (issue
+    // #660) overrides the catalog zone; an empty/absent tz keeps the catalog zone.
+    if (timezone) s.timezone = timezone;
     schedules = [s, ...schedules];
     return delay(scheduleDTO(s), 200);
   },

--- a/web/src/mocks/scheduleCatalog.test.ts
+++ b/web/src/mocks/scheduleCatalog.test.ts
@@ -40,6 +40,25 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     expect(paused.enabled).toBe(false);
   });
 
+  it("enableCatalogSchedule seeds the timezone override on a fresh row, ignores it on re-enable (issue #660)", async () => {
+    // A fresh materialize with an explicit tz stores it on the created row (the browser
+    // zone parity the create modal already has).
+    const created = await mockApi.enableCatalogSchedule("repo-www", "bug-triage", "Europe/Bucharest");
+    expect(created.timezone).toBe("Europe/Bucharest");
+
+    // A plain enable (no tz) keeps the catalog/default zone — the no-body path is byte-identical
+    // to before. bug-triage's catalog zone is UTC.
+    const plain = await mockApi.enableCatalogSchedule("repo-payments", "bug-triage");
+    const entry = (await mockApi.listScheduleCatalog()).entries.find((e) => e.slug === "bug-triage")!;
+    expect(plain.timezone).toBe(entry.timezone);
+
+    // The idempotent re-enable with a DIFFERENT tz does NOT clobber the stored zone
+    // (mirrors the server's ON CONFLICT DO NOTHING — the AC in commit 265313a4).
+    const again = await mockApi.enableCatalogSchedule("repo-www", "bug-triage", "America/New_York");
+    expect(again.id).toBe(created.id);
+    expect(again.timezone).toBe("Europe/Bucharest");
+  });
+
   it("resetSchedule restores a customized default's cadence and clears customized", async () => {
     const before = (await mockApi.listSchedules()).find(
       (s) => s.origin === "default" && s.catalog_slug === "docs-hygiene" && s.repo_id === "repo-uzi",

--- a/web/src/mocks/scheduleCatalog.test.ts
+++ b/web/src/mocks/scheduleCatalog.test.ts
@@ -46,11 +46,19 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     const created = await mockApi.enableCatalogSchedule("repo-www", "bug-triage", "Europe/Bucharest");
     expect(created.timezone).toBe("Europe/Bucharest");
 
-    // A plain enable (no tz) keeps the catalog/default zone — the no-body path is byte-identical
-    // to before. bug-triage's catalog zone is UTC.
-    const plain = await mockApi.enableCatalogSchedule("repo-payments", "bug-triage");
-    const entry = (await mockApi.listScheduleCatalog()).entries.find((e) => e.slug === "bug-triage")!;
+    // A plain enable (no tz) on a GENUINELY FRESH (repo, slug) — not an already-materialized
+    // one, which would hit the idempotent re-enable branch and mask a wrong fresh default —
+    // keeps the catalog/default zone. (repo-atlas, docs-hygiene) is unmaterialized in seed and
+    // untouched by every other test here.
+    const plain = await mockApi.enableCatalogSchedule("repo-atlas", "docs-hygiene");
+    const entry = (await mockApi.listScheduleCatalog()).entries.find((e) => e.slug === "docs-hygiene")!;
     expect(plain.timezone).toBe(entry.timezone);
+
+    // An invalid IANA name on a fresh enable rejects with a 400, mirroring the production
+    // handler (before this the mock stored any string unchecked).
+    await expect(mockApi.enableCatalogSchedule("repo-atlas", "planned-sweep", "Not/AZone")).rejects.toMatchObject({
+      status: 400,
+    });
 
     // The idempotent re-enable with a DIFFERENT tz does NOT clobber the stored zone
     // (mirrors the server's ON CONFLICT DO NOTHING — the AC in commit 265313a4).

--- a/web/src/pages/Schedules.test.tsx
+++ b/web/src/pages/Schedules.test.tsx
@@ -204,6 +204,70 @@ describe("Schedules — two tabs (PRD #589 M6)", () => {
   });
 });
 
+// ── issue #660: enabling a default sends the browser-detected timezone ─────────
+describe("Schedules — enable-default sends the browser timezone (issue #660)", () => {
+  const CATALOG = {
+    entries: [
+      {
+        slug: "bug-triage",
+        name: "Bug triage sweep",
+        description: "Daily bug sweep",
+        target: "sweep" as const,
+        cron: "0 2 * * *",
+        timezone: "UTC",
+        model: "",
+        prompt: "",
+        labels: ["bug"],
+        guidance: "Triage the bug.",
+        max_issues: 3,
+        auto_approve: true,
+        wait_on_limit: true,
+      },
+    ],
+    enablements: [],
+  };
+
+  it("the fan-out passes the detected zone as enableCatalogSchedule's third arg", async () => {
+    // Pin the detected browser zone so the expected third arg is deterministic (the util
+    // reads Intl.DateTimeFormat().resolvedOptions().timeZone). Restore in finally so the
+    // spy never leaks into a sibling test.
+    const dtfSpy = vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () => ({ resolvedOptions: () => ({ timeZone: "Europe/Bucharest" }) }) as unknown as Intl.DateTimeFormat,
+    );
+    try {
+      mockApi.listScheduleCatalog.mockResolvedValue(CATALOG);
+      mockApi.listSchedules.mockResolvedValue([]);
+      mockApi.listRepos.mockResolvedValue({
+        repos: [{ id: "repo-uzi", path_with_namespace: "vtmocanu/uzi" }],
+      } as Awaited<ReturnType<typeof api.listRepos>>);
+      mockApi.enableCatalogSchedule.mockResolvedValue(
+        sched({ id: "new1", origin: "default", catalog_slug: "bug-triage", timezone: "Europe/Bucharest" }),
+      );
+
+      // The page opens on the Default jobs tab, where the enable fan-out lives.
+      render(
+        <MemoryRouter>
+          <Schedules />
+        </MemoryRouter>,
+      );
+      await waitFor(() => expect(screen.getByText("Bug triage sweep")).toBeTruthy());
+
+      // Pick the repo in the shared RepoMultiSelect (its checkbox lives inside a collapsed
+      // <details>, so query it including hidden elements). Selecting it reveals the Enable
+      // button on the catalog row.
+      fireEvent.click(screen.getByRole("checkbox", { name: "vtmocanu/uzi", hidden: true }));
+      fireEvent.click(screen.getByRole("button", { name: /Enable/ }));
+
+      // The single real call site fans out one call per repo, now carrying the detected zone.
+      await waitFor(() =>
+        expect(mockApi.enableCatalogSchedule).toHaveBeenCalledWith("repo-uzi", "bug-triage", "Europe/Bucharest"),
+      );
+    } finally {
+      dtfSpy.mockRestore();
+    }
+  });
+});
+
 // ── PRD #308 M4: the enriched "Last run" cell + "Last fire" detail row ─────────
 const NOW = new Date().toISOString();
 

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -173,8 +173,10 @@ export function Schedules() {
     setError("");
     setNotice("");
     // Seed each new schedule's zone from the browser's detected IANA timezone (issue #660),
-    // parity with the create modal. Resolved once so every repo in the fan-out gets the
-    // same zone; an empty/UTC detection keeps the catalog zone server-side.
+    // parity with the create modal. Resolved once so every repo in the fan-out gets the same
+    // zone. browserTimezone() always returns a valid IANA name (falling back to "UTC"), so
+    // the web always sends a body; the catalog zone is kept only on the no-body path used by
+    // CLI/headless enable.
     const tz = browserTimezone();
     try {
       const results = await Promise.allSettled(

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -15,6 +15,7 @@ import {
   type ScheduleCatalog,
 } from "../lib/api";
 import { relativeFromNow, ScheduleModal } from "../components/ScheduleModal";
+import { browserTimezone } from "../lib/timezone";
 import { DefaultJobs } from "../components/DefaultJobs";
 import { AddAnotherRepo, ScheduleGroupRow, ScheduleSubRow } from "../components/ScheduleGroupRow";
 import { LastRunOutcome, LastFireDetail, formatStamp } from "../components/LastRun";
@@ -171,9 +172,13 @@ export function Schedules() {
     setBusyId(entry.slug);
     setError("");
     setNotice("");
+    // Seed each new schedule's zone from the browser's detected IANA timezone (issue #660),
+    // parity with the create modal. Resolved once so every repo in the fan-out gets the
+    // same zone; an empty/UTC detection keeps the catalog zone server-side.
+    const tz = browserTimezone();
     try {
       const results = await Promise.allSettled(
-        repoIds.map((rid) => api.enableCatalogSchedule(rid, entry.slug)),
+        repoIds.map((rid) => api.enableCatalogSchedule(rid, entry.slug, tz)),
       );
       const ok = results.filter((r) => r.status === "fulfilled").length;
       const failed = results.length - ok;


### PR DESCRIPTION
Implements issue #660.

Closes #660

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-660`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule enablement now uses the browser’s timezone by default.
  * Users can override the timezone with a valid IANA timezone.
  * Existing schedules retain their configured timezone when re-enabled.

* **Bug Fixes**
  * Invalid, malformed, or unsupported timezone values are rejected.
  * UTC is used when the browser timezone cannot be detected or no timezone is provided.
  * Initial schedule times now reflect the selected timezone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->