### PR TITLE
# Task: two small cleanups from issue #509 (items 3 and 4 only)

### DIFF
--- a/api/internal/handler/forge.go
+++ b/api/internal/handler/forge.go
@@ -583,43 +583,7 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 	// The badge STATE (PRD #66 M9) comes from this connection's stored report, run
 	// through the single shared downgrade — parsed once for the whole page.
 	report := parsePrivilegeReport(conn.PrivilegeReport, conn.ID)
-	// PRD #361: read the Docker-worker allowlist once per request. M1's per-repo
-	// docker_allowlisted flag membership-tests it; M3's docker_blocked reuses it to ask
-	// the DB which of the caller's repos a Docker-allowlist gap is actively blocking. The
-	// list itself is never sent — both fields are booleans about the caller's own repos.
-	var allowlist []uuid.UUID
-	allowlistOK := false
-	if al, err := h.settings.DockerRepoAllowlist(r.Context()); err != nil {
-		// Non-fatal: the chip is enrichment. Degrade to "not allowlisted" (false).
-		slog.Warn("list projects: docker allowlist", "error", err)
-	} else {
-		allowlist = al
-		allowlistOK = true
-	}
-	allowSet := map[uuid.UUID]bool{}
-	for _, id := range allowlist {
-		allowSet[id] = true
-	}
-	// docker_blocked reuses the same allowlist to ask the DB which repos a gap is actively
-	// blocking. Only run it when the allowlist read SUCCEEDED: with an untrustworthy
-	// (empty) allowlist the eligibility test fails closed and would over-escalate an
-	// actually-allowlisted repo to blocked — the opposite of docker_allowlisted's
-	// degrade-to-false. On a read failure, degrade to neutral (empty blockedSet, no
-	// escalation) instead, matching M1's direction.
-	blockedSet := map[uuid.UUID]bool{}
-	if allowlistOK {
-		if ids, err := h.q.ListDockerBlockedReposForUser(r.Context(), store.ListDockerBlockedReposForUserParams{
-			UserID:              user.ID,
-			DockerRepoAllowlist: allowlist,
-		}); err != nil {
-			// Non-fatal: the chip degrades to neutral (no escalation) on error.
-			slog.Warn("list projects: docker-blocked repos", "error", err)
-		} else {
-			for _, id := range ids {
-				blockedSet[id] = true
-			}
-		}
-	}
+	allowSet, blockedSet := h.dockerFlagsForRepos(r.Context(), user.ID, "list projects")
 	// PRD #576 M2: batch-load each repo's GitHub Projects v2 sync-health once per
 	// request and map it caller-scoped, alongside the docker/guardrail enrichments.
 	// A store error degrades gracefully (empty map → field stays nil), never failing
@@ -637,6 +601,51 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 		out = append(out, d)
 	}
 	httpx.JSON(w, http.StatusOK, map[string]any{"repos": out})
+}
+
+// dockerFlagsForRepos computes the per-repo Docker-worker allow/block sets for a
+// caller, shared by ListProjects and ListRepos. logPrefix threads the calling
+// handler's name so the two slog messages read the same as before the extraction.
+//
+// PRD #361: read the Docker-worker allowlist once per request. M1's per-repo
+// docker_allowlisted flag membership-tests it; M3's docker_blocked reuses it to ask
+// the DB which of the caller's repos a Docker-allowlist gap is actively blocking. The
+// list itself is never sent — both fields are booleans about the caller's own repos.
+func (h *Handler) dockerFlagsForRepos(ctx context.Context, userID uuid.UUID, logPrefix string) (allowSet, blockedSet map[uuid.UUID]bool) {
+	var allowlist []uuid.UUID
+	allowlistOK := false
+	if al, err := h.settings.DockerRepoAllowlist(ctx); err != nil {
+		// Non-fatal: the chip is enrichment. Degrade to "not allowlisted" (false).
+		slog.Warn(logPrefix+": docker allowlist", "error", err)
+	} else {
+		allowlist = al
+		allowlistOK = true
+	}
+	allowSet = map[uuid.UUID]bool{}
+	for _, id := range allowlist {
+		allowSet[id] = true
+	}
+	// docker_blocked reuses the same allowlist to ask the DB which repos a gap is actively
+	// blocking. Only run it when the allowlist read SUCCEEDED: with an untrustworthy
+	// (empty) allowlist the eligibility test fails closed and would over-escalate an
+	// actually-allowlisted repo to blocked — the opposite of docker_allowlisted's
+	// degrade-to-false. On a read failure, degrade to neutral (empty blockedSet, no
+	// escalation) instead, matching M1's direction.
+	blockedSet = map[uuid.UUID]bool{}
+	if allowlistOK {
+		if ids, err := h.q.ListDockerBlockedReposForUser(ctx, store.ListDockerBlockedReposForUserParams{
+			UserID:              userID,
+			DockerRepoAllowlist: allowlist,
+		}); err != nil {
+			// Non-fatal: the chip degrades to neutral (no escalation) on error.
+			slog.Warn(logPrefix+": docker-blocked repos", "error", err)
+		} else {
+			for _, id := range ids {
+				blockedSet[id] = true
+			}
+		}
+	}
+	return allowSet, blockedSet
 }
 
 // syncLinksForRepos batch-loads the GitHub Projects v2 link rows for a set of repo
