### PR TITLE
Interactive wake-guard watermark: close the peek↔stamp DB race (worker-provided id) + restore park-skip ownership ACK

### DIFF
--- a/agent/src/client.ts
+++ b/agent/src/client.ts
@@ -16,6 +16,7 @@ import {
   type StateRequest,
   type UserInput,
   type InputsResponse,
+  type RunOwnershipResponse,
   type WorkerProposal,
   type WorkerRunDetail,
   type WorkerRunListItem,
@@ -276,6 +277,14 @@ export class WorkerClient {
   async getInputs(runId: string): Promise<UserInput[]> {
     const res = (await this.getJSON(`${WORKER_API_PREFIX}/runs/${runId}/inputs`)) as InputsResponse;
     return res.inputs ?? [];
+  }
+
+  /** issue #559: lightweight read-only ownership/terminality probe for the interactive
+   *  park-SKIP path. Returns the run's current status. Throws a RequestError on 4xx/5xx —
+   *  the caller distinguishes a DEFINITIVE 404 (run not owned / reclaimed) from a transient
+   *  error via `err.status`. Reuses GetRunOwnedByWorker server-side; no new query. */
+  async getRunOwnership(runId: string): Promise<RunOwnershipResponse> {
+    return (await this.getJSON(`${WORKER_API_PREFIX}/runs/${runId}/ownership`)) as RunOwnershipResponse;
   }
 
   // ── Chat agent read surface (PRD #39 M3) ───────────────────────────────────

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -1601,3 +1601,10 @@ export interface UserInput {
 export interface InputsResponse {
   inputs: UserInput[];
 }
+
+/** Response of the interactive park-skip ownership probe (issue #559): the current
+ *  status of a run this worker owns. A 404 (not owned / reclaimed) is signalled by a
+ *  thrown RequestError, not by this shape. */
+export interface RunOwnershipResponse {
+  status: string;
+}

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -1524,6 +1524,15 @@ export interface StateRequest {
    *  secret-scrubs and size-caps it (git.workflowScopeDiff + redactText), and the server
    *  clamps it again before storing. Absent on every other report. */
   preserved_patch?: string;
+  /** issue #559 M2: the worker-provided wake-guard watermark, sent ONLY on the
+   *  `awaiting_followup` report — the highest `follow_up` input id the worker has already
+   *  applied/delivered (SteeringChannel.getLastDeliveredFollowUpId). The server clamps and
+   *  floors it (`GREATEST(0, LEAST(@open_followup_id, MAX(consumed follow_up id)))`) and
+   *  falls back to its server-derived MAX(consumed) when this is absent. Reporting the
+   *  last-DELIVERED id (which does NOT advance during the park report's DB round-trip)
+   *  excludes a follow-up consumed mid-round-trip from the watermark, so its later wake
+   *  succeeds instead of stranding the run. Additive + optional. */
+  open_followup_id?: number;
 }
 
 /**

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -1088,21 +1088,33 @@ export class RunRunner {
         // askUser's settle discipline; the ordering is satisfied by construction here.
         awaitFollowUp: async (idleMs) => {
           // issue #552 M1 (mid-turn wake-guard bug): report `awaiting_followup` — which stamps
-          // the open_followup_id watermark to MAX(consumed follow_up id) — ONLY when the run is
-          // genuinely going idle. If a follow-up (or stop/cancel) arrived mid-turn and is
-          // already buffered, reporting the park would fold that already-consumed-but-not-yet-
-          // applied follow-up INTO the watermark, so its own wake `running` report would then
-          // fail the server's `id > watermark` guard and strand a live run at awaiting_followup.
-          // Skip the park report in that case and service the buffered outcome directly (the run
-          // stays `running`, no spurious park). A follow-up arriving AFTER this point is consumed
+          // the open_followup_id watermark — ONLY when the run is genuinely going idle. If a
+          // follow-up (or stop/cancel) arrived mid-turn and is already buffered, reporting the
+          // park would fold that already-consumed-but-not-yet-applied follow-up INTO the
+          // watermark, so its own wake `running` report would then fail the server's
+          // `id > watermark` guard and strand a live run at awaiting_followup. Skip the park
+          // report in that case and service the buffered outcome directly (the run stays
+          // `running`, no spurious park). A follow-up arriving AFTER this point is consumed
           // after the stamp, so its id > watermark and it wakes normally.
+          //
+          // issue #559 M2: the park report now CARRIES the watermark it wants stamped —
+          // `open_followup_id` = the highest follow_up id the worker has already DELIVERED
+          // (steering.getLastDeliveredFollowUpId()). The server clamps/floors this instead of
+          // deriving MAX(consumed follow_up id) itself. This closes the residual race where a
+          // follow-up consumed by the poll loop DURING this report's DB round-trip would fold
+          // into a server-derived MAX(consumed) and strand the run: the last-DELIVERED id does
+          // NOT advance during the round-trip (the follow-up waiter is armed only AFTER this
+          // report returns, below), so the racing follow-up is excluded and its later wake wins.
           if (!steering.hasPendingFollowUpOutcome()) {
             // Read the ACK the same way askUser and the limit park do: the park TOOK only if
             // the server reports `awaiting_followup`. SetRunAwaitingFollowup (M2) matches
             // nothing when the run went terminal under us or is no longer ours (or is not an
             // interactive task) — without this check the worker would block on a follow-up no
             // surface can produce, since the status never changed. Fail loudly instead.
-            const ack = await reportState({ status: "awaiting_followup" });
+            const ack = await reportState({
+              status: "awaiting_followup",
+              open_followup_id: steering.getLastDeliveredFollowUpId(),
+            });
             const parked = (ack as { status?: string } | undefined)?.status;
             if (parked !== "awaiting_followup") {
               throw new Error(

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { WorkerClient } from "./client.js";
+import { RequestError } from "./client.js";
 import type { GitCache } from "./git.js";
 import {
   gitBasicCredential,
@@ -1122,6 +1123,43 @@ export class RunRunner {
               );
             }
             runLog.info("interactive task: awaiting follow-up", { run_id: runId });
+          } else {
+            // issue #559 M3: the SKIP path. A follow-up (or stop/cancel) is already buffered,
+            // so we deliberately do NOT report awaiting_followup (that would fold the
+            // not-yet-applied follow-up into the watermark — the #558/#552 fix above) and
+            // service the buffered outcome directly. But skipping the park report ALSO skips
+            // the ACK that, on the non-skip path, caught a mid-turn reclaim or terminal
+            // transition (status != awaiting_followup → throw). Restore that ownership/
+            // terminality check cheaply with a read-only ownership probe.
+            //
+            // ONLY a DEFINITIVE answer throws: a terminal status, or a definitive NOT-OWNED
+            // (HTTP 404 → reclaimed by another worker). A TRANSIENT error (network / 5xx /
+            // anything that is neither a 404 nor a terminal status) logs a warning and
+            // PROCEEDS — the non-skip path's reportState has bounded retries and never fails
+            // the run on a transient blip, and the run self-heals anyway at the next
+            // ACK-checked park report plus the SetRunRunning worker_id pin. We must not
+            // introduce a new spurious-failure mode, so a transient probe error is not one.
+            let ownershipStatus: string | undefined;
+            try {
+              ownershipStatus = (await this.client.getRunOwnership(runId)).status;
+            } catch (err) {
+              if (err instanceof RequestError && err.status === 404) {
+                throw new Error(
+                  `${REASON_FOLLOWUP_NOT_PARKED} (server reports the run is not owned by this worker)`,
+                );
+              }
+              // Transient (network / 5xx / unreadable): proceed and let the next park
+              // report's ACK + the SetRunRunning worker_id pin be the backstop.
+              runLog.warn(
+                "interactive task: ownership probe failed transiently on the follow-up skip path; proceeding",
+                { run_id: runId, error: String(err) },
+              );
+            }
+            if (ownershipStatus !== undefined && FOLLOWUP_TERMINAL_STATUSES.has(ownershipStatus)) {
+              throw new Error(
+                `${REASON_FOLLOWUP_NOT_PARKED} (server reports ${ownershipStatus})`,
+              );
+            }
           }
           return steering.awaitFollowUp(idleMs);
         },
@@ -3188,6 +3226,16 @@ const REASON_QUESTION_NOT_PARKED =
  *  took. */
 export const REASON_FOLLOWUP_NOT_PARKED =
   "could not park the interactive task to await a follow-up";
+
+/** issue #559 M3: the run statuses that mean the interactive turn must NOT continue —
+ *  a run that went terminal under us on the follow-up park-SKIP path. Checked against the
+ *  read-only ownership probe's reported status; a terminal answer throws
+ *  REASON_FOLLOWUP_NOT_PARKED just as a non-awaiting_followup ACK does on the non-skip path. */
+const FOLLOWUP_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
 
 /** PRD #84 M4: the additive `StateRequest` fields for a plan-time toolchain detection.
  *  Each array field is included ONLY when non-empty — mirroring the `milestones?.length ?

--- a/agent/src/steering.ts
+++ b/agent/src/steering.ts
@@ -111,7 +111,15 @@ function parseAnswerBody(
 export class SteeringChannel {
   private stopped = false;
   private loop: Promise<void> | undefined;
-  private readonly followUps: string[] = [];
+  private readonly followUps: { id: number; body: string }[] = [];
+  /** issue #559 M2: the highest `follow_up` input id this channel has already handed to the
+   *  executor — via pullFollowUp or awaitFollowUp/serviceFollowUp. This is the wake-guard
+   *  watermark the runner reports at the interactive park (open_followup_id). Buffering a
+   *  follow-up (route → push) does NOT advance it; only DELIVERY (takeFollowUp shift) does,
+   *  which is what makes it race-free across the park report's DB round-trip: the value is
+   *  stable while the report is in flight because the follow-up waiter is armed only AFTER
+   *  the report returns. Monotone (Math.max). */
+  private lastDeliveredFollowUpIdValue = 0;
   /** The current gate epoch (PRD #41): bumped at each awaiting_approval (re-)report.
    *  Every buffered verdict / queued revise is stamped with the epoch it arrived at, so
    *  a verdict written against a superseded plan version is detectable. Starts at 0 so a
@@ -298,9 +306,30 @@ export class SteeringChannel {
     w.resolve(v);
   }
 
+  /** Shift the oldest buffered follow-up and advance the last-delivered watermark to its id
+   *  (issue #559 M2). The SINGLE delivery site: every place that hands a follow-up to the
+   *  executor routes through here so none can forget to advance the watermark — the same
+   *  sibling-clear hazard the SQL wake-guard comments guard against. Monotone via Math.max. */
+  private takeFollowUp(): { id: number; body: string } | undefined {
+    const f = this.followUps.shift();
+    if (f)
+      this.lastDeliveredFollowUpIdValue = Math.max(
+        this.lastDeliveredFollowUpIdValue,
+        f.id,
+      );
+    return f;
+  }
+
+  /** issue #559 M2: the highest `follow_up` input id already delivered to the executor —
+   *  the wake-guard watermark the runner reports as `open_followup_id` on the interactive
+   *  park. Named to avoid colliding with the `lastDeliveredFollowUpIdValue` field. */
+  getLastDeliveredFollowUpId(): number {
+    return this.lastDeliveredFollowUpIdValue;
+  }
+
   /** Dequeue the oldest un-consumed follow-up, or undefined if none. */
   pullFollowUp(): string | undefined {
-    return this.followUps.shift();
+    return this.takeFollowUp()?.body;
   }
 
   /**
@@ -360,11 +389,13 @@ export class SteeringChannel {
         kind: "ended",
         reason: "stopped",
       });
-    if (this.followUps.length)
+    if (this.followUps.length) {
+      const f = this.takeFollowUp()!;
       return Promise.resolve<FollowUpOutcome>({
         kind: "followup",
-        body: this.followUps.shift()!,
+        body: f.body,
       });
+    }
     return new Promise<FollowUpOutcome>((resolve) => {
       this.followUpWaiter = { resolve, idleMs, parkedAt: this.now() };
     });
@@ -393,8 +424,9 @@ export class SteeringChannel {
       return;
     }
     if (this.followUps.length) {
+      const f = this.takeFollowUp()!;
       this.followUpWaiter = undefined;
-      w.resolve({ kind: "followup", body: this.followUps.shift()! });
+      w.resolve({ kind: "followup", body: f.body });
       return;
     }
     if (this.now() - w.parkedAt >= w.idleMs) {
@@ -442,7 +474,7 @@ export class SteeringChannel {
     w.resolve(v);
   }
 
-  private route(kind: string, body: string | null | undefined): void {
+  private route(kind: string, body: string | null | undefined, id: number): void {
     switch (kind) {
       case "approve_plan":
         // The body carries the JSON-encoded agent selection (PRD #37). Parse it
@@ -484,7 +516,10 @@ export class SteeringChannel {
         this.stopRequested = true;
         break;
       case "follow_up":
-        if (body && body.trim()) this.followUps.push(body.trim());
+        // issue #559 M2: carry the input id alongside the body so a delivery (takeFollowUp)
+        // can advance the wake-guard watermark. The other kinds ignore the id.
+        if (body && body.trim())
+          this.followUps.push({ id, body: body.trim() });
         break;
       case "answer": {
         // PRD #88. Reaching the default arm instead would DESTROY the answer: /inputs
@@ -515,7 +550,8 @@ export class SteeringChannel {
     while (!this.stopped) {
       try {
         const inputs = await this.client.getInputs(this.runId);
-        for (const inp of inputs) this.route(inp.kind, inp.body ?? undefined);
+        for (const inp of inputs)
+          this.route(inp.kind, inp.body ?? undefined, inp.id);
       } catch (err) {
         // The loop continues on a getInputs failure (HTTP >=400 / timeout) — but only the
         // FETCH is skipped, not the service step below. PRD #517 M5: serviceFollowUp()

--- a/agent/test/fake-api.ts
+++ b/agent/test/fake-api.ts
@@ -46,6 +46,14 @@ export class FakeApi {
     { status: number; body: string }
   >();
   private readonly refuseAllStates = new Set<string>();
+  // issue #559 M3: the read-only ownership probe (GET /runs/{id}/ownership). A run
+  // with no override answers 200 {status:"running"} — the "still ours, keep going"
+  // default the skip path proceeds on. An override expresses a terminal status, a
+  // 404 not-owned, or a transient 5xx.
+  private readonly ownershipByRun = new Map<
+    string,
+    { httpStatus: number; status?: string }
+  >();
 
   // --- records -------------------------------------------------------------
   readonly registers: RecordedRegister[] = [];
@@ -164,6 +172,24 @@ export class FakeApi {
 
   setInputs(runId: string, inputs: UserInput[]): void {
     this.inputsByRun.set(runId, inputs);
+  }
+
+  /** issue #559 M3: answer the ownership probe for this run with 200 {status}. Use a
+   *  terminal status (completed/failed/cancelled) to drive the skip-path terminal throw. */
+  setOwnershipStatus(runId: string, status: string): void {
+    this.ownershipByRun.set(runId, { httpStatus: 200, status });
+  }
+
+  /** issue #559 M3: answer the ownership probe with 404 — the DEFINITIVE not-owned
+   *  (reclaimed) signal that makes the skip path throw REASON_FOLLOWUP_NOT_PARKED. */
+  setOwnershipNotOwned(runId: string): void {
+    this.ownershipByRun.set(runId, { httpStatus: 404 });
+  }
+
+  /** issue #559 M3: answer the ownership probe with a TRANSIENT error (default 503) —
+   *  neither a 404 nor a terminal status, so the skip path logs and PROCEEDS. */
+  failOwnership(runId: string, httpStatus = 503): void {
+    this.ownershipByRun.set(runId, { httpStatus });
   }
 
   /** Observe each /state report as it lands, so a test can react to a value the
@@ -287,6 +313,20 @@ export class FakeApi {
         return send(res, 200, { inputs: pending });
       }
     }
+
+    // issue #559 M3: the read-only ownership probe. Not part of the runMatch
+    // alternation above (it is a GET-only read of a distinct segment), so it is
+    // routed here. No override ⇒ 200 {status:"running"} (still ours, keep going).
+    const ownMatch = /^\/api\/worker\/runs\/([^/]+)\/ownership$/.exec(p);
+    if (req.method === "GET" && ownMatch) {
+      const runId = ownMatch[1] as string;
+      const o = this.ownershipByRun.get(runId);
+      if (!o) return send(res, 200, { status: "running" });
+      if (o.httpStatus !== 200)
+        return send(res, o.httpStatus, { error: "run not found for this worker" });
+      return send(res, 200, { status: o.status ?? "running" });
+    }
+
     return send(res, 404, { error: "not found", path: p });
   }
 

--- a/agent/test/interactive-task-park.test.ts
+++ b/agent/test/interactive-task-park.test.ts
@@ -17,9 +17,11 @@ import type { PlanVerdict } from "../src/steering.js";
 import { SteeringChannel } from "../src/steering.js";
 import type { ClaimResponse, UserInput } from "../src/protocol.js";
 import type { WorkerClient } from "../src/client.js";
+import { RequestError } from "../src/client.js";
 import { makeClaim, nullLogger } from "./helpers.js";
 import {
   api,
+  client,
   fx,
   fakeGitlab,
   installHarness,
@@ -1128,5 +1130,135 @@ describe("RunRunner interactive follow-up park (PRD #517 M3)", () => {
       { kind: "followup", body: "turn 3" },
       { kind: "ended", reason: "stopped" },
     ]);
+  });
+
+  it("skip path: a reclaimed run (ownership probe 404) fails the turn with REASON_FOLLOWUP_NOT_PARKED (issue #559 M3)", async () => {
+    // The skip path (a follow-up already buffered mid-turn) does NOT report awaiting_followup,
+    // so it loses that report's ACK — the ownership/terminality check. M3 restores it with the
+    // read-only ownership probe: a DEFINITIVE not-owned (HTTP 404 → reclaimed by another worker)
+    // must fail the turn early, exactly as a non-awaiting_followup ACK does on the non-skip path.
+    // Mutation: drop the `err.status === 404 → throw` arm on the skip path → a reclaimed run runs
+    // one extra full turn before the SetRunRunning worker_id pin catches it, and this assert reddens.
+    const { gitlab } = fakeGitlab();
+    const log = { outcomes: [] as FollowUpOutcome[], checkpointed: false };
+    const claim = taskClaim();
+    // Buffer a follow-up before the run starts → the park callback takes the SKIP path.
+    api.setInputs(claim.run_id, [{ id: 1, kind: "follow_up", body: "keep going" }]);
+    api.setOwnershipNotOwned(claim.run_id);
+
+    await runner(parkingExecutor(log), gitlab).execute(claim);
+
+    const failed = api.states.find(
+      (s) => s.runId === claim.run_id && s.body.status === "failed",
+    );
+    assert.ok(failed, "a reclaimed run must fail early on the skip path, not run another turn");
+    assert.match(failed!.body.failure_reason ?? "", new RegExp(REASON_FOLLOWUP_NOT_PARKED));
+    assert.deepStrictEqual(log.outcomes, [], "the executor never received the buffered follow-up");
+  });
+
+  it("skip path: a terminal ownership status fails the turn with REASON_FOLLOWUP_NOT_PARKED (issue #559 M3)", async () => {
+    // The other DEFINITIVE answer: the run went terminal under us (completed/failed/cancelled).
+    // The probe returns 200 with a terminal status, which the WORKER interprets and throws.
+    // Mutation: drop the FOLLOWUP_TERMINAL_STATUSES check on the skip path → a terminal run runs
+    // an extra turn and this assert reddens.
+    const { gitlab } = fakeGitlab();
+    const log = { outcomes: [] as FollowUpOutcome[], checkpointed: false };
+    const claim = taskClaim();
+    api.setInputs(claim.run_id, [{ id: 1, kind: "follow_up", body: "keep going" }]);
+    api.setOwnershipStatus(claim.run_id, "completed");
+
+    await runner(parkingExecutor(log), gitlab).execute(claim);
+
+    const failed = api.states.find(
+      (s) => s.runId === claim.run_id && s.body.status === "failed",
+    );
+    assert.ok(failed, "a terminal run must fail the turn on the skip path");
+    assert.match(failed!.body.failure_reason ?? "", new RegExp(REASON_FOLLOWUP_NOT_PARKED));
+    assert.match(failed!.body.failure_reason ?? "", /completed/, "the failure names the terminal status");
+    assert.deepStrictEqual(log.outcomes, [], "the executor never received the buffered follow-up");
+  });
+
+  it("skip path: a TRANSIENT ownership probe error is swallowed and the run PROCEEDS (issue #559 M3)", async () => {
+    // The must-not-regress property: a transient probe failure (network / 5xx / anything that is
+    // neither a 404 nor a terminal status) must NOT fail the run. The non-skip path's reportState
+    // never fails on a transient blip either, and the run self-heals at the next ACK-checked park
+    // report + the SetRunRunning worker_id pin. Mutation: make the catch re-throw on any error →
+    // the buffered follow-up is never serviced, the run reports `failed`, and the completed assert
+    // reddens.
+    const { gitlab } = fakeGitlab();
+    const log = { outcomes: [] as FollowUpOutcome[], checkpointed: false };
+    const claim = taskClaim();
+    api.setInputs(claim.run_id, [{ id: 1, kind: "follow_up", body: "keep going" }]);
+    api.failOwnership(claim.run_id, 503);
+
+    await runner(parkingExecutor(log), gitlab).execute(claim);
+
+    const statuses = api.states
+      .filter((s) => s.runId === claim.run_id)
+      .map((s) => s.body.status);
+    assert.ok(
+      !statuses.includes("failed"),
+      `a transient probe error must NOT fail the run; statuses were ${JSON.stringify(statuses)}`,
+    );
+    assert.deepStrictEqual(
+      log.outcomes,
+      [{ kind: "followup", body: "keep going" }],
+      "the buffered follow-up was serviced despite the transient probe error",
+    );
+    assert.strictEqual(statuses.at(-1), "completed", "the run proceeded past the probe and finalized");
+  });
+
+  it("skip path: an owned+running ownership status proceeds normally (issue #559 M3)", async () => {
+    // The happy skip path: still ours, still running → service the buffered follow-up directly,
+    // no awaiting_followup park (the #558/#552 property) and no throw.
+    const { gitlab } = fakeGitlab();
+    const log = { outcomes: [] as FollowUpOutcome[], checkpointed: false };
+    const claim = taskClaim();
+    api.setInputs(claim.run_id, [{ id: 1, kind: "follow_up", body: "keep going" }]);
+    api.setOwnershipStatus(claim.run_id, "running");
+
+    await runner(parkingExecutor(log), gitlab).execute(claim);
+
+    const statuses = api.states
+      .filter((s) => s.runId === claim.run_id)
+      .map((s) => s.body.status);
+    assert.ok(
+      !statuses.includes("awaiting_followup"),
+      `a mid-turn-buffered follow-up must NOT trigger a park; statuses were ${JSON.stringify(statuses)}`,
+    );
+    assert.deepStrictEqual(
+      log.outcomes,
+      [{ kind: "followup", body: "keep going" }],
+      "the buffered follow-up was serviced directly after the owned+running probe",
+    );
+    assert.strictEqual(statuses.at(-1), "completed", "the run resumed past the skipped park and finalized");
+  });
+});
+
+describe("WorkerClient.getRunOwnership (issue #559 M3)", () => {
+  it("returns { status } on a 200 ownership response", async () => {
+    const runId = randomUUID();
+    api.setOwnershipStatus(runId, "running");
+    assert.deepStrictEqual(await client.getRunOwnership(runId), { status: "running" });
+  });
+
+  it("throws a RequestError carrying status 404 when the run is not owned", async () => {
+    const runId = randomUUID();
+    api.setOwnershipNotOwned(runId);
+    await assert.rejects(
+      () => client.getRunOwnership(runId),
+      (err: unknown) => err instanceof RequestError && err.status === 404,
+      "a 404 must surface as a RequestError whose status the caller can read",
+    );
+  });
+
+  it("throws a RequestError carrying the 5xx status on a transient error", async () => {
+    const runId = randomUUID();
+    api.failOwnership(runId, 503);
+    await assert.rejects(
+      () => client.getRunOwnership(runId),
+      (err: unknown) => err instanceof RequestError && err.status === 503,
+      "a 5xx must surface as a RequestError whose status the caller can distinguish from 404",
+    );
   });
 });

--- a/agent/test/interactive-task-park.test.ts
+++ b/agent/test/interactive-task-park.test.ts
@@ -881,6 +881,41 @@ function idleParkingExecutor(log: { outcome?: FollowUpOutcome }): Executor {
   };
 }
 
+/** Parks in a loop, recording every outcome, until the park ENDS (a stop/idle/cancel). The
+ *  vehicle for the issue #559 watermark test: it parks once per delivered follow-up, so the
+ *  runner emits one awaiting_followup report per turn and we can read the open_followup_id it
+ *  stamped at each. Commits real work at the end so the run finalizes through the normal push. */
+function multiParkExecutor(log: { outcomes: FollowUpOutcome[] }): Executor {
+  return {
+    async run(ctx: RunContext): Promise<{ branch: string }> {
+      await ctx.checkpoint?.({ reap: true });
+      for (;;) {
+        const o = await ctx.awaitFollowUp!(60_000);
+        log.outcomes.push(o);
+        if (o.kind === "ended") break;
+      }
+      fs.writeFileSync(path.join(ctx.worktreePath, "UZI_RUN.md"), "# interactive multi-turn\n");
+      execFileSync("git", ["add", "UZI_RUN.md"], { cwd: ctx.worktreePath });
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.name=uzi-agent",
+          "-c",
+          "user.email=uzi-agent@uzi.local",
+          "-c",
+          "commit.gpgsign=false",
+          "commit",
+          "-m",
+          "uzi test: interactive multi-turn handled",
+        ],
+        { cwd: ctx.worktreePath },
+      );
+      return { branch: ctx.branch };
+    },
+  };
+}
+
 function taskClaim(overrides: Partial<ClaimResponse> = {}): ClaimResponse {
   const runId = (overrides.run_id as string | undefined) ?? randomUUID();
   return makeClaim({
@@ -1053,5 +1088,45 @@ describe("RunRunner interactive follow-up park (PRD #517 M3)", () => {
     );
     // open_mr:false ⇒ a push, not an MR-open: no createMergeRequest POST reached the forge.
     assert.equal(calls.length, 0, "a no-MR idle finalize opens no merge request");
+  });
+
+  it("carries open_followup_id = the pre-round-trip last-delivered id on each park report (issue #559 M2)", async () => {
+    // The worker-provided wake-guard watermark. Each awaiting_followup report must carry the
+    // highest follow_up id ALREADY delivered before that report — a value stable across the
+    // report's DB round-trip because the next follow-up is consumed only AFTER the report
+    // returns. Three parks: nothing delivered yet (0), then after follow-up id 5 (5), then
+    // after follow-up id 8 (8); a final stop ends the loop. Mutation: drop `open_followup_id`
+    // from the reportState call in the awaitFollowUp callback → the field is undefined on
+    // every park report and the deepStrictEqual reddens.
+    const { gitlab } = fakeGitlab();
+    const log = { outcomes: [] as FollowUpOutcome[] };
+    const claim = taskClaim();
+
+    let park = 0;
+    api.onState(claim.run_id, (body) => {
+      if (body.status !== "awaiting_followup") return;
+      park++;
+      if (park === 1)
+        api.setInputs(claim.run_id, [{ id: 5, kind: "follow_up", body: "turn 2" }]);
+      else if (park === 2)
+        api.setInputs(claim.run_id, [{ id: 8, kind: "follow_up", body: "turn 3" }]);
+      else api.setInputs(claim.run_id, [{ id: 9, kind: "stop", body: "wind down" }]);
+    });
+
+    await runner(multiParkExecutor(log), gitlab).execute(claim);
+
+    const watermarks = api.states
+      .filter((s) => s.runId === claim.run_id && s.body.status === "awaiting_followup")
+      .map((s) => s.body.open_followup_id);
+    assert.deepStrictEqual(
+      watermarks,
+      [0, 5, 8],
+      `each park must report the pre-round-trip last-delivered id; got ${JSON.stringify(watermarks)}`,
+    );
+    assert.deepStrictEqual(log.outcomes, [
+      { kind: "followup", body: "turn 2" },
+      { kind: "followup", body: "turn 3" },
+      { kind: "ended", reason: "stopped" },
+    ]);
   });
 });

--- a/agent/test/steering.test.ts
+++ b/agent/test/steering.test.ts
@@ -86,6 +86,81 @@ describe("SteeringChannel", () => {
   });
 });
 
