### PR TITLE
Harden per-call-site: encode server-derived path segments at every dynamic navigate() sink

### DIFF
--- a/web/src/pages/AgentNew.test.tsx
+++ b/web/src/pages/AgentNew.test.tsx
@@ -1,9 +1,32 @@
 // @vitest-environment jsdom
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AgentNew } from "./AgentNew";
 import { useAuth } from "../auth/AuthContext";
+import { api } from "../lib/api";
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// Mock the editor to a bare submit trigger: this test is about the navigate()
+// sink's encoding, not the editor's form. onSubmit is the same callback the real
+// editor invokes with the built AgentTemplateInput.
+vi.mock("../components/AgentTemplateEditor", () => ({
+  AgentTemplateEditor: ({
+    onSubmit,
+  }: {
+    onSubmit: (input: unknown) => void;
+  }) => (
+    <button type="button" onClick={() => onSubmit({ name: "my-agent", prompt_body: "x" })}>
+      Create template
+    </button>
+  ),
+}));
 
 vi.mock("../lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/api")>();
@@ -35,5 +58,35 @@ describe("AgentNew — always-visible agent-templates guide link (PRD #57 M3)", 
 
     const docLink = screen.getByRole("link", { name: "agent templates" });
     expect(docLink.getAttribute("href")).toBe("/docs/agent-templates");
+  });
+});
+
+// Per-call-site open-redirect hardening (issue #644): the dynamic navigate() sink
+// must encode the server-derived id, so an id carrying a path-escaping character
+// is percent-encoded rather than injected into the path. A no-op for today's UUID
+// ids, but structural — it holds even if the id format ever changes.
+describe("AgentNew — encodes the server id at the navigate() sink (#644)", () => {
+  it.each([
+    ["../evil", "/agents/..%2Fevil"],
+    ["a/b", "/agents/a%2Fb"],
+  ])("navigates to an encoded path for id %j", async (id, expectedPath) => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: "u1", is_admin: false },
+    } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(api.createAgentTemplate).mockResolvedValue({
+      template: { id },
+    } as Awaited<ReturnType<typeof api.createAgentTemplate>>);
+
+    render(
+      <MemoryRouter>
+        <AgentNew />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /create template/i }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(expectedPath));
+    // Guard against the injection shape: the raw "/" must never reach navigate().
+    expect(mockNavigate).not.toHaveBeenCalledWith(`/agents/${id}`);
   });
 });

--- a/web/src/pages/AgentNew.tsx
+++ b/web/src/pages/AgentNew.tsx
@@ -26,7 +26,9 @@ export function AgentNew() {
     setBusy(true);
     try {
       const { template } = await api.createAgentTemplate(input);
-      navigate(`/agents/${template.id}`);
+      // encodeURIComponent the id: per-call-site open-redirect hardening (see
+      // safeNextPath in Login.tsx). A no-op for today's UUID ids.
+      navigate(`/agents/${encodeURIComponent(template.id)}`);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Failed to create template");
       setBusy(false);

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -586,7 +586,9 @@ export function Board() {
     setStarting(card.iid);
     try {
       const { run } = await api.createRun(repoId, card.iid);
-      navigate(`/runs/${run.id}`);
+      // encodeURIComponent the id: per-call-site open-redirect hardening (see
+      // safeNextPath in Login.tsx). A no-op for today's UUID ids.
+      navigate(`/runs/${encodeURIComponent(run.id)}`);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Could not start run");
       setStarting(null);
@@ -603,7 +605,8 @@ export function Board() {
     setFixingRef(ref);
     try {
       const { run } = await api.createCIFixRun(repoId, ref);
-      navigate(`/runs/${run.id}`);
+      // encodeURIComponent the id (see safeNextPath in Login.tsx).
+      navigate(`/runs/${encodeURIComponent(run.id)}`);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Could not start CI fix");
       setFixingRef(null);

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -98,7 +98,9 @@ export function ChatList() {
       // create returns a full runDTO under `run`; navigate to the new conversation,
       // seeding its meta optimistically so the header renders before the list loads.
       const { run } = await api.createChat(p);
-      navigate(`/chat/${run.id}`, { state: { seed: chatFromRun(run) } });
+      // encodeURIComponent the id: per-call-site open-redirect hardening (see
+      // safeNextPath in Login.tsx). A no-op for today's UUID ids.
+      navigate(`/chat/${encodeURIComponent(run.id)}`, { state: { seed: chatFromRun(run) } });
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Failed to start the chat");
       setStarting(false);
@@ -149,7 +151,10 @@ export function ChatList() {
               <ConversationRow
                 key={c.id}
                 chat={c}
-                onContinued={(run) => navigate(`/chat/${run.id}`, { state: { seed: chatFromRun(run) } })}
+                onContinued={(run) =>
+                  // encodeURIComponent the id (see safeNextPath in Login.tsx).
+                  navigate(`/chat/${encodeURIComponent(run.id)}`, { state: { seed: chatFromRun(run) } })
+                }
                 onError={setError}
               />
             ))}
@@ -287,7 +292,8 @@ export function ChatConversation() {
   const continueChat = () =>
     act(async () => {
       const { run: next } = await api.continueChat(id);
-      navigate(`/chat/${next.id}`, { state: { seed: chatFromRun(next) } });
+      // encodeURIComponent the id (see safeNextPath in Login.tsx).
+      navigate(`/chat/${encodeURIComponent(next.id)}`, { state: { seed: chatFromRun(next) } });
     });
 
   if (!run && !meta) {

--- a/web/src/pages/IssueView.tsx
+++ b/web/src/pages/IssueView.tsx
@@ -81,7 +81,9 @@ export function IssueView() {
     setStarting(true);
     try {
       const { run } = await api.createRun(repoId, issue.iid);
-      navigate(`/runs/${run.id}`);
+      // encodeURIComponent the id: per-call-site open-redirect hardening (see
+      // safeNextPath in Login.tsx). A no-op for today's UUID ids.
+      navigate(`/runs/${encodeURIComponent(run.id)}`);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Could not start run");
       setStarting(false);

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -27,6 +27,14 @@ function oidcErrorMessage(code: string | null): string | null {
 // window.location normalizes "\"→"/", so the day a refactor points it at
 // window.location.assign, "/\evil.com" would become a live open redirect. Reject
 // the backslash here so that refactor can't silently reopen the hole.
+//
+// INVARIANT (per-call-site, not global): this guard covers ONLY the returnTo
+// sink below (navigate(returnTo)). It is not a global open-redirect guard. Every
+// OTHER navigate() of a value derived from the URL or the server must protect its
+// own dynamic path segment — the sinks that interpolate a server id wrap it in
+// encodeURIComponent(...) so a future non-UUID id (slug, name, forge identifier)
+// cannot inject a "/", "//", or "\" path segment. A new navigate() sink is NOT
+// covered by anything here; encode its dynamic segment at the call site.
 export function safeNextPath(next: string | null): string {
   if (next && next.startsWith("/") && !next.startsWith("//") && !next.includes("\\")) {
     return next;


### PR DESCRIPTION
Implements issue #644.

Closes #644

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-644`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability when opening agent templates, runs, and conversations with special characters in their IDs.
  * Prevented path separators and traversal-like sequences in IDs from creating incorrect routes.
* **Documentation**
  * Clarified URL safety requirements for navigation targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->