@@ -696,43 +705,7 @@ func (h *Handler) ListRepos(w http.ResponseWriter, r *http.Request) {
 			reports[c.ID] = parsePrivilegeReport(c.PrivilegeReport, c.ID)
 		}
 	}
-	// PRD #361: read the Docker-worker allowlist once per request. M1's per-repo
-	// docker_allowlisted flag membership-tests it; M3's docker_blocked reuses it to ask
-	// the DB which of the caller's repos a Docker-allowlist gap is actively blocking. The
-	// list itself is never sent — both fields are booleans about the caller's own repos.
-	var allowlist []uuid.UUID
-	allowlistOK := false
-	if al, err := h.settings.DockerRepoAllowlist(r.Context()); err != nil {
-		// Non-fatal: the chip is enrichment. Degrade to "not allowlisted" (false).
-		slog.Warn("list repos: docker allowlist", "error", err)
-	} else {
-		allowlist = al
-		allowlistOK = true
-	}
-	allowSet := map[uuid.UUID]bool{}
-	for _, id := range allowlist {
-		allowSet[id] = true
-	}
-	// docker_blocked reuses the same allowlist to ask the DB which repos a gap is actively
-	// blocking. Only run it when the allowlist read SUCCEEDED: with an untrustworthy
-	// (empty) allowlist the eligibility test fails closed and would over-escalate an
-	// actually-allowlisted repo to blocked — the opposite of docker_allowlisted's
-	// degrade-to-false. On a read failure, degrade to neutral (empty blockedSet, no
-	// escalation) instead, matching M1's direction.
-	blockedSet := map[uuid.UUID]bool{}
-	if allowlistOK {
-		if ids, err := h.q.ListDockerBlockedReposForUser(r.Context(), store.ListDockerBlockedReposForUserParams{
-			UserID:              user.ID,
-			DockerRepoAllowlist: allowlist,
-		}); err != nil {
-			// Non-fatal: the chip degrades to neutral (no escalation) on error.
-			slog.Warn("list repos: docker-blocked repos", "error", err)
-		} else {
-			for _, id := range ids {
-				blockedSet[id] = true
-			}
-		}
-	}
+	allowSet, blockedSet := h.dockerFlagsForRepos(r.Context(), user.ID, "list repos")
 	// PRD #576 M2: batch-load each repo's GitHub Projects v2 sync-health once, keyed by
 	// repo id, degrading gracefully on a store error (see syncLinksForRepos).
 	syncLinks := syncLinksForRepos(r.Context(), h.q, repoIDs, "list repos")