+// issue #559 M2: the channel tracks the highest follow_up input id it has already DELIVERED
+// to the executor (getLastDeliveredFollowUpId) — the wake-guard watermark the runner reports
+// as open_followup_id at the interactive park. Buffering a follow-up does NOT advance it; only
+// delivery (the takeFollowUp shift) does, which is what keeps it stable across the park
+// report's DB round-trip.
+describe("SteeringChannel — last-delivered follow-up watermark (issue #559)", () => {
+  const inpId = (kind: UserInput["kind"], id: number, body?: string): UserInput => ({
+    id,
+    kind,
+    body: body ?? null,
+  });
+
+  it("threads the input id through route/follow_up; pullFollowUp advances the watermark to the delivered id", async () => {
+    // Mutation: drop the `id` param on route() (or store body only) → the queue loses the id
+    // and the watermark can never advance past 0.
+    const { ch } = makeChannel([
+      [inpId("follow_up", 3, "a"), inpId("follow_up", 7, "b")],
+    ]);
+    ch.start();
+    await tick(); // poll consumes + buffers both — buffering must NOT advance the watermark
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 0, "buffered, not delivered");
+    assert.strictEqual(ch.pullFollowUp(), "a");
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 3, "advanced to the first delivered id");
+    assert.strictEqual(ch.pullFollowUp(), "b");
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 7, "advanced to the second delivered id");
+    assert.strictEqual(ch.pullFollowUp(), undefined);
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 7, "an empty pull leaves it unchanged");
+    await ch.stop();
+  });
+
+  it("awaitFollowUp's drain-after-arm advances the watermark; buffering alone does NOT (the race property)", async () => {
+    // The race the whole feature closes: a follow-up merely BUFFERED (consumed by the poll loop
+    // while no waiter is armed) must not move the watermark, so a report in flight cannot fold
+    // it in. Only arming + delivering it advances the watermark. Mutation: make pullFollowUp/
+    // awaitFollowUp shift `this.followUps` directly instead of via takeFollowUp → delivery no
+    // longer advances the watermark and the final assert reddens.
+    const { ch } = makeChannel([[inpId("follow_up", 12, "task")]]);
+    ch.start();
+    await tick(); // buffered, no waiter armed yet
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 0, "a buffered follow-up does not advance it");
+    const outcome = await ch.awaitFollowUp(60_000); // immediate-return branch drains the buffer
+    assert.deepStrictEqual(outcome, { kind: "followup", body: "task" });
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 12, "delivery advanced it");
+    await ch.stop();
+  });
+
+  it("serviceFollowUp (poll-loop delivery to a parked waiter) advances the watermark", async () => {
+    // The third delivery site: the waiter is armed BEFORE the first poll routes, so the follow-up
+    // is delivered from serviceFollowUp (post-route), not the immediate-return branch. Mutation:
+    // leave serviceFollowUp shifting `this.followUps` directly → the watermark stays 0.
+    const { ch } = makeChannel([[inpId("follow_up", 9, "y")]]);
+    ch.start();
+    const parked = ch.awaitFollowUp(60_000); // arm before the first poll routes anything
+    const outcome = await parked;
+    assert.deepStrictEqual(outcome, { kind: "followup", body: "y" });
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 9, "serviceFollowUp advanced it");
+    await ch.stop();
+  });
+
+  it("the watermark is monotone (Math.max) across out-of-order delivered ids", async () => {
+    // A lower id delivered after a higher one must NOT regress the watermark. Mutation: replace
+    // Math.max(...) with a plain assignment in takeFollowUp → the second pull drops it to 4.
+    const { ch } = makeChannel([
+      [inpId("follow_up", 10, "hi"), inpId("follow_up", 4, "lo")],
+    ]);
+    ch.start();
+    await tick();
+    assert.strictEqual(ch.pullFollowUp(), "hi");
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 10);
+    assert.strictEqual(ch.pullFollowUp(), "lo");
+    assert.strictEqual(ch.getLastDeliveredFollowUpId(), 10, "a lower delivered id never regresses it");
+    await ch.stop();
+  });
+});
+
 // PRD #41: plan revision at the gate. The channel epoch-stamps every verdict/revise so
 // one written against a stale plan version is discardable, and a revise both enqueues
 // (FIFO) and wakes the gate.

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -1515,6 +1515,13 @@ func (h *Handler) mountWorkerRoutes(r chi.Router, proposalLimiter *mw.Limiter) {
 		r.Post("/runs/{id}/state", h.WorkerRunState)
 		r.Get("/runs/{id}/inputs", h.WorkerRunInputs)
 
+		// Ownership/terminality probe (#559): worker-authenticated, run-scoped,
+		// READ ONLY. The interactive park-SKIP path polls it to detect a mid-turn
+		// reclaim (404) or terminal transition early — restoring the ACK the
+		// skipped awaiting_followup park report used to give. Reuses
+		// GetRunOwnedByWorker; no new query.
+		r.Get("/runs/{id}/ownership", h.WorkerRunOwnership)
+
 		// Checkpoint publish (PRD #122 M8): the worker POSTs a raw delta packfile +
 		// tip OID; the api derives repo/branch/PAT from the run row and pushes it
 		// NON-FORCED to refs/uzi-checkpoints/<branch>. Inherits RequireWorker; feeds

--- a/api/internal/handler/route_limiter_mounts_test.go
+++ b/api/internal/handler/route_limiter_mounts_test.go
@@ -67,7 +67,9 @@ var limiterNames = [...]string{
 // error rather than a failing row. Spelled `lim*` rather than matching the parameter
 // names exactly, so nothing here shadows a parameter inside Routes.
 //
-// 169 as of this commit (PRD #685 M1 added GET /api/branding, GET
+// 170 as of this commit (issue #559 added GET /api/worker/runs/{id}/ownership —
+// the interactive park-skip ownership/terminality probe).
+// It was 169 until then (PRD #685 M1 added GET /api/branding, GET
 // /api/branding/logo/{slot}, PUT /api/admin/branding/logo/{slot} and DELETE
 // /api/admin/branding/logo/{slot} — the public instance-branding config + logo reads
 // and the admin logo upload/clear writes).
@@ -323,6 +325,7 @@ var wantRouteMounts = []routeMount{
 	{"GET", "/api/worker/runs/{id}/forge/pipelines/{pipeline_id}/jobs", noLimiter},
 	{"GET", "/api/worker/runs/{id}/inputs", noLimiter},
 	{"GET", "/api/worker/runs/{id}/memory", noLimiter},
+	{"GET", "/api/worker/runs/{id}/ownership", noLimiter},
 	{"GET", "/api/worker/runs/{id}/trace", noLimiter},
 	{"GET", "/api/workers/", noLimiter},
 	{"GET", "/api/workers/hosted/config", noLimiter},

--- a/api/internal/handler/worker_protocol.go
+++ b/api/internal/handler/worker_protocol.go
@@ -630,6 +630,35 @@ func (h *Handler) WorkerRunInputs(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, http.StatusOK, map[string]any{"inputs": inputs})
 }
 
+// WorkerRunOwnership returns the current status of a run this worker owns —
+// a lightweight, READ-ONLY ownership/terminality probe (#559). The interactive
+// park-SKIP path uses it to detect a mid-turn reclaim (404) or a terminal
+// transition (200 with a terminal status) early, restoring the ACK the skipped
+// awaiting_followup park report used to give.
+func (h *Handler) WorkerRunOwnership(w http.ResponseWriter, r *http.Request) {
+	wkr, ok := mw.WorkerFromContext(r.Context())
+	if !ok {
+		httpx.Error(w, http.StatusUnauthorized, "worker authentication required")
+		return
+	}
+	runID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httpx.Error(w, http.StatusBadRequest, "invalid run id")
+		return
+	}
+	status, err := h.wsvc.RunOwnership(r.Context(), wkr, runID)
+	if err != nil {
+		if errors.Is(err, workersvc.ErrRunNotOwned) {
+			httpx.Error(w, http.StatusNotFound, "run not found for this worker")
+			return
+		}
+		slog.Error("worker run ownership", "error", err)
+		httpx.Error(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	httpx.JSON(w, http.StatusOK, map[string]any{"status": status})
+}
+
 // workerMemoryToDTO maps a stored entry to the worker-facing DTO. It carries run_id
 // (provenance) but OMITS repo_id/repo_name — the worker already knows the run's repo
 // and the write derives it server-side, so echoing it would be redundant surface.

--- a/api/internal/handler/worker_protocol_test.go
+++ b/api/internal/handler/worker_protocol_test.go
@@ -616,6 +616,63 @@ func TestWorkerMessagesForeignRunReturns404(t *testing.T) {
 	}
 }
 
+// TestWorkerRunOwnershipOwnedRunning pins the happy path of the interactive
+// park-skip ownership probe (#559): an owned, still-running run returns 200 with
+// the live status, which the worker reads as "keep going".
+func TestWorkerRunOwnershipOwnedRunning(t *testing.T) {
+	runID := uuid.New()
+	h := newProtocolHandler(t, &protocolStore{ownedRun: store.Run{ID: runID, Status: "running"}})
+	rec := httptest.NewRecorder()
+	h.WorkerRunOwnership(rec, workerReq(http.MethodGet, "", runID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (owned+running)", rec.Code)
+	}
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Status != "running" {
+		t.Fatalf("status = %q, want %q", got.Status, "running")
+	}
+}
+
+// TestWorkerRunOwnershipReclaimedReturns404 pins the reclaim signal: a run no
+// longer owned by this worker (GetRunOwnedByWorker → ErrNoRows) is a definitive
+// 404, which the worker treats as a NOT-OWNED reclaim and fails the turn early.
+func TestWorkerRunOwnershipReclaimedReturns404(t *testing.T) {
+	runID := uuid.New()
+	h := newProtocolHandler(t, &protocolStore{ownedErr: pgx.ErrNoRows})
+	rec := httptest.NewRecorder()
+	h.WorkerRunOwnership(rec, workerReq(http.MethodGet, "", runID))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (run not owned by this worker)", rec.Code)
+	}
+}
+
+// TestWorkerRunOwnershipTerminalReturnsStatus pins that a still-owned but
+// terminal run returns 200 with the terminal status — the worker, not the
+// server, interprets terminality and fails the turn.
+func TestWorkerRunOwnershipTerminalReturnsStatus(t *testing.T) {
+	runID := uuid.New()
+	h := newProtocolHandler(t, &protocolStore{ownedRun: store.Run{ID: runID, Status: "completed"}})
+	rec := httptest.NewRecorder()
+	h.WorkerRunOwnership(rec, workerReq(http.MethodGet, "", runID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (owned+terminal)", rec.Code)
+	}
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Fatalf("status = %q, want %q", got.Status, "completed")
+	}
+}
+
 // TestNormalizeMemoryBasis pins the READ-side default for writer-declared
 // provenance (PRD #266). normalizeMemoryBasis is a pure function that had ZERO
 // tests, so a mutation flipping its default to "observed" left the suite green.

--- a/api/internal/store/interactive_task_runs_livedb_test.go
+++ b/api/internal/store/interactive_task_runs_livedb_test.go
@@ -313,3 +313,44 @@ func TestInteractiveTaskRunsFollowupWatermarkFallbackLiveDB(t *testing.T) {
 			"the NULL-param fallback is not byte-identical to the pre-#559 behavior", got, id2)
 	}
 }
