### PR TITLE
Task/handoff runs ignore the user's wait_on_limit default (fall to column default false)

### DIFF
--- a/api/internal/store/queries/task.sql
+++ b/api/internal/store/queries/task.sql
@@ -19,8 +19,12 @@
 -- then_fix_requested rides from the caller (--then-fix, PRD #400 M5): set on this ORIGINAL
 -- task so that when its auto-spawned review run completes, maybeEnqueueThenFix composes the
 -- review findings into a fix run on the same branch; false for an ordinary handoff.
-INSERT INTO runs (id, user_id, repo_id, kind, branch, base_branch, open_mr, interactive, review_requested, then_fix_requested, issue_title, issue_description, auto_approve, required_capabilities)
-VALUES (@run_id, @user_id, @repo_id::uuid, 'task', @branch, sqlc.narg('base_branch'), @open_mr, @interactive, @review_requested, @then_fix_requested, @issue_title, @issue_description, true, COALESCE((SELECT rp.required_capabilities FROM repos rp WHERE rp.id = @repo_id::uuid), '{}'))
+-- wait_on_limit (PRD #35) is stamped here from the OWNER's default, resolved in the
+-- service layer (resolveWaitOnLimit): a handoff has no per-request override today, so
+-- nil -> the owner's users.wait_on_limit is the whole behavior. Omitting it (as this
+-- query originally did) silently opts every task run OUT via the column DEFAULT false.
+INSERT INTO runs (id, user_id, repo_id, kind, branch, base_branch, open_mr, interactive, review_requested, then_fix_requested, issue_title, issue_description, auto_approve, wait_on_limit, required_capabilities)
+VALUES (@run_id, @user_id, @repo_id::uuid, 'task', @branch, sqlc.narg('base_branch'), @open_mr, @interactive, @review_requested, @then_fix_requested, @issue_title, @issue_description, true, @wait_on_limit, COALESCE((SELECT rp.required_capabilities FROM repos rp WHERE rp.id = @repo_id::uuid), '{}'))
 RETURNING *;
 
 -- name: CreateThenFixRun :one

--- a/api/internal/store/task.sql.go
+++ b/api/internal/store/task.sql.go
@@ -165,8 +165,8 @@ func (q *Queries) CreateTaskReviewRun(ctx context.Context, arg CreateTaskReviewR
 
 const createTaskRun = `-- name: CreateTaskRun :one
 
-INSERT INTO runs (id, user_id, repo_id, kind, branch, base_branch, open_mr, interactive, review_requested, then_fix_requested, issue_title, issue_description, auto_approve, required_capabilities)
-VALUES ($1, $2, $3::uuid, 'task', $4, $5, $6, $7, $8, $9, $10, $11, true, COALESCE((SELECT rp.required_capabilities FROM repos rp WHERE rp.id = $3::uuid), '{}'))
+INSERT INTO runs (id, user_id, repo_id, kind, branch, base_branch, open_mr, interactive, review_requested, then_fix_requested, issue_title, issue_description, auto_approve, wait_on_limit, required_capabilities)
+VALUES ($1, $2, $3::uuid, 'task', $4, $5, $6, $7, $8, $9, $10, $11, true, $12, COALESCE((SELECT rp.required_capabilities FROM repos rp WHERE rp.id = $3::uuid), '{}'))
 RETURNING id, user_id, repo_id, issue_iid, issue_title, issue_description, status, requeue_count, worker_id, session_id, last_seq, branch, mr_iid, failure_reason, plan_md, iteration_count, claimed_at, started_at, finished_at, created_at, updated_at, origin_column, board_column, move_pending_since, mr_state, auto_approve, autopilot_commented_at, kind, pipeline_id, pipeline_ref, failure_snapshot, fix_verdict, stop_kind, agent_source, agent_exclusions, repo_agents, title, resume_of_run_id, last_activity_at, health, health_reason, health_since, health_notified_at, target_run_id, mr_web_url, prd_done_path, prd_patch_settled_at, anthropic_secret_id, anthropic_secret_label, anthropic_select_reason, anthropic_headroom_pct, wait_on_limit, limit_resets_at, retry_not_before, limit_wait_count, rate_limit_type, open_question_id, revise_count, plan_source, planned_base_commit, require_base_match, milestones_candidate, milestones_frozen, milestones_completed, milestones_in_progress, budget_max_iterations, budget_wall_seconds, schedule_id, limit_dead_secret_id, report_only, report_md, ci_config_paths, model, override_subagent_model, fail_origin, priority, summary_intent, summary_plan, summary_deltas, issue_comments, base_branch, open_mr, dispatched_at, review_target_run_id, review_requested, then_fix_requested, then_fix_of_run_id, preserved_patch, required_capabilities, stop_reason, required_tools, size_class, interactive, open_followup_id, plan_changed_files, scope_ceiling, status_since, review_comments, budget_paused_seconds
 `
 
@@ -182,6 +182,7 @@ type CreateTaskRunParams struct {
 	ThenFixRequested bool        `json:"then_fix_requested"`
 	IssueTitle       string      `json:"issue_title"`
 	IssueDescription string      `json:"issue_description"`
+	WaitOnLimit      bool        `json:"wait_on_limit"`
 }
 
 // Task runs (PRD #400: uzi handoff) ------------------------------------------
@@ -203,6 +204,10 @@ type CreateTaskRunParams struct {
 // then_fix_requested rides from the caller (--then-fix, PRD #400 M5): set on this ORIGINAL
 // task so that when its auto-spawned review run completes, maybeEnqueueThenFix composes the
 // review findings into a fix run on the same branch; false for an ordinary handoff.
+// wait_on_limit (PRD #35) is stamped here from the OWNER's default, resolved in the
+// service layer (resolveWaitOnLimit): a handoff has no per-request override today, so
+// nil -> the owner's users.wait_on_limit is the whole behavior. Omitting it (as this
+// query originally did) silently opts every task run OUT via the column DEFAULT false.
 func (q *Queries) CreateTaskRun(ctx context.Context, arg CreateTaskRunParams) (Run, error) {
 	row := q.db.QueryRow(ctx, createTaskRun,
 		arg.RunID,
@@ -216,6 +221,7 @@ func (q *Queries) CreateTaskRun(ctx context.Context, arg CreateTaskRunParams) (R
 		arg.ThenFixRequested,
 		arg.IssueTitle,
 		arg.IssueDescription,
+		arg.WaitOnLimit,
 	)
 	var i Run
 	err := row.Scan(

--- a/api/internal/workersvc/task.go
+++ b/api/internal/workersvc/task.go
@@ -110,6 +110,10 @@ func (s *Service) CreateTaskRun(ctx context.Context, userID, repoID uuid.UUID, i
 		ThenFixRequested: thenFixRequested,
 		IssueTitle:       deriveTaskTitle(inlineContext),
 		IssueDescription: inlineContext,
+		// PRD #35: the OWNER's default. A handoff has no per-request wait_on_limit
+		// override today, so nil resolves to the user's users.wait_on_limit — the same
+		// defaulting every other creation path applies (ci_fix/mr_rework/CreateRun).
+		WaitOnLimit: s.resolveWaitOnLimit(ctx, userID, nil),
 	})
 	if err != nil {
 		return store.Run{}, err

--- a/api/internal/workersvc/task_test.go
+++ b/api/internal/workersvc/task_test.go
@@ -79,6 +79,65 @@ func TestCreateTaskRunMintsNamespacedBranch(t *testing.T) {
 	}
 }
 
+// TestCreateTaskRunStampsOwnerWaitOnLimit: a task/handoff run must inherit the
+// owner's users.wait_on_limit default, the same defaulting every other creation path
+// applies (resolveWaitOnLimit; PRD #35). handoff has no per-request override, so nil
+// resolves straight to the owner default. This is the ONLY guard — sqlc emits a params
+// STRUCT, so a call site that omits WaitOnLimit compiles fine and silently opts every
+// task run OUT via the column DEFAULT false (the exact bug this fixes).
+func TestCreateTaskRunStampsOwnerWaitOnLimit(t *testing.T) {
+	repo := uuid.New()
+
+	t.Run("opted-in owner => wait_on_limit true", func(t *testing.T) {
+		owner := uuid.New()
+		fs := &fakeStore{repoRow: aValidRepoRow(), userByID: store.User{ID: owner, WaitOnLimit: true}}
+		svc := New(fs, newBox(t), testParams())
+		svc.SetRepoGuard(&fakeGuard{res: privcheck.GuardResult{Blocked: false}})
+		if _, err := svc.CreateTaskRun(context.Background(), owner, repo, "do it", "", false, false, false, false); err != nil {
+			t.Fatalf("CreateTaskRun: %v", err)
+		}
+		if fs.taskRunParams == nil {
+			t.Fatal("insert did not run")
+		}
+		if !fs.taskRunParams.WaitOnLimit {
+			t.Fatal("a task run for an opted-in owner was stamped wait_on_limit=false — " +
+				"the handoff path fell to the column default instead of resolveWaitOnLimit")
+		}
+	})
+
+	t.Run("default-off owner => wait_on_limit false", func(t *testing.T) {
+		owner := uuid.New()
+		fs := &fakeStore{repoRow: aValidRepoRow(), userByID: store.User{ID: owner}} // WaitOnLimit false
+		svc := New(fs, newBox(t), testParams())
+		svc.SetRepoGuard(&fakeGuard{res: privcheck.GuardResult{Blocked: false}})
+		if _, err := svc.CreateTaskRun(context.Background(), owner, repo, "do it", "", false, false, false, false); err != nil {
+			t.Fatalf("CreateTaskRun: %v", err)
+		}
+		if fs.taskRunParams == nil {
+			t.Fatal("insert did not run")
+		}
+		if fs.taskRunParams.WaitOnLimit {
+			t.Fatal("a task run for a default-off owner was stamped wait_on_limit=true")
+		}
+	})
+
+	t.Run("torn user read resolves false rather than failing the creation", func(t *testing.T) {
+		owner := uuid.New()
+		fs := &fakeStore{repoRow: aValidRepoRow(), userByIDErr: errors.New("boom")}
+		svc := New(fs, newBox(t), testParams())
+		svc.SetRepoGuard(&fakeGuard{res: privcheck.GuardResult{Blocked: false}})
+		if _, err := svc.CreateTaskRun(context.Background(), owner, repo, "do it", "", false, false, false, false); err != nil {
+			t.Fatalf("a preference lookup failure must not fail the creation: %v", err)
+		}
+		if fs.taskRunParams == nil {
+			t.Fatal("insert did not run")
+		}
+		if fs.taskRunParams.WaitOnLimit {
+			t.Fatal("a failed user read resolved TRUE; false is today's behaviour and the safe direction")
+		}
+	})
+}
+
 // TestCreateTaskRunSanitizesAndCaps: NUL bytes are stripped from both context and
 // base_branch, an empty base_branch persists as NULL, and an over-cap context is
 // rejected with ErrDescriptionTooLarge before any insert.


### PR DESCRIPTION
Implements issue #806.

Closes #806

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-806`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task runs now consistently apply the task owner’s “wait on limit” preference when created.
  * User preference lookup failures safely default to waiting being disabled without blocking task-run creation.

* **Tests**
  * Added coverage for enabled, disabled, and unavailable owner preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->