### PR TITLE
TUI context meter (#565) follow-up: web-parity + perf/cleanup nits from #570 review

### DIFF
--- a/api/cmd/uzi/tui_context.go
+++ b/api/cmd/uzi/tui_context.go
@@ -111,20 +111,22 @@ func contextTone(pal palette, pct float64) color.Color {
 // row; under cool the tone is faintC, so the whole bar reads faint (no accent). No used/window
 // token counts — this is a bare pct meter.
 func (m tuiModel) contextMeterCell(bg color.Color, fill contextFill, barW int) string {
-	r := int(math.Round(fill.pct))
-	// The DISPLAYED label is clamped to [0,999] so it never exceeds the 4-col ("999%") budget
-	// laneRow reserves for the meter tail; the bar and tone stay on the TRUE unclamped pct
-	// (rateBarParts clamps the bar to [0,100], contextTone intentionally uses the raw pct).
-	label := r
-	if label < 0 {
-		label = 0
+	// Clamp pct in the FLOAT domain to the DISPLAYED-label budget [0,999] BEFORE converting to
+	// int: Go leaves out-of-range float→int conversions implementation-defined, so an
+	// extreme-but-finite pct (e.g. math.MaxFloat64, which passes finite()) would otherwise yield
+	// a platform-dependent label and bar. The 4-col ("999%") budget is what laneRow reserves for
+	// the meter tail. The bar still clamps to [0,100] in rateBarParts, and the tone still rides
+	// the TRUE unclamped pct via contextTone (no int conversion there).
+	p := fill.pct
+	if p < 0 {
+		p = 0
+	} else if p > 999 {
+		p = 999
 	}
-	if label > 999 {
-		label = 999
-	}
+	r := int(math.Round(p))
 	filled, empty := rateBarParts(r, barW)
 	return paintSeg(m.pal.faintC, bg, false, " ") +
 		paintSeg(contextTone(m.pal, fill.pct), bg, false, filled) +
 		paintSeg(m.pal.faintC, bg, false, empty) +
-		paintSeg(m.pal.faintC, bg, false, " "+fmt.Sprintf("%4s", strconv.Itoa(label)+"%"))
+		paintSeg(m.pal.faintC, bg, false, " "+fmt.Sprintf("%4s", strconv.Itoa(r)+"%"))
 }

--- a/api/cmd/uzi/tui_context.go
+++ b/api/cmd/uzi/tui_context.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"image/color"
@@ -18,20 +19,36 @@ import (
 //     (unclamped) rounded pct, so pct 112 → a full bar + "112%".
 //   - readContext (web runUsage.ts): render nothing unless used, window AND pct are all
 //     finite numbers — a malformed/partial context yields no meter.
+//   - the context read is GATED on the frame ALSO carrying a valid (non-null JSON object or
+//     array) "usage", matching web's `if (u)` branch (runUsage.ts:674): web reads "context"
+//     only inside the block guarded by a truthy readUsage(payload.usage), and readUsage
+//     returns a value for any non-null object/array (an empty {} counts) — the usage token
+//     VALUES are irrelevant, only its presence as an object. A frame carrying a valid context
+//     but no (or a null/scalar) usage is therefore ignored.
 //   - leadContext: latest-wins across LEAD frames only; a subagent frame's context is
 //     ignored.
 
-// contextFill is a decoded, validated lead context reading.
+// contextFill is a decoded, validated lead context reading. Only pct is stored — used/window
+// are still GUARDED for finiteness (readContext parity) but nothing downstream reads them.
 type contextFill struct {
-	used, window, pct float64
+	pct float64
 }
 
-// leadContextFill finds the lead lane and returns its newest valid context reading, mirroring
-// web's leadContext (latest-wins across lead frames only). It scans the lead lane's frames
-// NEWEST-FIRST and returns the first frame carrying a context whose used, window AND pct are
-// all present and finite — the exact readContext guard. A frame whose payload has no "context"
-// key (a lead text frame) or fails to decode is skipped. No lead lane, or no valid context on
-// it, yields (contextFill{}, false) and no meter.
+// isUsageObject reports whether raw is a non-null JSON object or array, mirroring web's rec()
+// acceptance (runUsage.ts:276-277: `v && typeof v === "object"`): an empty {} counts, a bare
+// null fails (it trims to "null", first byte 'n'), and a missing key leaves raw nil/empty.
+func isUsageObject(raw json.RawMessage) bool {
+	t := bytes.TrimSpace(raw)
+	return len(t) > 0 && (t[0] == '{' || t[0] == '[')
+}
+
+// leadContextFill finds the lead lane and returns the newest lead frame carrying BOTH a valid
+// usage object AND a finite context, mirroring web's leadContext (latest-wins across lead
+// frames only). It scans the lead lane's frames NEWEST-FIRST and returns the first frame whose
+// usage is a non-null JSON object/array (web's `if (u)` gate) and whose context has used, window
+// AND pct all present and finite — the exact readContext guard. A frame with no "context" key,
+// no/invalid "usage", or a decode failure is skipped. No lead lane, or no such frame on it,
+// yields (contextFill{}, false) and no meter.
 func leadContextFill(lanes []agentLane) (contextFill, bool) {
 	for _, l := range lanes {
 		if l.Key != laneLead {
@@ -39,10 +56,19 @@ func leadContextFill(lanes []agentLane) (contextFill, bool) {
 		}
 		for i := len(l.Frames) - 1; i >= 0; i-- {
 			var w struct {
+				Usage   json.RawMessage                       `json:"usage"`
 				Context *struct{ Used, Window, Pct *float64 } `json:"context"`
 			}
 			f := l.Frames[i]
-			if json.Unmarshal(f.Payload, &w) != nil || w.Context == nil {
+			if json.Unmarshal(f.Payload, &w) != nil {
+				continue
+			}
+			// Web reads context ONLY inside the `if (u)` branch, so the frame must carry a
+			// valid usage object first (empty {} counts; null/scalar/absent does not).
+			if !isUsageObject(w.Usage) {
+				continue
+			}
+			if w.Context == nil {
 				continue
 			}
 			c := w.Context
@@ -52,7 +78,7 @@ func leadContextFill(lanes []agentLane) (contextFill, bool) {
 			if !finite(*c.Used) || !finite(*c.Window) || !finite(*c.Pct) {
 				continue
 			}
-			return contextFill{used: *c.Used, window: *c.Window, pct: *c.Pct}, true
+			return contextFill{pct: *c.Pct}, true
 		}
 		// The lead lane exists but carries no valid context: no meter, and no other lane
 		// can be the lead (only laneLead is the lead).
@@ -86,9 +112,19 @@ func contextTone(pal palette, pct float64) color.Color {
 // token counts — this is a bare pct meter.
 func (m tuiModel) contextMeterCell(bg color.Color, fill contextFill, barW int) string {
 	r := int(math.Round(fill.pct))
+	// The DISPLAYED label is clamped to [0,999] so it never exceeds the 4-col ("999%") budget
+	// laneRow reserves for the meter tail; the bar and tone stay on the TRUE unclamped pct
+	// (rateBarParts clamps the bar to [0,100], contextTone intentionally uses the raw pct).
+	label := r
+	if label < 0 {
+		label = 0
+	}
+	if label > 999 {
+		label = 999
+	}
 	filled, empty := rateBarParts(r, barW)
 	return paintSeg(m.pal.faintC, bg, false, " ") +
 		paintSeg(contextTone(m.pal, fill.pct), bg, false, filled) +
 		paintSeg(m.pal.faintC, bg, false, empty) +
-		paintSeg(m.pal.faintC, bg, false, " "+fmt.Sprintf("%4s", strconv.Itoa(r)+"%"))
+		paintSeg(m.pal.faintC, bg, false, " "+fmt.Sprintf("%4s", strconv.Itoa(label)+"%"))
 }

--- a/api/cmd/uzi/tui_context_test.go
+++ b/api/cmd/uzi/tui_context_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"testing"
@@ -175,6 +176,34 @@ func TestContextMeterCellLabelClamped(t *testing.T) {
 	}
 	if !strings.Contains(row, "999%") {
 		t.Errorf("the clamped label must read 999%% for an over-999 pct:\n%q", row)
+	}
+}
+
+// TestContextMeterCellExtremePctClampedInFloatDomain — a finite-but-out-of-int-range pct passes
+// finite() and reaches contextMeterCell, so the clamp MUST happen in the float domain before the
+// int conversion (Go leaves out-of-range float→int implementation-defined). math.MaxFloat64 →
+// "999%" + a full ▰ bar; a large-negative pct → "0%". This guards the pre-fix path where the
+// conversion happened before any clamp.
+func TestContextMeterCellExtremePctClampedInFloatDomain(t *testing.T) {
+	m := tuiTestModel(t, nil, "")
+
+	huge := stripANSI(m.contextMeterCell(nil, contextFill{pct: math.MaxFloat64}, 13))
+	if !strings.Contains(huge, "999%") {
+		t.Errorf("math.MaxFloat64 pct must clamp the label to 999%%:\n%q", huge)
+	}
+	if !strings.Contains(huge, "▰▰▰▰▰▰") {
+		t.Errorf("math.MaxFloat64 pct must clamp the bar to full ▰▰▰▰▰▰:\n%q", huge)
+	}
+	if strings.Contains(huge, "/") {
+		t.Errorf("meter must NOT carry a used/window token count (no `/`):\n%q", huge)
+	}
+
+	neg := stripANSI(m.contextMeterCell(nil, contextFill{pct: -math.MaxFloat64}, 13))
+	if !strings.Contains(neg, "0%") {
+		t.Errorf("a large-negative pct must clamp the label to 0%%:\n%q", neg)
+	}
+	if strings.Contains(neg, "▰") {
+		t.Errorf("a large-negative pct must render an empty bar (no ▰):\n%q", neg)
 	}
 }
 

--- a/api/cmd/uzi/tui_context_test.go
+++ b/api/cmd/uzi/tui_context_test.go
@@ -56,7 +56,7 @@ func TestContextTone(t *testing.T) {
 func TestContextMeterCell(t *testing.T) {
 	m := tuiTestModel(t, nil, "")
 
-	over := stripANSI(m.contextMeterCell(nil, contextFill{used: 224000, window: 200000, pct: 112}, 13))
+	over := stripANSI(m.contextMeterCell(nil, contextFill{pct: 112}, 13))
 	if !strings.Contains(over, "▰▰▰▰▰▰") {
 		t.Errorf("pct 112 must clamp the bar to full ▰▰▰▰▰▰:\n%q", over)
 	}
@@ -67,7 +67,7 @@ func TestContextMeterCell(t *testing.T) {
 		t.Errorf("meter must NOT carry a used/window token count (no `/`):\n%q", over)
 	}
 
-	partial := stripANSI(m.contextMeterCell(nil, contextFill{used: 124000, window: 200000, pct: 62}, 13))
+	partial := stripANSI(m.contextMeterCell(nil, contextFill{pct: 62}, 13))
 	if !strings.Contains(partial, "62%") {
 		t.Errorf("pct 62 label missing:\n%q", partial)
 	}
@@ -105,6 +105,76 @@ func TestLeadContextFillGuards(t *testing.T) {
 	}
 	if fill.pct != 50 {
 		t.Errorf("newest-VALID wins: want pct 50, got %v", fill.pct)
+	}
+}
+
+// leadFrame builds a lead-lane usage frame from a raw payload JSON, so a test can exercise the
+// exact usage/context bytes leadContextFill decodes (mirrors leadCtxMsg but with hand-written
+// payloads for the usage-gate cases).
+func leadFrame(seq int32, payload string, at time.Time) apitypes.MessageDTO {
+	agent := "lead"
+	return apitypes.MessageDTO{Seq: seq, Kind: "usage", CreatedAt: at, Agent: &agent,
+		Payload: json.RawMessage(payload)}
+}
+
+// TestLeadContextFillUsageGate — web reads `context` ONLY inside the `if (u)` branch (runUsage.ts:674),
+// so a valid context is used only when the same frame ALSO carries a valid usage OBJECT. readUsage
+// accepts any non-null object/array (empty {} counts), and rejects null/scalar/absent.
+func TestLeadContextFillUsageGate(t *testing.T) {
+	now := time.Now()
+
+	// A newer frame with valid context but NO usage key is IGNORED; an earlier frame carrying
+	// BOTH a valid usage object and context wins.
+	lanes := buildLanes([]laneFrame{
+		laneFrameFromMessage(leadFrame(1, `{"usage":{"input_tokens":1},"context":{"used":100000,"window":200000,"pct":50}}`, now.Add(-time.Minute))),
+		laneFrameFromMessage(leadFrame(2, `{"context":{"used":180000,"window":200000,"pct":90}}`, now)),
+	})
+	fill, ok := leadContextFill(lanes)
+	if !ok {
+		t.Fatal("a context-only newer frame must be skipped, letting the earlier usage+context frame win")
+	}
+	if fill.pct != 50 {
+		t.Errorf("usage-gated: want the earlier usage+context frame's pct 50, got %v", fill.pct)
+	}
+
+	// A frame with "usage":null + valid context is IGNORED (null is not a usage object).
+	lanes = buildLanes([]laneFrame{
+		laneFrameFromMessage(leadFrame(1, `{"usage":null,"context":{"used":100000,"window":200000,"pct":50}}`, now)),
+	})
+	if _, ok := leadContextFill(lanes); ok {
+		t.Error(`a frame with "usage":null must be ignored (web's readUsage rejects null)`)
+	}
+
+	// A frame with "usage":{} (empty object) + valid context IS accepted — web's rec() accepts
+	// any non-null object, the token values being irrelevant.
+	lanes = buildLanes([]laneFrame{
+		laneFrameFromMessage(leadFrame(1, `{"usage":{},"context":{"used":124000,"window":200000,"pct":62}}`, now)),
+	})
+	fill, ok = leadContextFill(lanes)
+	if !ok {
+		t.Fatal(`a frame with "usage":{} (empty object) + valid context must be accepted`)
+	}
+	if fill.pct != 62 {
+		t.Errorf(`empty-usage-object frame: want pct 62, got %v`, fill.pct)
+	}
+}
+
+// TestContextMeterCellLabelClamped — the DISPLAYED label is bounded to 4 cols ("999%") even for an
+// absurd pct, so a lead row never overflows the rail; the bar/tone still ride the true pct.
+func TestContextMeterCellLabelClamped(t *testing.T) {
+	m := tuiTestModel(t, nil, "")
+
+	row := strings.SplitN(stripANSI(
+		m.laneRow(agentLane{Key: laneLead, Role: "lead"}, false, crewIdle, "", contextFill{pct: 1e9}, true)),
+		"\n", 2)[0]
+	if w := visualWidth(row); w != laneRailWidth {
+		t.Errorf("an absurd pct must keep the row at laneRailWidth %d, got %d:\n%q", laneRailWidth, w, row)
+	}
+	if strings.Contains(row, "1000000000%") {
+		t.Errorf("the label must be clamped, not show the raw 1e9 pct:\n%q", row)
+	}
+	if !strings.Contains(row, "999%") {
+		t.Errorf("the clamped label must read 999%% for an over-999 pct:\n%q", row)
 	}
 }
 
@@ -147,7 +217,7 @@ func TestContextMeterCellToneColour(t *testing.T) {
 		// The FILLED run is the tone SGR code immediately followed by a ▰ glyph; asserting the
 		// code sits directly on ▰ (not merely somewhere in the string) pins the colour to the
 		// filled portion, distinct from the faint leading space / empty run / label.
-		raw := m.contextMeterCell(nil, contextFill{used: 1, window: 2, pct: c.pct}, 13)
+		raw := m.contextMeterCell(nil, contextFill{pct: c.pct}, 13)
 		wantFilled := "\x1b[" + c.want + "m▰"
 		if !strings.Contains(raw, wantFilled) {
 			t.Errorf("%s (pct=%v): filled run must carry tone %s directly on ▰:\n%q",
@@ -157,7 +227,7 @@ func TestContextMeterCellToneColour(t *testing.T) {
 
 	// Non-vacuity guard: the cool meter must carry NEITHER the amber NOR the alarm colour, so the
 	// test would fail if contextMeterCell ever painted one fixed accent regardless of pct.
-	cool := m.contextMeterCell(nil, contextFill{used: 1, window: 2, pct: 50}, 13)
+	cool := m.contextMeterCell(nil, contextFill{pct: 50}, 13)
 	if strings.Contains(cool, amberCode) {
 		t.Errorf("cool meter must not carry the amber (molten) colour %s:\n%q", amberCode, cool)
 	}
@@ -298,7 +368,7 @@ func TestDetailLeadContextMeterFillsRail(t *testing.T) {
 // a ·N suffix yields a shorter one, both padded to exactly 26.
 func TestContextMeterCellShrinksWithPrefix(t *testing.T) {
 	m := tuiTestModel(t, nil, "")
-	fill := contextFill{used: 124000, window: 200000, pct: 62}
+	fill := contextFill{pct: 62}
 
 	firstLine := func(s string) string {
 		return strings.SplitN(stripANSI(s), "\n", 2)[0]

--- a/api/cmd/uzi/tui_detail.go
+++ b/api/cmd/uzi/tui_detail.go
@@ -45,6 +45,11 @@ type detailState struct {
 
 	lanes   []agentLane
 	laneIdx int
+	// leadCtx is the lead context-window meter reading, memoized on rebuild so a
+	// render does not re-scan+unmarshal lead frames each View() (mirrors web's
+	// leadContext memoization in deriveRunUsage).
+	leadCtx   contextFill
+	leadCtxOK bool
 	// scroll is the transcript window's TOP line index (M5, bottom-anchored). When follow
 	// is true the window is pinned to the bottom (auto-tail) and scroll is recomputed on
 	// render; when paused, scroll is the fixed top so the view does not jump as frames
@@ -187,6 +192,9 @@ func (d *detailState) rebuild() {
 	if d.laneIdx < 0 {
 		d.laneIdx = 0
 	}
+	// Memoize the lead context-window meter reading now that d.lanes is final, so each
+	// render reads the cached value instead of re-scanning+unmarshalling lead frames.
+	d.leadCtx, d.leadCtxOK = leadContextFill(d.lanes)
 }
 
 func (d *detailState) selectedLane() (agentLane, bool) {
@@ -677,9 +685,10 @@ func (m tuiModel) renderLaneRail() string {
 		}
 		return crewStateFor(d.run.Status, d.run.Health, l.Key, active, l.LastActivity, now)
 	}
-	// The lead's context-window meter (#565): latest-wins across LEAD frames only, computed once
-	// and shown ONLY on the lead lane. A subagent lane and the synthetic ALL lane never get it.
-	fill, hasCtx := leadContextFill(d.lanes)
+	// The lead's context-window meter (#565): latest-wins across LEAD frames only, memoized in
+	// rebuild() (d.leadCtx) so a render does not re-scan+unmarshal lead frames, and shown ONLY on
+	// the lead lane. A subagent lane and the synthetic ALL lane never get it.
+	fill, hasCtx := d.leadCtx, d.leadCtxOK
 	if d.railCollapsed {
 		// Just the selected lane, so the reader still knows whose transcript is on screen while
 		// the milestones get the rest of the column.

--- a/api/cmd/uzi/uxlab_gen_test.go
+++ b/api/cmd/uzi/uxlab_gen_test.go
@@ -312,13 +312,15 @@ const detailRunID = "a1b2c3d4-1111-2222-3333-444444444444"
 func laneMsgs(now time.Time) []apitypes.MessageDTO {
 	return []apitypes.MessageDTO{
 		msgDTO(1, "text", "lead", "", "", "Planning the change. I'll split this into a scheduler tweak and a test, then dispatch a coder and a tester.", now.Add(-4*time.Minute)),
-		// A lead usage frame carrying a cool/quiet context reading (pct 62, below the 70 molten
-		// cutoff) so it renders un-accented (faint) — matching the issue's mock, which shows 62%.
-		// This exercises the crew rail's inline context-window meter (#565) in the regenerated scenes.
-		leadCtxMsg(5, 124000, 200000, 62, now.Add(-30*time.Second)),
 		msgDTO(2, "tool_use", "coder", "toolu_01aaaaaa3v6ptu", "scheduler headroom", "`Edit`", now.Add(-90*time.Second)),
 		msgDTO(3, "text", "coder", "toolu_01aaaaaa3v6ptu", "scheduler headroom", "Adjusted `pollInterval` to back off when the usage window is within 10% of the cap. Running the unit tests now.", now.Add(-40*time.Second)),
 		msgDTO(4, "tool_use", "tester", "toolu_01bbbbbb2k9xqf", "regression sweep", "`Bash`", now.Add(-8*time.Second)),
+		// A lead usage frame carrying a cool/quiet context reading (pct 62, below the 70 molten
+		// cutoff) so it renders un-accented (faint) — matching the issue's mock, which shows 62%.
+		// This exercises the crew rail's inline context-window meter (#565) in the regenerated scenes.
+		// Placed LAST so the fixture's slice order is ascending seq (1,2,3,4,5); addFrame appends in
+		// slice order without sorting, matching production's always-ascending seq.
+		leadCtxMsg(5, 124000, 200000, 62, now.Add(-30*time.Second)),
 	}
 }
 


### PR DESCRIPTION
Implements issue #571.

Closes #571

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-571`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Context meters now appear only when valid usage data is available.
  - Context percentage labels are capped between `0%` and `999%`, while meter sizing remains accurate.
  - Context-window indicators now remain consistent as activity updates.
  - Extreme percentage values no longer cause display overflow or incorrect token counts.
- **Tests**
  - Expanded coverage for missing, null, and empty usage data.
  - Added verification for percentage clamping, extreme values, and transcript ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->