+
+// Issue #559 M1: the LOWER floor. LEAST only bounds a huge value from above; a nonsensical
+// NEGATIVE worker value (e.g. -1) would otherwise be stamped verbatim and fail-open THIS
+// run's own wake guard (`id > COALESCE(open_followup_id, 0)` becomes `id > -1`, true for
+// every positive bigserial id, so any consumed follow_up wakes it — reopening #558 for that
+// run). GREATEST(0, ...) floors it to 0 ("nothing applied", the first-park value). A
+// consumed follow_up then still admits the wake (0 is not a strand), matching first-park
+// semantics rather than the fail-open a raw -1 would give.
+func TestInteractiveTaskRunsFollowupWatermarkNegativeFloorLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	w, done := newFollowupWatermarkFixture(ctx, t, dsn)
+	defer done()
+
+	// A consumed follow_up exists (max-consumed > 0), so the LEAST ceiling is positive and
+	// cannot itself account for a 0 result — only the GREATEST(0, ...) floor can.
+	id := w.createConsumedFollowup(t)
+	if id <= 0 {
+		t.Fatalf("run_user_inputs.id not positive: %d", id)
+	}
+	w.park(t, ptrInt64(-1))
+	if got := w.watermark(t); got != 0 {
+		t.Fatalf("open_followup_id = %d, want 0 — a negative worker value must floor to 0, not "+
+			"be stamped verbatim (a stored -1 fail-opens the run's own wake guard)", got)
+	}
+	// The consumed follow_up (> 0 == watermark) still admits the wake: floored-to-0 is
+	// first-park semantics, not a strand.
+	rows, err := w.f.q.SetRunRunning(ctx, store.SetRunRunningParams{
+		ID: w.run, WorkerID: pgU(w.wkr), IterationCount: 1,
+	})
+	if err != nil {
+		t.Fatalf("SetRunRunning: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("SetRunRunning matched %d rows, want 1 — a consumed follow_up (id=%d > watermark 0) "+
+			"should admit the wake", rows, id)
+	}
+}

