### PR TITLE
White-label the favicon and browser-tab title (follow-up to #685)

### DIFF
--- a/specs/ai.md
+++ b/specs/ai.md
@@ -23044,3 +23044,50 @@ of the "looks queued, never runs" gap the `issue-triage` skill exists to hunt.
   section **supersedes** the design recorded in §119 (PRDLESS settings) and §308 (`PRD`+`PRDLESS`
   server-side assembly), and the run-eligibility narrative in §445; those remain as history of the
   now-removed model.
+
+## 585. Issue #688 — white-label the favicon base icon and the browser-tab `<title>`, reusing #685's `/api/branding` (no new setting)
+
+Follow-up to the #685 instance-branding layer, extending it to the two chrome surfaces #685 left
+factory-branded. **`web/`-only: no api, agent, DB, or migration change** — every value both surfaces
+need is already in the public `GET /api/branding` response (`app_logo_mode`, `app_logo_preset`,
+`app_logo_present`, `app_logo_keep_name`, `brand_company`), so nothing server-side moves.
+
+- **Favicon base white-labels to the admin app logo, the PRD #70 status overlay unchanged (§276).**
+  `web/src/lib/favicon.ts`'s `renderFavicon`/`applyFavicon` take an optional preloaded
+  `HTMLImageElement`; when a drawable branded base is supplied it is drawn object-contain on the
+  near-black field **instead of** the stroked ember `FactoryIcon`, with the status dot still overlaid.
+  `web/src/lib/useFavicon.ts` gains an `appLogoSrc` param (fed `appMarkImgSrc(branding)` at the
+  AppShell call site) that preloads a **same-origin** `<img>` (`/api/branding/logo/app` or a preset
+  asset — no `crossOrigin`) and re-applies on decode. The base is the app logo whenever one is set
+  (custom-with-upload or preset), **independent of keep_name** — keep_name governs the wordmark, not
+  the logo image. Unbranded stays today's ember mark; idle+unbranded still restores the static
+  `/favicon.svg`.
+- **Applies signed-out.** The favicon base and the title both white-label for a guest on a branded
+  instance (the favicon carries no status dot signed-out). The `useFavicon` disabled/logged-out branch
+  keeps `baseImgRef` (branding is independent of auth); the `document.title` effect sits before
+  AppShell's guest early return.
+- **Canvas is not tainted.** A same-origin `<img>` keeps the canvas clean, so `toDataURL` does not
+  throw regardless of the `/api/branding/logo/app` route's `Content-Security-Policy: sandbox` +
+  `X-Content-Type-Options: nosniff` response headers (those govern documents/sniffing, not an
+  `<img>`-loaded same-origin resource). Verified in a real browser against the preset path; the
+  custom-upload path with those exact headers is the one live-stack residual.
+- **Accepted limitation: a dimensionless SVG base (viewBox only, no intrinsic `width`/`height`) falls
+  back to the factory mark in browsers that report `naturalWidth === 0`.** `isDrawableImage`'s
+  `naturalWidth > 0` guard doubles as the load-error detector, so it is deliberately NOT relaxed; a
+  browser (e.g. some Firefox/Safari versions) that gives a dimensionless SVG no intrinsic size simply
+  shows the unbranded mark — graceful, no error. Chromium derived a non-zero size for the shipped
+  preset, so it brands there. Fixing an admin's own dimensionless upload is out of scope.
+- **Tab `<title>` reuses `brand_company`, gated on the FULL white-label condition.**
+  `web/src/lib/brandTitle.ts#brandTabTitle` returns `brand_company` only when the instance is fully
+  white-labeled — a byte-exact mirror of `appMarkShowName` (§ #685): `app_logo_mode` is `custom` or
+  `preset` **and** `app_logo_keep_name === false` — and `brand_company` is non-empty after trim; else
+  the static default. Per the issue's 2026-08-29 triage steer this reuses the existing
+  `brand_company` field rather than adding a dedicated `brand_title` setting. Consequences, accepted:
+  a co-brand (keep_name=true) keeps the uzi title; a white-label with an empty `brand_company` falls
+  back to the default (no other text source exists — the admin sets `brand_company` to drive the tab).
+  `DEFAULT_TITLE` is kept byte-identical to `web/index.html:6` (`Uzi — AI dark factory`, U+2014 em
+  dash); `index.html` retains the static title as the correct pre-hydration/unbranded value and the
+  SPA overrides `document.title` at runtime once branding resolves.
+- **Inherited (not introduced here): branding is module-memoised**, so a live branding change in Admin
+  does not update the favicon or title without a full reload — the existing #685 chrome behavior,
+  which these surfaces correctly track.

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -23079,7 +23079,8 @@ need is already in the public `GET /api/branding` response (`app_logo_mode`, `ap
   preset, so it brands there. Fixing an admin's own dimensionless upload is out of scope.
 - **Tab `<title>` reuses `brand_company`, gated on the FULL white-label condition.**
   `web/src/lib/brandTitle.ts#brandTabTitle` returns `brand_company` only when the instance is fully
-  white-labeled — a byte-exact mirror of `appMarkShowName` (§ #685): `app_logo_mode` is `custom` or
+  white-labeled — the same white-label gate as `appMarkShowName` (§ #685), its logical inverse
+  selecting the identical instance set (no shared helper binds them): `app_logo_mode` is `custom` or
   `preset` **and** `app_logo_keep_name === false` — and `brand_company` is non-empty after trim; else
   the static default. Per the issue's 2026-08-29 triage steer this reuses the existing
   `brand_company` field rather than adding a dedicated `brand_title` setting. Consequences, accepted:

--- a/web/src/components/AppShell.branding.test.tsx
+++ b/web/src/components/AppShell.branding.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { MemoryRouter } from "react-router-dom";
 import { AppShell, __resetBrandingForTests } from "./AppShell";
 import { api, type Branding } from "../lib/api";
+import { DEFAULT_TITLE } from "../lib/brandTitle";
 import { useAuth } from "../auth/AuthContext";
 import { mockBuildInfo } from "../mocks/data";
 
@@ -397,6 +398,48 @@ describe("AppShell branding — one-row footer", () => {
     const credit = await screen.findByTestId("license-credit");
     const row = credit.parentElement as HTMLElement;
     expect(row.className).toMatch(/justify-between/);
+  });
+});
+
+// White-label browser-tab <title> (issue #688 M2): AppShell drives document.title
+// from brandTabTitle(branding) in an effect placed before the guest early return, so
+// it applies signed-out too. Reset the title between cases so one test's white-label
+// company cannot leak into the next.
+describe("AppShell branding — browser-tab title (issue #688)", () => {
+  afterEach(() => {
+    document.title = DEFAULT_TITLE;
+  });
+
+  it("default branding, signed in: title is the static default", async () => {
+    renderShell();
+    await waitFor(() => expect(document.title).toBe(DEFAULT_TITLE));
+  });
+
+  it("full white-label, signed in: title becomes the brand company", async () => {
+    mockApi.branding.mockResolvedValue(
+      brandingWith({
+        app_logo_mode: "custom",
+        app_logo_present: true,
+        app_logo_keep_name: false,
+        brand_company: "Acme, Inc.",
+      }),
+    );
+    renderShell();
+    await waitFor(() => expect(document.title).toBe("Acme, Inc."));
+  });
+
+  it("full white-label, SIGNED OUT: title still becomes the brand company (applies to guests)", async () => {
+    signOut();
+    mockApi.branding.mockResolvedValue(
+      brandingWith({
+        app_logo_mode: "custom",
+        app_logo_present: true,
+        app_logo_keep_name: false,
+        brand_company: "Acme, Inc.",
+      }),
+    );
+    renderShell("/");
+    await waitFor(() => expect(document.title).toBe("Acme, Inc."));
   });
 });
 

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -16,6 +16,7 @@ import { VaultBadge, VaultLockedBanner } from "./VaultControls";
 import { RateLimitAnnouncer, SidebarRateLimits } from "./RateLimitMeters";
 import { onNotificationsChanged } from "../lib/notifications";
 import { useFavicon } from "../lib/useFavicon";
+import { brandTabTitle } from "../lib/brandTitle";
 import { JudgeTodoContext, JudgeTodoValueContext } from "./JudgeTodoContext";
 import { BuildInfoPopover } from "./BuildInfoPopover";
 import { ChangelogDrawer } from "./ChangelogDrawer";
@@ -1172,6 +1173,15 @@ export function AppShell({ children }: { children: ReactNode }) {
   // branding fetch, and applies signed-out too so a guest on a branded instance
   // still gets the branded base (no status dot).
   useFavicon({ unread, enabled: !!user, appLogoSrc: appMarkImgSrc(branding) });
+
+  // White-label the browser-tab title (issue #688): index.html carries the static
+  // default for pre-hydration/unbranded; this effect swaps it to brand_company for a
+  // full white-label. Placed before the guest early return so it applies to guests
+  // too and the hook order stays stable. No cleanup/restore needed — AppShell is the
+  // root shell, so the title it last set is always the correct one.
+  useEffect(() => {
+    document.title = brandTabTitle(branding);
+  }, [branding]);
 
   if (!user) return <PublicShell>{children}</PublicShell>;
 

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1167,8 +1167,11 @@ export function AppShell({ children }: { children: ReactNode }) {
   // guest and survives logout (enabled flips false → reset to the static mark).
   // Reuses the unread count above — no second unread poll — and owns its own
   // runs poll (which fires while the tab is hidden). Called before the guest
-  // early return so the hook order stays stable.
-  useFavicon({ unread, enabled: !!user });
+  // early return so the hook order stays stable. The base icon white-labels to the
+  // branded app logo (issue #688) — appMarkImgSrc reuses the module-memoised
+  // branding fetch, and applies signed-out too so a guest on a branded instance
+  // still gets the branded base (no status dot).
+  useFavicon({ unread, enabled: !!user, appLogoSrc: appMarkImgSrc(branding) });
 
   if (!user) return <PublicShell>{children}</PublicShell>;
 

--- a/web/src/lib/brandTitle.test.ts
+++ b/web/src/lib/brandTitle.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { brandTabTitle, DEFAULT_TITLE } from "./brandTitle";
+import type { Branding } from "./api";
+
+// brandingWith builds a Branding starting from the default (unbranded) shape, so each
+// case only names the fields the white-label gate reads (mode / keep_name / company).
+const DEFAULT_BRANDING: Branding = {
+  app_logo_mode: "default",
+  app_logo_preset: "",
+  app_logo_present: false,
+  app_logo_keep_name: true,
+  brand_mode: "none",
+  brand_company: "",
+  brand_placement: "below",
+  brand_plaque: false,
+  brand_logo_present: false,
+};
+
+function brandingWith(overrides: Partial<Branding>): Branding {
+  return { ...DEFAULT_BRANDING, ...overrides };
+}
+
+describe("brandTabTitle", () => {
+  it("null branding → DEFAULT_TITLE", () => {
+    expect(brandTabTitle(null)).toBe(DEFAULT_TITLE);
+  });
+
+  it("default mode, keep_name true, empty company → DEFAULT_TITLE", () => {
+    expect(brandTabTitle(brandingWith({}))).toBe(DEFAULT_TITLE);
+  });
+
+  it("default mode with a non-empty company → DEFAULT_TITLE (default is never white-label)", () => {
+    expect(brandTabTitle(brandingWith({ brand_company: "Acme, Inc." }))).toBe(DEFAULT_TITLE);
+  });
+
+  it("custom mode, keep_name TRUE (co-brand) → DEFAULT_TITLE (keep_name keeps uzi)", () => {
+    expect(
+      brandTabTitle(brandingWith({ app_logo_mode: "custom", app_logo_keep_name: true, brand_company: "Acme, Inc." })),
+    ).toBe(DEFAULT_TITLE);
+  });
+
+  it("custom mode, keep_name FALSE → the brand_company", () => {
+    expect(
+      brandTabTitle(brandingWith({ app_logo_mode: "custom", app_logo_keep_name: false, brand_company: "Acme, Inc." })),
+    ).toBe("Acme, Inc.");
+  });
+
+  it("preset mode, keep_name FALSE → the brand_company", () => {
+    expect(
+      brandTabTitle(brandingWith({ app_logo_mode: "preset", app_logo_keep_name: false, brand_company: "Acme, Inc." })),
+    ).toBe("Acme, Inc.");
+  });
+
+  it("white-label with an empty brand_company → DEFAULT_TITLE (fallback)", () => {
+    expect(
+      brandTabTitle(brandingWith({ app_logo_mode: "custom", app_logo_keep_name: false, brand_company: "" })),
+    ).toBe(DEFAULT_TITLE);
+  });
+
+  it("white-label with a whitespace-only brand_company → DEFAULT_TITLE (trim)", () => {
+    expect(
+      brandTabTitle(brandingWith({ app_logo_mode: "custom", app_logo_keep_name: false, brand_company: "   " })),
+    ).toBe(DEFAULT_TITLE);
+  });
+
+  it("DEFAULT_TITLE uses the U+2014 em dash, not a hyphen", () => {
+    expect(DEFAULT_TITLE).toContain("—");
+  });
+});

--- a/web/src/lib/brandTitle.test.ts
+++ b/web/src/lib/brandTitle.test.ts
@@ -64,6 +64,6 @@ describe("brandTabTitle", () => {
   });
 
   it("DEFAULT_TITLE uses the U+2014 em dash, not a hyphen", () => {
-    expect(DEFAULT_TITLE).toContain("—");
+    expect(DEFAULT_TITLE).toBe("Uzi — AI dark factory");
   });
 });

--- a/web/src/lib/brandTitle.ts
+++ b/web/src/lib/brandTitle.ts
@@ -1,0 +1,25 @@
+// White-label browser-tab <title> (issue #688 M2): the tab title reflects the
+// instance's brand when it is FULLY white-labeled, so a branded deployment reads
+// as itself in the tab bar (and in bookmarks / history) rather than as "uzi".
+// index.html carries the static default for pre-hydration and the unbranded case;
+// AppShell overrides document.title from this at runtime once branding resolves.
+
+import type { Branding } from "./api";
+
+// The static default the SPA overrides at runtime. MUST stay byte-identical to the
+// <title> in web/index.html:6 — the dash is a U+2014 EM DASH (—) with a normal
+// ASCII space on each side, NOT a hyphen and NOT an en dash.
+export const DEFAULT_TITLE = "Uzi — AI dark factory";
+
+// brandTabTitle picks the tab title from branding. It reuses brand_company (already
+// in the /api/branding response) as the title source per the issue's 2026-08-29
+// triage steer — no new setting. Only a FULL white-label overrides the default:
+// mirroring the appMarkShowName gate in AppShell.tsx, that is a non-default logo mode
+// (custom or preset) with keep-name OFF. A co-brand (keep_name=true) keeps the uzi
+// title; a white-label with an empty brand_company falls back to DEFAULT_TITLE (no
+// other text source exists); `null`/pending branding is the default too.
+export function brandTabTitle(branding: Branding | null): string {
+  const isWhiteLabel =
+    branding != null && branding.app_logo_mode !== "default" && branding.app_logo_keep_name === false;
+  return isWhiteLabel && branding.brand_company.trim() !== "" ? branding.brand_company : DEFAULT_TITLE;
+}

--- a/web/src/lib/brandTitle.ts
+++ b/web/src/lib/brandTitle.ts
@@ -14,8 +14,10 @@ export const DEFAULT_TITLE = "Uzi — AI dark factory";
 // brandTabTitle picks the tab title from branding. It reuses brand_company (already
 // in the /api/branding response) as the title source per the issue's 2026-08-29
 // triage steer — no new setting. Only a FULL white-label overrides the default:
-// a byte-exact mirror of the appMarkShowName gate in AppShell.tsx, that is a
-// non-default logo mode (custom or preset) with keep-name OFF. A co-brand
+// the same gate as appMarkShowName in AppShell.tsx (this is its logical inverse —
+// appMarkShowName returns whether to KEEP the wordmark — selecting the identical
+// instance set; no shared helper binds the two, so keep them in step by hand), that
+// is a non-default logo mode (custom or preset) with keep-name OFF. A co-brand
 // (keep_name=true) keeps the uzi title; a white-label with an empty brand_company
 // falls back to DEFAULT_TITLE (no other text source exists); `null`/pending branding
 // is the default too.

--- a/web/src/lib/brandTitle.ts
+++ b/web/src/lib/brandTitle.ts
@@ -14,12 +14,15 @@ export const DEFAULT_TITLE = "Uzi — AI dark factory";
 // brandTabTitle picks the tab title from branding. It reuses brand_company (already
 // in the /api/branding response) as the title source per the issue's 2026-08-29
 // triage steer — no new setting. Only a FULL white-label overrides the default:
-// mirroring the appMarkShowName gate in AppShell.tsx, that is a non-default logo mode
-// (custom or preset) with keep-name OFF. A co-brand (keep_name=true) keeps the uzi
-// title; a white-label with an empty brand_company falls back to DEFAULT_TITLE (no
-// other text source exists); `null`/pending branding is the default too.
+// a byte-exact mirror of the appMarkShowName gate in AppShell.tsx, that is a
+// non-default logo mode (custom or preset) with keep-name OFF. A co-brand
+// (keep_name=true) keeps the uzi title; a white-label with an empty brand_company
+// falls back to DEFAULT_TITLE (no other text source exists); `null`/pending branding
+// is the default too.
 export function brandTabTitle(branding: Branding | null): string {
   const isWhiteLabel =
-    branding != null && branding.app_logo_mode !== "default" && branding.app_logo_keep_name === false;
+    branding != null &&
+    (branding.app_logo_mode === "custom" || branding.app_logo_mode === "preset") &&
+    branding.app_logo_keep_name === false;
   return isWhiteLabel && branding.brand_company.trim() !== "" ? branding.brand_company : DEFAULT_TITLE;
 }

--- a/web/src/lib/favicon.ts
+++ b/web/src/lib/favicon.ts
@@ -3,8 +3,10 @@
 // failed / needs you / is working". Split into a pure M2 state-derivation half
 // (deriveFaviconState / failedRunIds — unit-tested here) and an M3 DOM half
 // (renderFavicon / applyFavicon — canvas + <link> swap, exercised in the browser,
-// not unit-tested). The favicon is ALWAYS the ember brand mark, theme-independent:
-// a tab has no theme context, so it must read on any browser chrome.
+// not unit-tested). The base mark is theme-independent — a tab has no theme context,
+// so it must read on any browser chrome — and defaults to the ember factory mark,
+// but white-labels to the branded app logo when one is set (issue #688), with the
+// PRD #70 status dot still overlaid on top.
 
 import { effectiveRunStatus, isStoppedRun, needsHumanAttention } from "./runBadge";
 import type { StopKind } from "./api";
@@ -99,10 +101,24 @@ const MARK_TICKS = "M17 18h1M12 18h1M7 18h1";
 
 const SIZE = 64; // 64×64 backing store; the browser shrinks it to ~16px.
 
-// renderFavicon draws the mark (and, for non-idle states, a top-right status dot)
-// on a 64×64 canvas and returns a PNG data URL. It throws if 2D context is
-// unavailable — applyFavicon wraps it so a render failure never reaches React.
-function renderFavicon(state: FaviconState): string {
+// The inset margin (in backing-store px) kept clear on every edge when a branded
+// base logo is drawn, so the fitted image never touches the rounded field corners.
+const BASE_INSET = 6;
+
+// isDrawableImage reports whether a preloaded <img> is safe to draw: it must have
+// finished decoding (complete) and carry real pixels (naturalWidth > 0). A pending
+// or errored image draws nothing, so we fall back to the factory mark instead.
+function isDrawableImage(img: HTMLImageElement | null | undefined): img is HTMLImageElement {
+  return !!img && img.complete && img.naturalWidth > 0;
+}
+
+// renderFavicon draws the base mark (and, for non-idle states, a top-right status
+// dot) on a 64×64 canvas and returns a PNG data URL. The base is the branded app
+// logo when a drawable `baseImg` is supplied — fitted object-contain inside an
+// inset field — and otherwise today's stroked ember factory mark. It throws if 2D
+// context is unavailable — applyFavicon wraps it so a render failure never reaches
+// React.
+function renderFavicon(state: FaviconState, baseImg?: HTMLImageElement | null): string {
   const canvas = document.createElement("canvas");
   canvas.width = SIZE;
   canvas.height = SIZE;
@@ -121,18 +137,29 @@ function renderFavicon(state: FaviconState): string {
   ctx.fillStyle = FIELD;
   ctx.fill();
 
-  // Factory mark, stroked ember under a 24→64 transform. lineWidth is bumped so the
-  // strokes still read once the browser shrinks the icon to ~16px; round caps/joins
-  // keep it soft.
-  ctx.save();
-  ctx.scale(SIZE / 24, SIZE / 24);
-  ctx.strokeStyle = EMBER;
-  ctx.lineWidth = 2;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.stroke(new Path2D(MARK_OUTLINE));
-  ctx.stroke(new Path2D(MARK_TICKS));
-  ctx.restore();
+  if (isDrawableImage(baseImg)) {
+    // Branded base: draw the app logo fitted object-contain (aspect ratio
+    // preserved, centered) inside the inset field, so it reads as the tab identity
+    // instead of the factory mark. The status dot below still overlays it.
+    const box = SIZE - BASE_INSET * 2;
+    const scale = Math.min(box / baseImg.naturalWidth, box / baseImg.naturalHeight);
+    const w = baseImg.naturalWidth * scale;
+    const h = baseImg.naturalHeight * scale;
+    ctx.drawImage(baseImg, (SIZE - w) / 2, (SIZE - h) / 2, w, h);
+  } else {
+    // Factory mark, stroked ember under a 24→64 transform. lineWidth is bumped so
+    // the strokes still read once the browser shrinks the icon to ~16px; round
+    // caps/joins keep it soft.
+    ctx.save();
+    ctx.scale(SIZE / 24, SIZE / 24);
+    ctx.strokeStyle = EMBER;
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.stroke(new Path2D(MARK_OUTLINE));
+    ctx.stroke(new Path2D(MARK_TICKS));
+    ctx.restore();
+  }
 
   // Status dot, top-right, with a thin near-black ring so it reads on any tab
   // background. Idle draws no dot (the plain mark).
@@ -162,21 +189,38 @@ function findIconLink(): HTMLLinkElement | null {
 }
 
 // applyFavicon points the icon <link> at the right image for the state, keeping its
-// `type` in step: idle restores the static /favicon.svg (type image/svg+xml); any
-// other state swaps in a freshly-rendered PNG data URL (type image/png). It is
-// defensive on purpose: a missing link is a no-op, and any render failure
-// (canvas/toDataURL unsupported, e.g. some Safari configs) is swallowed so the icon
-// and its type simply stay the static mark rather than throwing into React.
-export function applyFavicon(state: FaviconState): void {
+// `type` in step. Non-idle states swap in a freshly-rendered PNG data URL (type
+// image/png) with a corner status dot. Idle restores a base with NO dot: the static
+// /favicon.svg (type image/svg+xml) when unbranded, or a rendered PNG of the branded
+// app logo when a drawable `baseImg` is supplied. It is defensive on purpose: a
+// missing link is a no-op, and any render failure (canvas/toDataURL unsupported,
+// e.g. some Safari configs) is swallowed so the icon and its type simply fall back
+// to the static mark rather than throwing into React.
+export function applyFavicon(state: FaviconState, baseImg?: HTMLImageElement | null): void {
   const link = findIconLink();
   if (!link) return;
   if (state === "idle") {
-    link.type = "image/svg+xml";
-    link.href = "/favicon.svg";
+    if (!isDrawableImage(baseImg)) {
+      // Unbranded (or the branded base has not decoded yet): today's static mark.
+      link.type = "image/svg+xml";
+      link.href = "/favicon.svg";
+      return;
+    }
+    try {
+      // Branded idle base: the app logo, no status dot, as a PNG data URL.
+      const url = renderFavicon(state, baseImg);
+      link.type = "image/png";
+      link.href = url;
+    } catch {
+      // Fall back to the static mark on any render failure.
+      link.type = "image/svg+xml";
+      link.href = "/favicon.svg";
+    }
     return;
   }
   try {
-    const url = renderFavicon(state);
+    // Non-idle: the status dot overlays whatever base was drawn (branded or factory).
+    const url = renderFavicon(state, baseImg);
     link.type = "image/png";
     link.href = url;
   } catch {

--- a/web/src/lib/useFavicon.test.tsx
+++ b/web/src/lib/useFavicon.test.tsx
@@ -59,10 +59,10 @@ describe("useFavicon", () => {
   it("Fix 3: applies attention from unread BEFORE any runs poll resolves", async () => {
     // listRuns never resolves this tick, so the baseline stays null.
     listRuns.mockReturnValueOnce(new Promise(() => {}));
-    renderHook(() => useFavicon({ unread: 1, enabled: true }));
+    renderHook(() => useFavicon({ unread: 1, enabled: true, appLogoSrc: null }));
 
     // The unread-keyed effect runs synchronously on mount; no poll has resolved.
-    expect(applyFavicon).toHaveBeenCalledWith("attention");
+    expect(applyFavicon).toHaveBeenCalledWith("attention", null);
   });
 
   it("Fix 3: nothing is applied pre-baseline with no unread (no premature redden)", async () => {
@@ -71,9 +71,9 @@ describe("useFavicon", () => {
     // nothing at all — in particular it must not redden, which requires the seeded
     // baseline to tell a fresh failure from a pre-existing one.
     listRuns.mockReturnValueOnce(new Promise(() => {}));
-    renderHook(() => useFavicon({ unread: 0, enabled: true }));
+    renderHook(() => useFavicon({ unread: 0, enabled: true, appLogoSrc: null }));
 
-    expect(applyFavicon).not.toHaveBeenCalledWith("failed");
+    expect(applyFavicon).not.toHaveBeenCalledWith("failed", null);
     expect(applyFavicon).not.toHaveBeenCalled();
   });
 
@@ -81,11 +81,11 @@ describe("useFavicon", () => {
     // First poll: empty, seeds an empty baseline. Second poll: a NEW failed run —
     // fresh relative to the seeded baseline, so it reddens.
     nextRuns = [];
-    const { rerender } = renderHook((props: { unread: number }) => useFavicon({ ...props, enabled: true }), {
+    const { rerender } = renderHook((props: { unread: number }) => useFavicon({ ...props, enabled: true, appLogoSrc: null }), {
       initialProps: { unread: 0 },
     });
     await flush(); // seed baseline (empty), derive idle
-    expect(applyFavicon).not.toHaveBeenCalledWith("failed");
+    expect(applyFavicon).not.toHaveBeenCalledWith("failed", null);
 
     nextRuns = [run("r1", "failed")];
     await act(async () => {
@@ -93,14 +93,14 @@ describe("useFavicon", () => {
     });
     await flush();
     rerender({ unread: 0 });
-    expect(applyFavicon).toHaveBeenCalledWith("failed");
+    expect(applyFavicon).toHaveBeenCalledWith("failed", null);
   });
 
   it("Fix 4: two polls with the SAME runs apply the icon at most once for that state", async () => {
     nextRuns = [run("r1", "running")];
-    renderHook(() => useFavicon({ unread: 0, enabled: true }));
+    renderHook(() => useFavicon({ unread: 0, enabled: true, appLogoSrc: null }));
     await flush(); // first poll resolves -> running
-    expect(applyFavicon).toHaveBeenCalledWith("running");
+    expect(applyFavicon).toHaveBeenCalledWith("running", null);
     const callsAfterFirst = applyFavicon.mock.calls.length;
 
     // Second tick, identical runs: the lastStateRef guard should suppress a re-apply.
@@ -113,13 +113,13 @@ describe("useFavicon", () => {
 
   it("derives a normal seeded run (running) after the poll resolves", async () => {
     nextRuns = [run("r1", "running")];
-    renderHook(() => useFavicon({ unread: 0, enabled: true }));
+    renderHook(() => useFavicon({ unread: 0, enabled: true, appLogoSrc: null }));
     await flush();
-    expect(applyFavicon).toHaveBeenCalledWith("running");
+    expect(applyFavicon).toHaveBeenCalledWith("running", null);
   });
 
   it("#331: marks the favicon poll passive so the server skips the rolling refresh", async () => {
-    renderHook(() => useFavicon({ unread: 0, enabled: true }));
+    renderHook(() => useFavicon({ unread: 0, enabled: true, appLogoSrc: null }));
     await flush(); // immediate seed poll
     expect(listRuns).toHaveBeenCalledWith({ passive: true });
   });

--- a/web/src/lib/useFavicon.test.tsx
+++ b/web/src/lib/useFavicon.test.tsx
@@ -123,4 +123,46 @@ describe("useFavicon", () => {
     await flush(); // immediate seed poll
     expect(listRuns).toHaveBeenCalledWith({ passive: true });
   });
+
+  it("#688: a failed REPLACEMENT logo load clears the stale base and reverts to the factory mark", async () => {
+    // Capture each new Image() so the test can drive its onload/onerror directly.
+    const images: TestImage[] = [];
+    class TestImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      src = "";
+      constructor() {
+        images.push(this);
+      }
+    }
+    const OriginalImage = globalThis.Image;
+    globalThis.Image = TestImage as unknown as typeof Image;
+    try {
+      const { rerender } = renderHook(
+        (props: { appLogoSrc: string | null }) =>
+          useFavicon({ unread: 0, enabled: true, appLogoSrc: props.appLogoSrc }),
+        { initialProps: { appLogoSrc: "/logo-a.png" } },
+      );
+
+      // First logo loads successfully: the branded base image is applied.
+      const first = images[0];
+      act(() => {
+        first.onload?.();
+      });
+      const lastCall = applyFavicon.mock.calls[applyFavicon.mock.calls.length - 1];
+      expect(lastCall[1]).toBe(first);
+      expect(lastCall[1]).not.toBeNull();
+
+      // Swap to a new src whose load FAILS. The base must revert to null (factory
+      // mark), not retain the previously loaded logo.
+      rerender({ appLogoSrc: "/logo-b.png" });
+      const second = images[1];
+      act(() => {
+        second.onerror?.();
+      });
+      expect(applyFavicon).toHaveBeenLastCalledWith("idle", null);
+    } finally {
+      globalThis.Image = OriginalImage;
+    }
+  });
 });

--- a/web/src/lib/useFavicon.ts
+++ b/web/src/lib/useFavicon.ts
@@ -151,10 +151,15 @@ export function useFavicon({
   // IMAGE changed under the same state, which the guard would otherwise swallow.
   useEffect(() => {
     if (!appLogoSrc) {
-      // Unbranded: clear the ref so the base reverts to the factory mark and, on the
-      // next re-apply, idle restores the static /favicon.svg. No forced re-apply — the
-      // poll/unread effects re-apply naturally, and branding rarely changes live.
+      // Unbranded: clear the ref so the base reverts to the factory mark and idle
+      // restores the static /favicon.svg. Force a re-apply ONLY when we are actually
+      // CLEARING a previously-set branded base (had === true): the poll/unread guard
+      // (next === lastStateRef.current) would otherwise suppress a same-state redraw
+      // and leave a stale branded PNG on the tab. Skip it on the initial null pass so
+      // we don't flash idle over the enabled effect's own first apply.
+      const had = baseImgRef.current !== null;
       baseImgRef.current = null;
+      if (had) applyFavicon(lastStateRef.current ?? "idle", null);
       return;
     }
     let alive = true;

--- a/web/src/lib/useFavicon.ts
+++ b/web/src/lib/useFavicon.ts
@@ -169,6 +169,15 @@ export function useFavicon({
       baseImgRef.current = img;
       applyFavicon(lastStateRef.current ?? "idle", img);
     };
+    // A failed replacement load must NOT leave the previous tenant's image in
+    // baseImgRef: clear it and re-apply the current state on the factory mark, so
+    // a branded src that 404s reverts to the fallback rather than pinning a stale
+    // logo. Symmetric with onload, which also applies unconditionally.
+    img.onerror = () => {
+      if (!alive) return;
+      baseImgRef.current = null;
+      applyFavicon(lastStateRef.current ?? "idle", null);
+    };
     img.src = appLogoSrc;
     return () => {
       alive = false;

--- a/web/src/lib/useFavicon.ts
+++ b/web/src/lib/useFavicon.ts
@@ -33,10 +33,24 @@ import { onNotificationsChanged } from "./notifications";
 // favicon stays live.
 const POLL_MS = 20_000;
 
-export function useFavicon({ unread, enabled }: { unread: number; enabled: boolean }): void {
+export function useFavicon({
+  unread,
+  enabled,
+  appLogoSrc,
+}: {
+  unread: number;
+  enabled: boolean;
+  appLogoSrc: string | null;
+}): void {
   // Latest runs, in a ref (not state): the icon is a side effect, so no component
   // renders from this and a poll tick must not trigger React work.
   const runsRef = useRef<FaviconRun[]>([]);
+  // The preloaded branded base image (issue #688). Held in a ref because, like the
+  // runs, nothing renders from it: it is passed straight into applyFavicon as the
+  // base to draw under the status dot. null means "unbranded" — the base reverts to
+  // the factory mark (and idle restores the static /favicon.svg). Independent of
+  // auth, so it survives the disabled branch's reset.
+  const baseImgRef = useRef<HTMLImageElement | null>(null);
   // Latest unread, mirrored into a ref every render so the stable deriveAndApply
   // callback always reads the current count.
   const unreadRef = useRef(unread);
@@ -69,7 +83,7 @@ export function useFavicon({ unread, enabled }: { unread: number; enabled: boole
     }
     if (next === lastStateRef.current) return;
     lastStateRef.current = next;
-    applyFavicon(next);
+    applyFavicon(next, baseImgRef.current);
   }, []);
 
   // The poll lifecycle is keyed ONLY on `enabled` (deriveAndApply is stable) — never
@@ -79,11 +93,13 @@ export function useFavicon({ unread, enabled }: { unread: number; enabled: boole
   useEffect(() => {
     if (!enabled) {
       // Logged out / disabled: no fetch, drop the baseline so a later sign-in
-      // re-seeds it, clear the cached runs, and restore the plain static brand mark.
+      // re-seeds it, clear the cached runs, and restore the plain base mark. We do
+      // NOT null out baseImgRef — branding is independent of auth, so a signed-out
+      // visitor to a branded instance still gets the branded idle base (no dot).
       baselineRef.current = null;
       lastStateRef.current = null;
       runsRef.current = [];
-      applyFavicon("idle");
+      applyFavicon("idle", baseImgRef.current);
       return;
     }
 
@@ -122,6 +138,37 @@ export function useFavicon({ unread, enabled }: { unread: number; enabled: boole
       offNotif();
     };
   }, [enabled, deriveAndApply]);
+
+  // Preload the branded app logo (issue #688) into an <img> held in baseImgRef, so
+  // renderFavicon can draw it synchronously as the base under the status dot. Keyed
+  // on appLogoSrc: null clears the ref (base reverts to the factory mark, idle to the
+  // static /favicon.svg); a URL creates a new Image() and, once it decodes, re-applies
+  // the CURRENT tab state so the branded base appears without waiting for the next
+  // poll. Same-origin src (/api/branding/logo/app or a preset asset), so no crossOrigin.
+  //
+  // The load handler bypasses the lastStateRef equality guard on purpose: that guard
+  // only suppresses re-applies when the derived STATE is unchanged, but here the base
+  // IMAGE changed under the same state, which the guard would otherwise swallow.
+  useEffect(() => {
+    if (!appLogoSrc) {
+      // Unbranded: clear the ref so the base reverts to the factory mark and, on the
+      // next re-apply, idle restores the static /favicon.svg. No forced re-apply — the
+      // poll/unread effects re-apply naturally, and branding rarely changes live.
+      baseImgRef.current = null;
+      return;
+    }
+    let alive = true;
+    const img = new Image();
+    img.onload = () => {
+      if (!alive) return;
+      baseImgRef.current = img;
+      applyFavicon(lastStateRef.current ?? "idle", img);
+    };
+    img.src = appLogoSrc;
+    return () => {
+      alive = false;
+    };
+  }, [appLogoSrc]);
 
   // Re-derive from the ref'd latest runs whenever `unread` changes, so a pure-unread
   // `attention` shows both before and after the baseline is seeded (Fix 3).


### PR DESCRIPTION
Implements issue #688.

Closes #688

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-688`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added white-label browser-tab titles for fully branded instances.
  * Added branded favicon support while preserving unread and status indicators.
  * Branded visuals now work for both signed-in and guest sessions.
  * Retains default titles and favicon behavior when custom branding is unavailable.
  * Automatically falls back to the standard icon if a branded logo cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->