--- a/api/internal/uzidocs/embed/run-health.md
+++ b/api/internal/uzidocs/embed/run-health.md
@@ -22,12 +22,12 @@ from when the flag was raised, not from when the run started.
 | ⚠ needs approval | Sitting at `awaiting_approval` longer than expected (never shown for autopilot runs, which approve themselves). | Approve, reject, or request changes to the plan — see [Plan approval gate](./run-activity.md#plan-approval-gate). |
 
 One **waiting for worker** reason worth calling out is the Docker-worker
-allowlist. When a run's repo needs a Docker-capable worker and none currently
-eligible has that repo on the Docker worker allowlist, the run stays `queued`
-and the owner's reason names it specifically — "repo not Docker-allowlisted"
-(the repo isn't on the Docker worker allowlist) — distinct from "no worker
-online" or "all workers busy". The fix is to add the repo to the allowlist, not
-to start another worker.
+allowlist. When every online worker is a Docker worker and the run's repo
+isn't on the Docker-worker allowlist, no worker is eligible to claim it, so
+the run stays `queued` and the owner's reason names it specifically — _"this
+repo isn't on the Docker worker allowlist, so no Docker worker can run it"_ —
+distinct from "no worker online" or "all workers busy". The fix is to add the
+repo to the allowlist, not to start another worker.
 
 Only the run's owner (and admins) see the reason text behind a flag; everyone
 else viewing a shared board sees just the ⚠ badge.

--- a/api/internal/uzidocs/embed/run-health.md
+++ b/api/internal/uzidocs/embed/run-health.md
@@ -21,6 +21,14 @@ from when the flag was raised, not from when the run started.
 | ⚠ waiting for worker | Queued longer than expected with no worker claiming it. | The reason names why, if you own the run: no worker online, your vault is locked, or just a wait — start a worker or unlock your vault as needed. A judge or self-improve run instead reads **deprioritized** (yielding to interactive work on purpose, not stuck) or, once it's waited past the grace window, **priority restored** — see [Queue priority](#queue-priority). |
 | ⚠ needs approval | Sitting at `awaiting_approval` longer than expected (never shown for autopilot runs, which approve themselves). | Approve, reject, or request changes to the plan — see [Plan approval gate](./run-activity.md#plan-approval-gate). |
 
+One **waiting for worker** reason worth calling out is the Docker-worker
+allowlist. When a run's repo needs a Docker-capable worker and none currently
+eligible has that repo on the Docker worker allowlist, the run stays `queued`
+and the owner's reason names it specifically — "repo not Docker-allowlisted"
+(the repo isn't on the Docker worker allowlist) — distinct from "no worker
+online" or "all workers busy". The fix is to add the repo to the allowlist, not
+to start another worker.
+
 Only the run's owner (and admins) see the reason text behind a flag; everyone
 else viewing a shared board sees just the ⚠ badge.
 

--- a/docs/run-health.md
+++ b/docs/run-health.md
@@ -22,12 +22,12 @@ from when the flag was raised, not from when the run started.
 | ⚠ needs approval | Sitting at `awaiting_approval` longer than expected (never shown for autopilot runs, which approve themselves). | Approve, reject, or request changes to the plan — see [Plan approval gate](./run-activity.md#plan-approval-gate). |
 
 One **waiting for worker** reason worth calling out is the Docker-worker
-allowlist. When a run's repo needs a Docker-capable worker and none currently
-eligible has that repo on the Docker worker allowlist, the run stays `queued`
-and the owner's reason names it specifically — "repo not Docker-allowlisted"
-(the repo isn't on the Docker worker allowlist) — distinct from "no worker
-online" or "all workers busy". The fix is to add the repo to the allowlist, not
-to start another worker.
+allowlist. When every online worker is a Docker worker and the run's repo
+isn't on the Docker-worker allowlist, no worker is eligible to claim it, so
+the run stays `queued` and the owner's reason names it specifically — _"this
+repo isn't on the Docker worker allowlist, so no Docker worker can run it"_ —
+distinct from "no worker online" or "all workers busy". The fix is to add the
+repo to the allowlist, not to start another worker.
 
 Only the run's owner (and admins) see the reason text behind a flag; everyone
 else viewing a shared board sees just the ⚠ badge.

--- a/docs/run-health.md
+++ b/docs/run-health.md
@@ -21,6 +21,14 @@ from when the flag was raised, not from when the run started.
 | ⚠ waiting for worker | Queued longer than expected with no worker claiming it. | The reason names why, if you own the run: no worker online, your vault is locked, or just a wait — start a worker or unlock your vault as needed. A judge or self-improve run instead reads **deprioritized** (yielding to interactive work on purpose, not stuck) or, once it's waited past the grace window, **priority restored** — see [Queue priority](#queue-priority). |
 | ⚠ needs approval | Sitting at `awaiting_approval` longer than expected (never shown for autopilot runs, which approve themselves). | Approve, reject, or request changes to the plan — see [Plan approval gate](./run-activity.md#plan-approval-gate). |
 
+One **waiting for worker** reason worth calling out is the Docker-worker
+allowlist. When a run's repo needs a Docker-capable worker and none currently
+eligible has that repo on the Docker worker allowlist, the run stays `queued`
+and the owner's reason names it specifically — "repo not Docker-allowlisted"
+(the repo isn't on the Docker worker allowlist) — distinct from "no worker
+online" or "all workers busy". The fix is to add the repo to the allowlist, not
+to start another worker.
+
 Only the run's owner (and admins) see the reason text behind a flag; everyone
 else viewing a shared board sees just the ⚠ badge.
 


### PR DESCRIPTION
Handoff task (PRD #400). This run worked inline context on the server-named
`uzi/task/a445ceb0-5c32-490e-bfea-153f932c1cf5` branch (branched from `origin/main`) and opened this merge request because it was created with `--mr`.
There is no tracking issue, so this MR closes nothing.

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `uzi/task/a445ceb0-5c32-490e-bfea-153f932c1cf5`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project and repository listings now show GitHub Projects synchronization health.
  * Docker worker allowlist status is surfaced consistently across projects and repositories.

* **Documentation**
  * Added guidance explaining when runs wait for an approved Docker worker.
  * Documented the queued-run behavior, user-facing message, distinction from other worker shortages, and remediation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->