--- a/api/internal/store/interactive_task_runs_livedb_test.go
+++ b/api/internal/store/interactive_task_runs_livedb_test.go
@@ -135,3 +135,181 @@ func TestInteractiveTaskRunConstraintsLiveDB(t *testing.T) {
 		t.Error("run_user_inputs_kind_check ACCEPTED a bogus kind: the CHECK is vacuous")
 	}
 }
+
+// followupWatermarkFixture bundles the shared seeding + query closures the issue #559 M1
+// watermark tests below all need: a fresh online worker, a running interactive task run,
+// and helpers to append a follow_up, consume the queue, park with a worker-provided
+// watermark, and read the stamped open_followup_id back. It reuses the followupFixture
+// helpers from interactive_task_runs_recovery_livedb_test.go (same package).
+type followupWatermarkFixture struct {
+	f   *followupFixture
+	ctx context.Context
+	wkr uuid.UUID
+	run uuid.UUID
+}
+
+func newFollowupWatermarkFixture(ctx context.Context, t *testing.T, dsn string) (*followupWatermarkFixture, func()) {
+	t.Helper()
+	f, done := setupFollowup(ctx, t, dsn)
+	wkr := f.seedWorker(ctx, t, "online", pgtype.Int4{}, false)
+	run := f.seedInteractiveTaskRun(ctx, t, "running", &wkr)
+	return &followupWatermarkFixture{f: f, ctx: ctx, wkr: wkr, run: run}, done
+}
+
+// createConsumedFollowup appends a follow_up steering input and consumes the queue,
+// returning the new input's id (a member of the run's max-consumed set thereafter).
+func (w *followupWatermarkFixture) createConsumedFollowup(t *testing.T) int64 {
+	t.Helper()
+	in, err := w.f.q.CreateRunInput(w.ctx, store.CreateRunInputParams{
+		RunID: w.run, Kind: "follow_up", Body: pgT(`{"body":"steer"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateRunInput(follow_up): %v", err)
+	}
+	if _, err := w.f.q.ConsumeRunInputs(w.ctx, w.run); err != nil {
+		t.Fatalf("ConsumeRunInputs: %v", err)
+	}
+	return in.ID
+}
+
+// park reports awaiting_followup with the given worker-provided watermark. provided==nil
+// omits it (old worker / first park), so the server's COALESCE fallback fires.
+func (w *followupWatermarkFixture) park(t *testing.T, provided *int64) {
+	t.Helper()
+	p := pgtype.Int8{}
+	if provided != nil {
+		p = pgtype.Int8{Int64: *provided, Valid: true}
+	}
+	rows, err := w.f.q.SetRunAwaitingFollowup(w.ctx, store.SetRunAwaitingFollowupParams{
+		OpenFollowupID: p, ID: w.run, WorkerID: pgU(w.wkr),
+	})
+	if err != nil || rows != 1 {
+		t.Fatalf("SetRunAwaitingFollowup(provided=%v): rows=%d err=%v", provided, rows, err)
+	}
+}
+
+// watermark reads the stamped open_followup_id (Int64 is 0 when NULL, matching the guard).
+func (w *followupWatermarkFixture) watermark(t *testing.T) int64 {
+	t.Helper()
+	got, err := w.f.q.GetRunByID(w.ctx, w.run)
+	if err != nil {
+		t.Fatalf("GetRunByID: %v", err)
+	}
+	return got.OpenFollowupID.Int64
+}
+
+// ptr is a tiny helper so a test can pass a *int64 literal to park().
+func ptrInt64(v int64) *int64 { return &v }
+
+// Issue #559 M1: a WORKER-PROVIDED watermark ≤ the run's max-consumed is stamped VERBATIM.
+// Two follow_ups are consumed (id1 < id2, so max-consumed == id2); the worker reports id1
+// (it only applied id1), and the LEAST(provided, max-consumed) clamp leaves id1 untouched
+// because id1 < id2. Proves the provided value flows through, not the server subquery.
+func TestInteractiveTaskRunsFollowupWatermarkWorkerProvidedLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	w, done := newFollowupWatermarkFixture(ctx, t, dsn)
+	defer done()
+
+	id1 := w.createConsumedFollowup(t)
+	id2 := w.createConsumedFollowup(t)
+	if id2 <= id1 {
+		t.Fatalf("run_user_inputs.id not monotone: id2=%d id1=%d", id2, id1)
+	}
+	w.park(t, ptrInt64(id1))
+	if got := w.watermark(t); got != id1 {
+		t.Fatalf("open_followup_id = %d, want the worker-provided id1=%d (max-consumed was id2=%d) — "+
+			"the provided value did not flow through, or the clamp over-clamped", got, id1, id2)
+	}
+}
+
+// Issue #559 M1: THE RACE. Two follow_ups are consumed (M < N, so N was consumed DURING
+// what would be this park's DB round-trip), but the worker only APPLIED M and reports M.
+// The pure-server watermark would fold N in and permanently strand the run (the wake guard
+// would then never see a follow_up NEWER than the watermark). With the worker-provided
+// value, the watermark is M, so N (> M, consumed) still admits awaiting_followup → running.
+func TestInteractiveTaskRunsFollowupWatermarkRaceLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	w, done := newFollowupWatermarkFixture(ctx, t, dsn)
+	defer done()
+
+	m := w.createConsumedFollowup(t)
+	n := w.createConsumedFollowup(t) // consumed during the park's round-trip; not yet applied by the worker
+	if n <= m {
+		t.Fatalf("run_user_inputs.id not monotone: n=%d m=%d", n, m)
+	}
+	w.park(t, ptrInt64(m))
+	if got := w.watermark(t); got != m {
+		t.Fatalf("open_followup_id = %d, want M=%d (NOT N=%d) — the server folded the raced-in "+
+			"follow_up into the watermark and would strand the run", got, m, n)
+	}
+	// N (> M) is consumed, so the wake guard admits the resume: the run is NOT stranded.
+	rows, err := w.f.q.SetRunRunning(ctx, store.SetRunRunningParams{
+		ID: w.run, WorkerID: pgU(w.wkr), IterationCount: 1,
+	})
+	if err != nil {
+		t.Fatalf("SetRunRunning: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("SetRunRunning matched %d rows, want 1 — N=%d (> watermark M=%d, consumed) should admit "+
+			"the wake, proving the run is not stranded", rows, n, m)
+	}
+	if got := w.f.status(ctx, t, w.run); got != "running" {
+		t.Fatalf("status = %q after wake, want running", got)
+	}
+}
+
+// Issue #559 M1: the CLAMP. A buggy worker reports a watermark FAR above any consumed
+// follow_up. LEAST(provided, max-consumed) clamps it down to max-consumed, so it cannot
+// permanently strand the run (an unclamped huge value would exceed every future follow_up
+// id and the wake guard would never admit a resume).
+func TestInteractiveTaskRunsFollowupWatermarkClampLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	w, done := newFollowupWatermarkFixture(ctx, t, dsn)
+	defer done()
+
+	maxConsumed := w.createConsumedFollowup(t)
+	w.park(t, ptrInt64(maxConsumed+1_000_000))
+	if got := w.watermark(t); got != maxConsumed {
+		t.Fatalf("open_followup_id = %d, want it clamped down to max-consumed=%d — a buggy huge "+
+			"worker value was NOT neutralized and would strand the run", got, maxConsumed)
+	}
+}
+
+// Issue #559 M1: BACKWARD-COMPAT. An old worker omits open_followup_id (NULL param), so the
+// COALESCE fallback recomputes the server-derived max-consumed — byte-identical to the
+// pre-#559 behavior. Also covers the first-park case (nothing consumed → watermark 0).
+func TestInteractiveTaskRunsFollowupWatermarkFallbackLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	w, done := newFollowupWatermarkFixture(ctx, t, dsn)
+	defer done()
+
+	// First park, nothing consumed, no provided value → server-derived MAX over no rows = 0.
+	w.park(t, nil)
+	if got := w.watermark(t); got != 0 {
+		t.Fatalf("open_followup_id on first old-worker park = %d, want 0 (server-derived floor)", got)
+	}
+	// Two consumed follow_ups, still omitting the provided value → falls back to max-consumed.
+	_ = w.createConsumedFollowup(t)
+	id2 := w.createConsumedFollowup(t)
+	w.park(t, nil)
+	if got := w.watermark(t); got != id2 {
+		t.Fatalf("open_followup_id on old-worker re-park = %d, want the server-derived max-consumed=%d — "+
+			"the NULL-param fallback is not byte-identical to the pre-#559 behavior", got, id2)
+	}
+}

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -1061,11 +1061,15 @@ WHERE runs.id = @id AND worker_id = @worker_id
   -- consumed follow_up genuinely IS new.
   --
   -- No clear-on-wake is needed, and a future reader must NOT "add the missing sibling
-  -- clear" the way open_question_id needs one. The watermark keys on CONSUMED-only rows
-  -- and is RECOMPUTED at each park (SetRunAwaitingFollowup) to the max already-consumed
-  -- follow_up: the follow_up that wakes a park is unconsumed until it wakes, so it never
-  -- counts toward the watermark that guards its own park, and the next park's recompute
-  -- rolls the watermark forward to include it. There is nothing to reset between parks.
+  -- clear" the way open_question_id needs one. As of issue #559 the watermark is
+  -- WORKER-PROVIDED at each park (SetRunAwaitingFollowup) — the max follow_up id the
+  -- worker has already DELIVERED — CLAMPED there to the server's max already-consumed
+  -- follow_up, with a server-derived fallback to that same max-consumed when the worker
+  -- omits it (old worker / first park). Either way it keys on CONSUMED-only rows for its
+  -- ceiling: the follow_up that wakes a park is unconsumed until it wakes, so it never
+  -- counts toward the watermark that guards its own park, and the next park rolls the
+  -- watermark forward to include it. There is nothing to reset between parks. The guard
+  -- predicate below (`id > COALESCE(open_followup_id, 0)`) is UNCHANGED by #559.
   AND (status <> 'awaiting_followup' OR EXISTS (
         SELECT 1 FROM run_user_inputs
         WHERE run_user_inputs.run_id = @id
@@ -1481,19 +1485,39 @@ UPDATE runs SET
     status     = 'awaiting_followup',
     status_since = now(),
     session_id = COALESCE(sqlc.narg('session_id'), session_id),
-    -- Issue #552 M1: the park-scoped follow_up watermark. Stamp it, at EVERY park, to
-    -- the highest follow_up this run has ALREADY consumed. A later follow_up with a
-    -- higher id — the one the resuming worker will consume to wake THIS park — is what
-    -- SetRunRunning's Decision-7 guard requires to admit awaiting_followup → running,
-    -- so it discriminates "THIS park's follow_up" from "any follow_up ever consumed".
+    -- Issue #552 M1 / #559 M1: the park-scoped follow_up watermark. The value is now
+    -- WORKER-PROVIDED — the highest follow_up id the worker has ALREADY DELIVERED/applied
+    -- to a turn at the moment it parks — and CLAMPED here to the server-derived max
+    -- already-consumed follow_up as a safety ceiling (the LEAST(...) below). When the
+    -- worker OMITS it (an old worker, or the very first park before anything was
+    -- delivered) the COALESCE falls back to that same server-derived max-consumed, so an
+    -- absent param is byte-identical to the pre-#559 pure-server behavior.
     --
-    -- CONSUMED-only (consumed_at IS NOT NULL) is load-bearing: the follow_up that wakes
-    -- a park is UNCONSUMED until it wakes, so a consumed-only MAX never advances past
-    -- it. That makes recomputing the watermark at every re-park correct with NO claim
-    -- re-delivery, NO worker echo and NO clear-on-wake — the watermark simply names the
-    -- last follow_up already spent, and anything newer is a genuine new steer.
-    open_followup_id = (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
-                        WHERE run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL),
+    -- Why worker-provided: deriving the watermark purely from the server's max-consumed
+    -- races a follow_up consumed DURING this park report's DB round-trip — it would fold a
+    -- not-yet-applied follow_up into the watermark and permanently strand the run (the
+    -- guard then never sees a follow_up NEWER than the watermark). The worker knows exactly
+    -- which follow_ups it has applied, so it reports that; a correct worker's last-delivered
+    -- id is ALWAYS ≤ max-consumed, so the clamp never bites it. The clamp exists only to
+    -- neutralize a buggy huge value that would otherwise strand the run forever.
+    --
+    -- A later follow_up with a higher id — the one the resuming worker will consume to wake
+    -- THIS park — is what SetRunRunning's Decision-7 guard requires to admit
+    -- awaiting_followup → running, so the watermark discriminates "THIS park's follow_up"
+    -- from "any follow_up ever consumed".
+    --
+    -- CONSUMED-only (consumed_at IS NOT NULL) remains load-bearing on the server ceiling:
+    -- the follow_up that wakes a park is UNCONSUMED until it wakes, so a consumed-only MAX
+    -- never advances past it. The watermark stays monotone across re-parks with NO claim
+    -- re-delivery and NO clear-on-wake — it simply names the last follow_up already spent
+    -- (or the worker's last-delivered id, whichever is lower), and anything newer is a
+    -- genuine new steer.
+    open_followup_id = LEAST(
+        COALESCE(sqlc.narg('open_followup_id')::bigint,
+                 (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
+                  WHERE run_user_inputs.run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
+        (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
+         WHERE run_user_inputs.run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
     health = 'ok', health_reason = NULL, health_since = NULL,
     updated_at = now()
 WHERE id = @id AND worker_id = @worker_id

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -1512,12 +1512,20 @@ UPDATE runs SET
     -- re-delivery and NO clear-on-wake — it simply names the last follow_up already spent
     -- (or the worker's last-delivered id, whichever is lower), and anything newer is a
     -- genuine new steer.
-    open_followup_id = LEAST(
+    -- The GREATEST(0, ...) floor is the LOWER bound the LEAST ceiling does not give:
+    -- LEAST only bounds a huge value from above, so a nonsensical NEGATIVE worker value
+    -- (e.g. -1) would otherwise pass through and fail-open THIS run's own wake guard
+    -- (`id > COALESCE(open_followup_id, 0)` is `id > -1`, true for every positive
+    -- bigserial id, so any consumed follow_up wakes it — reopening #558 for that run).
+    -- Flooring to 0 maps it to "nothing applied" (the first-park value), matching the
+    -- stated "neutralize a buggy value" intent. GREATEST(0, ...) never affects a correct
+    -- worker: its last-delivered id is always ≥ 0.
+    open_followup_id = GREATEST(0, LEAST(
         COALESCE(sqlc.narg('open_followup_id')::bigint,
                  (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
                   WHERE run_user_inputs.run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
         (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
-         WHERE run_user_inputs.run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
+         WHERE run_user_inputs.run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL))),
     health = 'ok', health_reason = NULL, health_since = NULL,
     updated_at = now()
 WHERE id = @id AND worker_id = @worker_id

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -5307,29 +5307,50 @@ UPDATE runs SET
     status     = 'awaiting_followup',
     status_since = now(),
     session_id = COALESCE($1, session_id),
-    -- Issue #552 M1: the park-scoped follow_up watermark. Stamp it, at EVERY park, to
-    -- the highest follow_up this run has ALREADY consumed. A later follow_up with a
-    -- higher id — the one the resuming worker will consume to wake THIS park — is what
-    -- SetRunRunning's Decision-7 guard requires to admit awaiting_followup → running,
-    -- so it discriminates "THIS park's follow_up" from "any follow_up ever consumed".
+    -- Issue #552 M1 / #559 M1: the park-scoped follow_up watermark. The value is now
+    -- WORKER-PROVIDED — the highest follow_up id the worker has ALREADY DELIVERED/applied
+    -- to a turn at the moment it parks — and CLAMPED here to the server-derived max
+    -- already-consumed follow_up as a safety ceiling (the LEAST(...) below). When the
+    -- worker OMITS it (an old worker, or the very first park before anything was
+    -- delivered) the COALESCE falls back to that same server-derived max-consumed, so an
+    -- absent param is byte-identical to the pre-#559 pure-server behavior.
     --
-    -- CONSUMED-only (consumed_at IS NOT NULL) is load-bearing: the follow_up that wakes
-    -- a park is UNCONSUMED until it wakes, so a consumed-only MAX never advances past
-    -- it. That makes recomputing the watermark at every re-park correct with NO claim
-    -- re-delivery, NO worker echo and NO clear-on-wake — the watermark simply names the
-    -- last follow_up already spent, and anything newer is a genuine new steer.
-    open_followup_id = (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
-                        WHERE run_id = $2 AND kind = 'follow_up' AND consumed_at IS NOT NULL),
+    -- Why worker-provided: deriving the watermark purely from the server's max-consumed
+    -- races a follow_up consumed DURING this park report's DB round-trip — it would fold a
+    -- not-yet-applied follow_up into the watermark and permanently strand the run (the
+    -- guard then never sees a follow_up NEWER than the watermark). The worker knows exactly
+    -- which follow_ups it has applied, so it reports that; a correct worker's last-delivered
+    -- id is ALWAYS ≤ max-consumed, so the clamp never bites it. The clamp exists only to
+    -- neutralize a buggy huge value that would otherwise strand the run forever.
+    --
+    -- A later follow_up with a higher id — the one the resuming worker will consume to wake
+    -- THIS park — is what SetRunRunning's Decision-7 guard requires to admit
+    -- awaiting_followup → running, so the watermark discriminates "THIS park's follow_up"
+    -- from "any follow_up ever consumed".
+    --
+    -- CONSUMED-only (consumed_at IS NOT NULL) remains load-bearing on the server ceiling:
+    -- the follow_up that wakes a park is UNCONSUMED until it wakes, so a consumed-only MAX
+    -- never advances past it. The watermark stays monotone across re-parks with NO claim
+    -- re-delivery and NO clear-on-wake — it simply names the last follow_up already spent
+    -- (or the worker's last-delivered id, whichever is lower), and anything newer is a
+    -- genuine new steer.
+    open_followup_id = LEAST(
+        COALESCE($2::bigint,
+                 (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
+                  WHERE run_user_inputs.run_id = $3 AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
+        (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
+         WHERE run_user_inputs.run_id = $3 AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
     health = 'ok', health_reason = NULL, health_since = NULL,
     updated_at = now()
-WHERE id = $2 AND worker_id = $3
+WHERE id = $3 AND worker_id = $4
   AND status NOT IN ('completed', 'failed', 'cancelled')
 `
 
 type SetRunAwaitingFollowupParams struct {
-	SessionID pgtype.Text `json:"session_id"`
-	ID        uuid.UUID   `json:"id"`
-	WorkerID  pgtype.UUID `json:"worker_id"`
+	SessionID      pgtype.Text `json:"session_id"`
+	OpenFollowupID pgtype.Int8 `json:"open_followup_id"`
+	ID             uuid.UUID   `json:"id"`
+	WorkerID       pgtype.UUID `json:"worker_id"`
 }
 
 // PRD #517 M2/M3: the interactive-task park. On signal_done an interactive task run
@@ -5352,7 +5373,12 @@ type SetRunAwaitingFollowupParams struct {
 // status write like its siblings. status NOT IN (terminal) makes a report onto an
 // already-terminal run (a cancel raced in) a no-op → 0 rows → "already terminal".
 func (q *Queries) SetRunAwaitingFollowup(ctx context.Context, arg SetRunAwaitingFollowupParams) (int64, error) {
-	result, err := q.db.Exec(ctx, setRunAwaitingFollowup, arg.SessionID, arg.ID, arg.WorkerID)
+	result, err := q.db.Exec(ctx, setRunAwaitingFollowup,
+		arg.SessionID,
+		arg.OpenFollowupID,
+		arg.ID,
+		arg.WorkerID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -6135,11 +6161,15 @@ WHERE runs.id = $16 AND worker_id = $17
   -- consumed follow_up genuinely IS new.
   --
   -- No clear-on-wake is needed, and a future reader must NOT "add the missing sibling
-  -- clear" the way open_question_id needs one. The watermark keys on CONSUMED-only rows
-  -- and is RECOMPUTED at each park (SetRunAwaitingFollowup) to the max already-consumed
-  -- follow_up: the follow_up that wakes a park is unconsumed until it wakes, so it never
-  -- counts toward the watermark that guards its own park, and the next park's recompute
-  -- rolls the watermark forward to include it. There is nothing to reset between parks.
+  -- clear" the way open_question_id needs one. As of issue #559 the watermark is
+  -- WORKER-PROVIDED at each park (SetRunAwaitingFollowup) — the max follow_up id the
+  -- worker has already DELIVERED — CLAMPED there to the server's max already-consumed
+  -- follow_up, with a server-derived fallback to that same max-consumed when the worker
+  -- omits it (old worker / first park). Either way it keys on CONSUMED-only rows for its
+  -- ceiling: the follow_up that wakes a park is unconsumed until it wakes, so it never
+  -- counts toward the watermark that guards its own park, and the next park rolls the
+  -- watermark forward to include it. There is nothing to reset between parks. The guard
+  -- predicate below (` + "`" + `id > COALESCE(open_followup_id, 0)` + "`" + `) is UNCHANGED by #559.
   AND (status <> 'awaiting_followup' OR EXISTS (
         SELECT 1 FROM run_user_inputs
         WHERE run_user_inputs.run_id = $16

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -5334,12 +5334,20 @@ UPDATE runs SET
     -- re-delivery and NO clear-on-wake — it simply names the last follow_up already spent
     -- (or the worker's last-delivered id, whichever is lower), and anything newer is a
     -- genuine new steer.
-    open_followup_id = LEAST(
+    -- The GREATEST(0, ...) floor is the LOWER bound the LEAST ceiling does not give:
+    -- LEAST only bounds a huge value from above, so a nonsensical NEGATIVE worker value
+    -- (e.g. -1) would otherwise pass through and fail-open THIS run's own wake guard
+    -- (` + "`" + `id > COALESCE(open_followup_id, 0)` + "`" + ` is ` + "`" + `id > -1` + "`" + `, true for every positive
+    -- bigserial id, so any consumed follow_up wakes it — reopening #558 for that run).
+    -- Flooring to 0 maps it to "nothing applied" (the first-park value), matching the
+    -- stated "neutralize a buggy value" intent. GREATEST(0, ...) never affects a correct
+    -- worker: its last-delivered id is always ≥ 0.
+    open_followup_id = GREATEST(0, LEAST(
         COALESCE($2::bigint,
                  (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
                   WHERE run_user_inputs.run_id = $3 AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
         (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
-         WHERE run_user_inputs.run_id = $3 AND kind = 'follow_up' AND consumed_at IS NOT NULL)),
+         WHERE run_user_inputs.run_id = $3 AND kind = 'follow_up' AND consumed_at IS NOT NULL))),
     health = 'ok', health_reason = NULL, health_since = NULL,
     updated_at = now()
 WHERE id = $3 AND worker_id = $4

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -4148,6 +4148,18 @@ func (s *Service) ListMemoryForRun(ctx context.Context, wkr store.Worker, runID 
 	})
 }
 
+// RunOwnership returns the current status of a run this worker owns, or
+// ErrRunNotOwned when it is not (reclaimed / never owned). Read-only; the
+// interactive park-skip path (#559) uses it to detect a mid-turn reclaim or
+// terminal transition early, restoring the ACK the skipped park report gave.
+func (s *Service) RunOwnership(ctx context.Context, wkr store.Worker, runID uuid.UUID) (string, error) {
+	run, err := s.runOwnedByWorker(ctx, runID, wkr)
+	if err != nil {
+		return "", err
+	}
+	return run.Status, nil
+}
+
 func (s *Service) runOwnedByWorker(ctx context.Context, runID uuid.UUID, wkr store.Worker) (store.Run, error) {
 	run, err := s.q.GetRunOwnedByWorker(ctx, store.GetRunOwnedByWorkerParams{ID: runID, WorkerID: pgUUID(wkr.ID)})
 	if err != nil {

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -3352,6 +3352,19 @@ type StateRequest struct {
 	// answer guard, which asks "was THIS question answered" rather than "has this run
 	// ever been answered". Required for `awaiting_input`; ignored on every other state.
 	OpenQuestionID *string `json:"open_question_id"`
+	// OpenFollowupID is the park-scoped follow_up watermark reported by the worker on
+	// the `awaiting_followup` transition ONLY (issue #559 M1): the highest follow_up id
+	// the worker has already APPLIED to a turn at the moment it parks. The server CLAMPS
+	// it to the run's max already-consumed follow_up (SetRunAwaitingFollowup's LEAST) —
+	// a correct worker's last-delivered id is always ≤ max-consumed, so the clamp only
+	// neutralizes a buggy huge value; and absent (an old worker, or the first park before
+	// anything was delivered) → the server falls back to that server-derived max-consumed,
+	// byte-identical to the pre-#559 behavior. Deriving the watermark purely server-side
+	// races a follow_up consumed during this report's DB round-trip and would strand the
+	// run, which is why the worker provides it. Additive and OPTIONAL, but the field MUST
+	// exist because httpx.DecodeJSON sets DisallowUnknownFields — a new worker that sends
+	// it would 400 otherwise. Ignored on every state other than awaiting_followup.
+	OpenFollowupID *int64 `json:"open_followup_id"`
 	// LimitResetsAt is the epoch at which the exhausted Anthropic usage window
 	// reopens, as the worker read it off the SDK frame (PRD #35). The worker
 	// normalizes the SDK's unit-less number to MILLISECONDS before sending; the
@@ -3538,7 +3551,12 @@ func (s *Service) SetState(ctx context.Context, wkr store.Worker, runID uuid.UUI
 			return store.Run{}, false, fmt.Errorf("%w: awaiting_followup requires an interactive task run", ErrInvalidState)
 		}
 		rows, err = s.q.SetRunAwaitingFollowup(ctx, store.SetRunAwaitingFollowupParams{
-			SessionID: sessionID, ID: runID, WorkerID: pgUUID(wkr.ID),
+			// int8Param maps nil → pgtype.Int8{} (Valid:false → SQL NULL), so an old
+			// worker that omits open_followup_id lands NULL and the query's COALESCE
+			// fallback recomputes the server-derived max-consumed watermark. A present
+			// value is clamped to ≤ max-consumed by the query's LEAST.
+			OpenFollowupID: int8Param(req.OpenFollowupID),
+			SessionID:      sessionID, ID: runID, WorkerID: pgUUID(wkr.ID),
 		})
 	case "completed":
 		// PRD #265 M1: reconcile the milestone tracker from the lead's signal_done

--- a/api/internal/workersvc/service_test.go
+++ b/api/internal/workersvc/service_test.go
@@ -2319,6 +2319,51 @@ func TestSetStateAwaitingFollowupAcceptsInteractiveTask(t *testing.T) {
 	}
 }
 
+// Issue #559 M1: the worker-provided follow_up watermark threads from the StateRequest
+// into SetRunAwaitingFollowupParams.OpenFollowupID. A present *int64 lands Valid with the
+// exact value; an omitted (nil) field lands NULL (Valid:false) so the query's COALESCE
+// fallback recomputes the server-derived watermark (old-worker parity). The store-level
+// clamp is proven by the LiveDB tests; here we prove the SERVICE hands the value across.
+func TestSetStateAwaitingFollowupThreadsOpenFollowupID(t *testing.T) {
+	w := worker()
+	owned := store.Run{WorkerID: pgUUID(w.ID), Status: "running", Kind: RunKindTask, Interactive: true}
+
+	t.Run("present value threads as Valid", func(t *testing.T) {
+		owned.ID = uuid.New()
+		fs := &fakeStore{runOwned: owned, setFollowupRows: 1}
+		svc := New(fs, newBox(t), testParams())
+		want := int64(4242)
+		if _, _, err := svc.SetState(context.Background(), w, owned.ID, StateRequest{
+			State: "awaiting_followup", OpenFollowupID: &want,
+		}); err != nil {
+			t.Fatalf("SetState: %v", err)
+		}
+		if fs.setFollowup == nil {
+			t.Fatal("SetRunAwaitingFollowup was never called")
+		}
+		if !fs.setFollowup.OpenFollowupID.Valid || fs.setFollowup.OpenFollowupID.Int64 != want {
+			t.Fatalf("OpenFollowupID = %+v, want Valid with Int64=%d — the worker-provided watermark did not thread through",
+				fs.setFollowup.OpenFollowupID, want)
+		}
+	})
+
+	t.Run("omitted value lands NULL for the COALESCE fallback", func(t *testing.T) {
+		owned.ID = uuid.New()
+		fs := &fakeStore{runOwned: owned, setFollowupRows: 1}
+		svc := New(fs, newBox(t), testParams())
+		if _, _, err := svc.SetState(context.Background(), w, owned.ID, StateRequest{State: "awaiting_followup"}); err != nil {
+			t.Fatalf("SetState: %v", err)
+		}
+		if fs.setFollowup == nil {
+			t.Fatal("SetRunAwaitingFollowup was never called")
+		}
+		if fs.setFollowup.OpenFollowupID.Valid {
+			t.Fatalf("OpenFollowupID = %+v, want NULL (Valid:false) for an old worker so the server-derived fallback fires",
+				fs.setFollowup.OpenFollowupID)
+		}
+	})
+}
+
 // Each fixture flips exactly ONE of the two guard conditions, so a test that dropped
 // either half of `kind == RunKindTask && interactive` would let one of these through;
 // a run holding both would satisfy the guard and could not observe the guard at all.

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -22017,8 +22017,10 @@ rationale in the Decision Log of `prds/done/517-interactive-task-runs.md`. <!-- 
   admitted only when a CONSUMED `follow_up` input exists, as a third independent clause beside
   the `answer` gate — so a stale/duplicate pre-park `running` report cannot un-park an idle task
   and re-arm the wall clock. It is now keyed on a per-park identity (issue #552): `runs.open_followup_id`,
-  a watermark of the highest already-CONSUMED `follow_up` id, recomputed at each park by
-  `SetRunAwaitingFollowup`, so the wake requires a consumed `follow_up` NEWER than the watermark —
+  a watermark of the highest already-CONSUMED `follow_up` id, stamped at each park by
+  `SetRunAwaitingFollowup` (originally recomputed purely server-side; **as of issue #559 the value is
+  worker-provided then server-clamped/floored — see §585**), so the wake requires a consumed
+  `follow_up` NEWER than the watermark —
   a stale pre-park `running` report on a run that has already iterated (cycle ≥2) can no longer un-park
   an idle run. The worker completes the identity: the `awaiting_followup` report (which stamps the
   watermark) is emitted ONLY when the run is genuinely going idle — `RunRunner.awaitFollowUp` first
@@ -23044,3 +23046,48 @@ of the "looks queued, never runs" gap the `issue-triage` skill exists to hunt.
   section **supersedes** the design recorded in §119 (PRDLESS settings) and §308 (`PRD`+`PRDLESS`
   server-side assembly), and the run-eligibility narrative in §445; those remain as history of the
   now-removed model.
+
+## 585. issue #559 — close two #558-review residuals of the interactive wake-guard watermark: worker-PROVIDED (not server-derived) `open_followup_id`, and an ownership ACK on the park-SKIP path
+
+Context: two residuals surfaced by the #558 merge-gate review of the interactive-run mid-turn
+wake-guard watermark (issue #552 M1 / PRD #517). The watermark is `runs.open_followup_id`, which
+`SetRunRunning`'s Decision-7 guard compares (`id > COALESCE(open_followup_id, 0)`,
+`api/internal/store/queries/runtime.sql`) to admit `awaiting_followup → running`.
+
+- **Residual 1 — the watermark is now WORKER-PROVIDED, reversing #552 M1's server-derived design.**
+  `SetRunAwaitingFollowup` previously stamped `open_followup_id` from a server-derived
+  `MAX(consumed follow_up id)` subquery. That races a follow-up consumed by the poll loop DURING
+  the park report's DB round-trip: it folds a not-yet-applied follow-up into the watermark, so that
+  follow-up's own wake report fails `id > watermark` and strands the run at `awaiting_followup`
+  until the ~30m idle sweeper. Fix: the worker reports the highest follow_up id it has already
+  DELIVERED as `open_followup_id` on the `awaiting_followup` `StateRequest`
+  (`agent/src/protocol.ts`, `api/internal/workersvc/service.go` `StateRequest.OpenFollowupID
+  *int64`), and the server stamps `GREATEST(0, LEAST(COALESCE(@open_followup_id, <server
+  max-consumed>), <server max-consumed>))`. Worker-owned because only the worker knows what it
+  applied: buffering a follow-up during the round-trip does NOT advance the worker's last-delivered
+  id — `agent/src/steering.ts` `takeFollowUp` is the SINGLE shift+advance site (route→push only
+  buffers), and the follow-up waiter is armed only AFTER the report returns
+  (`agent/src/runner.ts`) — so the racing follow-up is excluded and its later wake succeeds.
+  The `LEAST(..., max-consumed)` ceiling and `GREATEST(0, ...)` floor bound a buggy worker value
+  (a huge value would strand forever; a negative value would fail-open `id > -1` and reopen #558)
+  to the range a correct worker could send — self-harm only, no cross-run reach. Absent field (old
+  worker / first park before anything delivered) → `int8Param(nil)` → NULL → COALESCE falls back to
+  the pre-#559 server-derived value, byte-identical and backward compatible (additive-optional, but
+  the JSON field MUST exist because `httpx.DecodeJSON` sets `DisallowUnknownFields`). This
+  **reverses** the SOURCE half of §566's #552 M1 decision (the `awaiting_followup`/wake-guard design
+  under PRD #517): its server-derived, no-worker-echo watermark is retired for the
+  worker-provided-then-clamped value. Only the source changes — the watermark is still stamped at
+  every park, there is still no clear-on-wake, and the guard predicate itself is UNCHANGED.
+- **Residual 2 — restore the ownership/terminality ACK on the park-SKIP path.** When a follow-up is
+  already buffered, the worker deliberately SKIPS the `awaiting_followup` park report (the #558 fix,
+  so it doesn't fold the not-yet-applied follow-up into the watermark) and services the buffered
+  outcome directly — but that skipped report's ACK doubled as the ownership check that throws
+  `REASON_FOLLOWUP_NOT_PARKED` when the run went terminal or was reclaimed by another worker.
+  Restored via a new read-only worker endpoint `GET /api/worker/runs/{id}/ownership`
+  (`WorkerRunOwnership` → `workersvc.RunOwnership`, reusing `GetRunOwnedByWorker` — no new SQL) that
+  the runner probes on the skip path. Only a DEFINITIVE answer throws early: a terminal status
+  (`completed`/`failed`/`cancelled`, `FOLLOWUP_TERMINAL_STATUSES`) or a definitive 404 (reclaimed).
+  A TRANSIENT error (network / 5xx) logs a warning and PROCEEDS — no new spurious-failure mode; the
+  `SetRunRunning` worker_id pin and the next ACK-checked park report remain the backstop.
+- Commits `aace2d0b`/`fc072247` (M1, server clamp+floor), `d8625495` (M2, worker threads the
+  last-delivered id through `SteeringChannel`), `ab774e05` (M3, park-skip ownership probe).

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -22017,7 +22017,7 @@ rationale in the Decision Log of `prds/done/517-interactive-task-runs.md`. <!-- 
   admitted only when a CONSUMED `follow_up` input exists, as a third independent clause beside
   the `answer` gate — so a stale/duplicate pre-park `running` report cannot un-park an idle task
   and re-arm the wall clock. It is now keyed on a per-park identity (issue #552): `runs.open_followup_id`,
-  a watermark of the highest already-CONSUMED `follow_up` id, stamped at each park by
+  a watermark of the highest already-DELIVERED `follow_up` id (worker-provided, then server-clamped to max-consumed), stamped at each park by
   `SetRunAwaitingFollowup` (originally recomputed purely server-side; **as of issue #559 the value is
   worker-provided then server-clamped/floored — see §585**), so the wake requires a consumed
   `follow_up` NEWER than the watermark —
@@ -23072,8 +23072,10 @@ wake-guard watermark (issue #552 M1 / PRD #517). The watermark is `runs.open_fol
   (a huge value would strand forever; a negative value would fail-open `id > -1` and reopen #558)
   to the range a correct worker could send — self-harm only, no cross-run reach. Absent field (old
   worker / first park before anything delivered) → `int8Param(nil)` → NULL → COALESCE falls back to
-  the pre-#559 server-derived value, byte-identical and backward compatible (additive-optional, but
-  the JSON field MUST exist because `httpx.DecodeJSON` sets `DisallowUnknownFields`). This
+  the pre-#559 server-derived value, byte-identical and backward compatible. The value is
+  additive-optional: the request SCHEMA must DECLARE `open_followup_id` so `httpx.DecodeJSON`
+  (which sets `DisallowUnknownFields`) accepts it when a new worker sends it, but an old worker may
+  OMIT the wire field — an absent field decodes to NULL and preserves the server-derived fallback. This
   **reverses** the SOURCE half of §566's #552 M1 decision (the `awaiting_followup`/wake-guard design
   under PRD #517): its server-derived, no-worker-echo watermark is retired for the
   worker-provided-then-clamped value. Only the source changes — the watermark is still stamped at


### PR DESCRIPTION
Implements issue #559.

Closes #559

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-559`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added run ownership and status checks for interactive runs.
  * Improved follow-up tracking when runs pause or resume.

* **Bug Fixes**
  * Prevented valid follow-ups from becoming stranded.
  * Added safeguards for reclaimed, completed, or cancelled runs.
  * Added graceful handling for temporary ownership-check failures.

* **Tests**
  * Expanded coverage for follow-up delivery, ownership states, watermarks, and interactive run recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->