### PR TITLE
fix(uzi-watcher): don't count addressed CodeRabbit findings as live; accept final_review_risk marker

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -498,6 +498,30 @@ on green CI; >0 → triage); (a)/(b) are corroborating detail only when actionab
 existed. A poller must key on (c), never on the `CodeRabbit` PR check nor on the presence of a
 new review object.
 
+**Two updates to signal (c) and the live-findings count, both measured 2026-08-29 driving a
+6-PR batch, both now fixed in `scripts/watch-pr.sh`:**
+
+- **CodeRabbit is migrating the walkthrough marker away from the `recent_review` range to a
+  `final_review_risk` block, so key on BOTH.** The new block reads `**Merge Risk:** _🟡
+  Moderate_ · up to` then the head short-sha in backticks (e.g. `up to 280ac`), sits between
+  `<!-- final_review_risk_start -->` / `<!-- final_review_risk_end -->`, and states a
+  merge-readiness verdict in prose ("no actionable merge-blocking risk remaining; it is
+  merge-ready" on a clean pass). On several PRs here the older `recent_review` "between BASE and
+  HEAD" range was **absent** while `final_review_risk` was present. `watch-pr.sh` now confirms
+  "reviewed this head" from EITHER the range's trailing SHA OR that `up to` short-sha marker; a poller you hand-roll must
+  do the same, or a clean re-review reads as never-landed and you time out on a merge-ready PR.
+- **An ADDRESSED finding keeps `line != null`; it is NOT outdated — do not count it as live.**
+  The `line: null`/`original_line` "outdated" signal in (b) above is only ONE of the two ways a
+  finding stops being live. When CodeRabbit judges a finding FIXED by a later commit it leaves
+  the inline comment anchored to live code (`line != null`) and instead appends a
+  `✅ Addressed in commit <sha>` line to the comment **body**. A live-findings count that filters
+  only on `line != null` therefore counts a resolved finding as open: measured on PR #807, where
+  two addressed findings produced a false "2 live findings" (`watch-pr.sh` exit 3) after a clean
+  rework, stalling a merge-ready PR. Exclude any comment whose body `contains("Addressed in
+  commit")` — the fix now in `watch-pr.sh`'s `live` count. This is also why, when you read
+  findings by hand (e.g. via `pr-findings.sh`), a finding tagged `Addressed in commit` is done;
+  verify against the body marker, not the line anchor.
+
 **The shared `main` worktree is a multi-writer tree — never assert it is clean.** Other
 sessions leave modified files in it and advance `main` mid-review (measured 2026-08-20:
 two reviewers found unrelated `tui_*` edits and `main` moving `6fc6c5eb`→`2007cbf4` under

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -501,19 +501,22 @@ new review object.
 **Two updates to signal (c) and the live-findings count, both measured 2026-08-29 driving a
 6-PR batch, both now fixed in `scripts/watch-pr.sh`:**
 
-- **CodeRabbit is migrating the walkthrough marker away from the `recent_review` range to a
-  `final_review_risk` block, so key on BOTH.** The new block reads `**Merge Risk:** _🟡
-  Moderate_ · up to` then the head short-sha in backticks (e.g. `up to 280ac`), sits between
-  `<!-- final_review_risk_start -->` / `<!-- final_review_risk_end -->`, and states a
-  merge-readiness verdict in prose ("no actionable merge-blocking risk remaining; it is
-  merge-ready" on a clean pass). On several PRs here the older `recent_review` "between BASE and
-  HEAD" range was **absent** while `final_review_risk` was present. `watch-pr.sh` now confirms
-  "reviewed this head" from EITHER the range's trailing SHA OR that `up to` short-sha marker; a poller you hand-roll must
-  do the same, or a clean re-review reads as never-landed and you time out on a merge-ready PR.
-  Parse each SHA only **inside its own marker block**, and only when **exactly one** walkthrough
-  comment exists (fail closed on 0 or >1) — otherwise an unrelated `up to` / `and <sha>` phrase
-  elsewhere in the body can forge a `reviewed_head=1` and, with zero live findings, a false
-  auto-merge. That is the "exactly one match, fail closed" contract above, now enforced in the script.
+- **The `recent_review` range is GONE; signal (c) now keys on the `final_review_risk` block.**
+  The long treatment above describes the `recent_review` "between BASE and HEAD" range as the
+  signal that "ALWAYS fires" — that format is **retired**: 0 occurrences across PRs #807 / #809 /
+  #812 on 2026-08-29, all of which carry a `final_review_risk` block instead. That block reads
+  `**Merge Risk:** _🟡 Moderate_ · up to` then the head short-sha in backticks (e.g. `up to
+  280ac`), sits between `<!-- final_review_risk_start -->` / `<!-- final_review_risk_end -->`,
+  and states a merge-readiness verdict in prose ("no actionable merge-blocking risk remaining;
+  it is merge-ready" on a clean pass). `watch-pr.sh` confirms "reviewed this head" from that `up
+  to` short-sha marker (**parsed only inside the `final_review_risk` block**, and only when
+  **exactly one** walkthrough comment exists — fail closed on 0 or >1), plus signal (a), a review
+  object whose `commit_id` is the head. It no longer parses `recent_review`: matching a retired
+  format over the whole body could false-match an unrelated "up to `<sha>`" phrase and, with zero
+  live findings, forge a merge — the "exactly one match, fail closed" contract above. A poller you
+  hand-roll must key on `final_review_risk` (block-scoped) + signal (a); if `recent_review` ever
+  returns, signal (a) still covers a real review, so the loss is fail-closed (a timeout, never a
+  false ready).
 - **An ADDRESSED finding keeps `line != null`; it is NOT outdated — do not count it as live.**
   The `line: null`/`original_line` "outdated" signal in (b) above is only ONE of the two ways a
   finding stops being live. When CodeRabbit judges a finding FIXED by a later commit it leaves

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -511,12 +511,13 @@ new review object.
   it is merge-ready" on a clean pass). `watch-pr.sh` confirms "reviewed this head" from that `up
   to` short-sha marker (**parsed only inside the `final_review_risk` block**, and only when
   **exactly one** walkthrough comment exists — fail closed on 0 or >1), plus signal (a), a review
-  object whose `commit_id` is the head. It no longer parses `recent_review`: matching a retired
-  format over the whole body could false-match an unrelated "up to `<sha>`" phrase and, with zero
-  live findings, forge a merge — the "exactly one match, fail closed" contract above. A poller you
-  hand-roll must key on `final_review_risk` (block-scoped) + signal (a); if `recent_review` ever
-  returns, signal (a) still covers a real review, so the loss is fail-closed (a timeout, never a
-  false ready).
+  object whose `commit_id` is the head. It no longer parses `recent_review`, which is a retired
+  format. Parsing the `final_review_risk` SHA over the whole body could false-match an unrelated
+  "up to `<sha>`" phrase and, with zero live findings, forge a merge; the parser therefore scopes
+  that SHA to its marker block and fails closed unless exactly one walkthrough comment exists (the
+  "exactly one match, fail closed" contract above). A poller you hand-roll must key on `final_review_risk` (block-scoped)
+  + signal (a); if `recent_review` ever returns, signal (a) still covers a real review, so the
+  loss is fail-closed (a timeout, never a false ready).
 - **An ADDRESSED finding keeps `line != null`; it is NOT outdated — do not count it as live.**
   The `line: null`/`original_line` "outdated" signal in (b) above is only ONE of the two ways a
   finding stops being live. When CodeRabbit judges a finding FIXED by a later commit it leaves

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -510,6 +510,10 @@ new review object.
   HEAD" range was **absent** while `final_review_risk` was present. `watch-pr.sh` now confirms
   "reviewed this head" from EITHER the range's trailing SHA OR that `up to` short-sha marker; a poller you hand-roll must
   do the same, or a clean re-review reads as never-landed and you time out on a merge-ready PR.
+  Parse each SHA only **inside its own marker block**, and only when **exactly one** walkthrough
+  comment exists (fail closed on 0 or >1) — otherwise an unrelated `up to` / `and <sha>` phrase
+  elsewhere in the body can forge a `reviewed_head=1` and, with zero live findings, a false
+  auto-merge. That is the "exactly one match, fail closed" contract above, now enforced in the script.
 - **An ADDRESSED finding keeps `line != null`; it is NOT outdated — do not count it as live.**
   The `line: null`/`original_line` "outdated" signal in (b) above is only ONE of the two ways a
   finding stops being live. When CodeRabbit judges a finding FIXED by a later commit it leaves

--- a/.claude/skills/uzi-watcher/scripts/watch-pr.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-pr.sh
@@ -107,24 +107,24 @@ while [ "$i" -lt "$MAX" ]; do
     unknown=1
   fi
   # Signal (c): the walkthrough comment, which CodeRabbit edits in place each pass and which
-  # covers the zero-actionable incremental case (that posts no review object). TWO formats are
-  # accepted because CodeRabbit is migrating between them (both observed 2026-08-29): the older
-  # `recent_review` "... between BASE and HEAD" range, and the newer `final_review_risk` block
-  # "**Merge Risk:** ... · up to `<short-sha>`". Either one naming the current head confirms it.
+  # covers the zero-actionable incremental case (that posts no review object). It keys on the
+  # `final_review_risk` block — "**Merge Risk:** ... · up to `<short-sha>`" between
+  # `<!-- final_review_risk_start -->` / `<!-- final_review_risk_end -->`. (The older
+  # `recent_review` "between BASE and HEAD" range is gone: 0 occurrences across PRs #807/#809/
+  # #812 on 2026-08-29 — CodeRabbit migrated to final_review_risk. Parsing it was dead-format
+  # matching over the whole body, which could false-match an unrelated "between … and <sha>"
+  # phrase and forge a ready; removed. If it ever returns, signal (a) still covers a real review.)
   #
   # FAIL CLOSED, because reviewed_head=1 + live=0 is the auto-merge trigger: (1) exactly ONE
   # walkthrough comment is expected (CodeRabbit edits it in place) — 0 or >1 means don't trust
-  # signal (c) at all, leave reviewed_head to signal (a); and (2) each SHA is parsed only inside
-  # its OWN marker block, so an unrelated "up to `<sha>`" or "and <sha>" phrase elsewhere in the
-  # body cannot forge a match. The exact bot login is matched so a crafted comment can't spoof it.
+  # signal (c) at all, leave reviewed_head to signal (a); and (2) the SHA is parsed only INSIDE
+  # the final_review_risk block, so an unrelated "up to `<sha>`" phrase elsewhere in the body
+  # cannot forge a match. The exact bot login is matched so a crafted comment can't spoof it.
   if issue_c=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null); then
     wt_count=$(printf '%s' "$issue_c" | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))]|length' 2>/dev/null || echo 0)
     if [ "${wt_count:-0}" -eq 1 ]; then
       wt_body=$(printf '%s' "$issue_c" | jq -rs '.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' 2>/dev/null || true)
-      # (c1) recent_review range: the "between BASE and HEAD" phrase only; HEAD is the 2nd SHA.
-      wt_head=$(printf '%s' "$wt_body" | grep -oiE 'between [0-9a-f]{7,40} and [0-9a-f]{7,40}' | tail -1 | grep -oE '[0-9a-f]{7,40}' | tail -1 || true)
-      if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
-      # (c2) final_review_risk marker: "up to `<sha>`" parsed ONLY within the final_review_risk block.
+      # final_review_risk marker: "up to `<sha>`" parsed ONLY within its own block.
       fr_block=$(printf '%s' "$wt_body" | awk '/final_review_risk_start/{f=1} f{print} /final_review_risk_end/{f=0}')
       # shellcheck disable=SC2016  # the backticks are LITERAL text in CodeRabbit's marker, not a subshell
       fr_head=$(printf '%s' "$fr_block" | grep -oE 'up to `[0-9a-f]{5,40}`' | tail -1 | grep -oE '[0-9a-f]{5,40}' || true)

--- a/.claude/skills/uzi-watcher/scripts/watch-pr.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-pr.sh
@@ -106,21 +106,35 @@ while [ "$i" -lt "$MAX" ]; do
   else
     unknown=1
   fi
-  # Signal (c): the walkthrough recent_review range ending at this head — covers the
-  # zero-actionable incremental case, which posts no review object.
+  # Signal (c): the walkthrough comment, which CodeRabbit edits in place each pass and which
+  # covers the zero-actionable incremental case (that posts no review object). TWO formats are
+  # accepted because CodeRabbit is migrating between them (both observed 2026-08-29): the older
+  # `recent_review` "... between BASE and HEAD" range, and the newer `final_review_risk` block
+  # "**Merge Risk:** ... · up to `<short-sha>`". Either one naming the current head confirms it
+  # was reviewed. The walkthrough body is fetched once and both markers are checked against it.
   if issue_c=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null); then
-    wt_head=$(printf '%s' "$issue_c" | jq -rs '.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' 2>/dev/null \
-      | grep -oE 'and [0-9a-f]{7,40}' | tail -1 | awk '{print $2}' || true)
+    wt_body=$(printf '%s' "$issue_c" | jq -rs '.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' 2>/dev/null || true)
+    # (c1) recent_review range: "... and <head>"
+    wt_head=$(printf '%s' "$wt_body" | grep -oE 'and [0-9a-f]{7,40}' | tail -1 | awk '{print $2}' || true)
     if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
+    # (c2) final_review_risk marker: "up to `<sha>`" (short or full)
+    # shellcheck disable=SC2016  # the backticks are LITERAL text in CodeRabbit's marker, not a subshell
+    fr_head=$(printf '%s' "$wt_body" | grep -oE 'up to `[0-9a-f]{5,40}`' | tail -1 | grep -oE '[0-9a-f]{5,40}' || true)
+    if [ -n "$fr_head" ] && printf '%s' "$head" | grep -q "^$fr_head"; then reviewed_head=1; fi
   else
     unknown=1
   fi
 
-  # Live inline findings: CodeRabbit comments still anchored to current code (line != null);
-  # an addressed finding re-anchors to line == null (outdated).
+  # Live inline findings: CodeRabbit comments still anchored to current code (line != null)
+  # AND not self-marked resolved. Two ways a finding stops being live, and only the first was
+  # handled before: an outdated finding re-anchors to line == null; but a finding CodeRabbit
+  # judged FIXED by a later commit keeps line != null and instead appends a "✅ Addressed in
+  # commit <sha>" line to its body (measured 2026-08-29 on PR #807, where two such addressed
+  # findings were mis-counted as live=2 and produced a false exit-3 after a clean rework).
+  # Exclude both, so an addressed finding does not read as a live one.
   live=0
   if pull_c=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null); then
-    live=$(printf '%s' "$pull_c" | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]" and .line!=null)]|length' 2>/dev/null || echo 0)
+    live=$(printf '%s' "$pull_c" | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]" and .line!=null and ((.body|contains("Addressed in commit"))|not))]|length' 2>/dev/null || echo 0)
   else
     unknown=1
   fi

--- a/.claude/skills/uzi-watcher/scripts/watch-pr.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-pr.sh
@@ -110,17 +110,26 @@ while [ "$i" -lt "$MAX" ]; do
   # covers the zero-actionable incremental case (that posts no review object). TWO formats are
   # accepted because CodeRabbit is migrating between them (both observed 2026-08-29): the older
   # `recent_review` "... between BASE and HEAD" range, and the newer `final_review_risk` block
-  # "**Merge Risk:** ... · up to `<short-sha>`". Either one naming the current head confirms it
-  # was reviewed. The walkthrough body is fetched once and both markers are checked against it.
+  # "**Merge Risk:** ... · up to `<short-sha>`". Either one naming the current head confirms it.
+  #
+  # FAIL CLOSED, because reviewed_head=1 + live=0 is the auto-merge trigger: (1) exactly ONE
+  # walkthrough comment is expected (CodeRabbit edits it in place) — 0 or >1 means don't trust
+  # signal (c) at all, leave reviewed_head to signal (a); and (2) each SHA is parsed only inside
+  # its OWN marker block, so an unrelated "up to `<sha>`" or "and <sha>" phrase elsewhere in the
+  # body cannot forge a match. The exact bot login is matched so a crafted comment can't spoof it.
   if issue_c=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null); then
-    wt_body=$(printf '%s' "$issue_c" | jq -rs '.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' 2>/dev/null || true)
-    # (c1) recent_review range: "... and <head>"
-    wt_head=$(printf '%s' "$wt_body" | grep -oE 'and [0-9a-f]{7,40}' | tail -1 | awk '{print $2}' || true)
-    if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
-    # (c2) final_review_risk marker: "up to `<sha>`" (short or full)
-    # shellcheck disable=SC2016  # the backticks are LITERAL text in CodeRabbit's marker, not a subshell
-    fr_head=$(printf '%s' "$wt_body" | grep -oE 'up to `[0-9a-f]{5,40}`' | tail -1 | grep -oE '[0-9a-f]{5,40}' || true)
-    if [ -n "$fr_head" ] && printf '%s' "$head" | grep -q "^$fr_head"; then reviewed_head=1; fi
+    wt_count=$(printf '%s' "$issue_c" | jq -rs '[.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))]|length' 2>/dev/null || echo 0)
+    if [ "${wt_count:-0}" -eq 1 ]; then
+      wt_body=$(printf '%s' "$issue_c" | jq -rs '.[][]|select(.user.login=="coderabbitai[bot]")|select(.body|contains("<!-- walkthrough_start -->"))|.body' 2>/dev/null || true)
+      # (c1) recent_review range: the "between BASE and HEAD" phrase only; HEAD is the 2nd SHA.
+      wt_head=$(printf '%s' "$wt_body" | grep -oiE 'between [0-9a-f]{7,40} and [0-9a-f]{7,40}' | tail -1 | grep -oE '[0-9a-f]{7,40}' | tail -1 || true)
+      if [ -n "$wt_head" ] && printf '%s' "$head" | grep -q "^$wt_head"; then reviewed_head=1; fi
+      # (c2) final_review_risk marker: "up to `<sha>`" parsed ONLY within the final_review_risk block.
+      fr_block=$(printf '%s' "$wt_body" | awk '/final_review_risk_start/{f=1} f{print} /final_review_risk_end/{f=0}')
+      # shellcheck disable=SC2016  # the backticks are LITERAL text in CodeRabbit's marker, not a subshell
+      fr_head=$(printf '%s' "$fr_block" | grep -oE 'up to `[0-9a-f]{5,40}`' | tail -1 | grep -oE '[0-9a-f]{5,40}' || true)
+      if [ -n "$fr_head" ] && printf '%s' "$head" | grep -q "^$fr_head"; then reviewed_head=1; fi
+    fi
   else
     unknown=1
   fi


### PR DESCRIPTION
## What

Two fixes to the `uzi-watcher` skill's `scripts/watch-pr.sh` merge-readiness poller, both found driving a 6-PR batch through `mr_rework` + CodeRabbit re-review this session.

### 1. Addressed findings were counted as live

An inline CodeRabbit finding that a later commit fixed keeps `line != null` and only appends a `✅ Addressed in commit <sha>` line to its body. The `live` count filtered on `line != null` alone, so a resolved finding read as open. On PR #807 this produced a false "2 live findings" (`watch-pr.sh` exit 3) after a clean rework and stalled a merge-ready PR. The count now also excludes any comment whose body contains `Addressed in commit`.

### 2. New CodeRabbit walkthrough marker

CodeRabbit is migrating the walkthrough head marker from the `recent_review` "between BASE and HEAD" range to a `final_review_risk` block ("**Merge Risk:** ... up to `<sha>`"). Some PRs in the batch had only the latter, so a clean re-review could read as never-landed. Head-review detection (signal c) now confirms from either marker.

`SKILL.md` documents both behaviors so a hand-rolled poller does not repeat them.

## Testing

- `shellcheck` clean on `watch-pr.sh` (also the `gate:repo` / `lint:shell` check).
- `agnix .claude/skills/uzi-watcher/SKILL.md`: 0 errors.
- No `.github/workflows` or code changes; skill + script only.

Companion to the broader `mr_rework` hardening brainstorm in #813.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request review status detection for the current walkthrough format.
  - Review status now requires exactly one valid walkthrough comment matching the current pull request version.
  - Retired walkthrough formats are no longer accepted.
  - Resolved findings marked “Addressed in commit” are excluded from active findings.
  - Findings without a valid line reference are no longer treated as outstanding issues.

- **Documentation**
  - Clarified walkthrough format handling and finding-status interpretation in review guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->