### PR TITLE
Harden cross-kind branch guard in mr_rework create against TOCTOU (atomic count+insert)

### DIFF
--- a/api/internal/store/migrations/00167_run_mr_rework_kind.sql
+++ b/api/internal/store/migrations/00167_run_mr_rework_kind.sql
@@ -41,7 +41,7 @@ CREATE UNIQUE INDEX uq_runs_one_active_mr_rework
 -- ci_fix fires on RED CI and mr_rework on GREEN, so they must never share one branch
 -- (agent/issue-N) worktree concurrently — on hosted k8s there is no git "already
 -- checked out" backstop. The guard is now the single atomic INSERT … WHERE NOT EXISTS
--- in CreateAutoMRReworkRun (its predicate matches an active ci_fix/mr_rework on the same
+-- in CreateAutoMRReworkRun (its predicate matches an active ci_fix on the same
 -- pipeline_ref, populated AT INSERT for both kinds); this partial unique index is that
 -- guard's durable backstop and ALSO supplies the typed ErrBranchInUse on the
 -- concurrent-window loser — the insert whose snapshot could not see a racing sibling

--- a/api/internal/store/migrations/00167_run_mr_rework_kind.sql
+++ b/api/internal/store/migrations/00167_run_mr_rework_kind.sql
@@ -40,12 +40,15 @@ CREATE UNIQUE INDEX uq_runs_one_active_mr_rework
 -- CROSS-KIND create-time branch guard (Decision 6, the most severe review finding).
 -- ci_fix fires on RED CI and mr_rework on GREEN, so they must never share one branch
 -- (agent/issue-N) worktree concurrently — on hosted k8s there is no git "already
--- checked out" backstop. The required guard is CountActiveBranchRunsForRef (a create-
--- time count on pipeline_ref, populated AT INSERT for both kinds); this partial unique
--- index is the durable belt behind it. It subsumes uq_runs_one_active_ci_fix's
--- (repo_id, pipeline_ref) key over the ci_fix half, so existing active ci_fix rows —
--- already unique per (repo_id, pipeline_ref) by that index — cannot violate it, and no
--- mr_rework rows exist yet.
+-- checked out" backstop. The guard is now the single atomic INSERT … WHERE NOT EXISTS
+-- in CreateAutoMRReworkRun (its predicate matches an active ci_fix/mr_rework on the same
+-- pipeline_ref, populated AT INSERT for both kinds); this partial unique index is that
+-- guard's durable backstop and ALSO supplies the typed ErrBranchInUse on the
+-- concurrent-window loser — the insert whose snapshot could not see a racing sibling
+-- slips past WHERE NOT EXISTS and is arbitrated here, raising 23505 on this constraint.
+-- It subsumes uq_runs_one_active_ci_fix's (repo_id, pipeline_ref) key over the ci_fix
+-- half, so existing active ci_fix rows — already unique per (repo_id, pipeline_ref) by
+-- that index — cannot violate it, and no mr_rework rows exist yet.
 CREATE UNIQUE INDEX uq_runs_one_active_branch_ref
     ON runs (repo_id, pipeline_ref)
     WHERE kind IN ('ci_fix', 'mr_rework') AND status NOT IN ('completed', 'failed', 'cancelled');

--- a/api/internal/store/mr_rework.sql.go
+++ b/api/internal/store/mr_rework.sql.go
@@ -24,7 +24,7 @@ SELECT
 WHERE NOT EXISTS (
     SELECT 1 FROM runs
     WHERE repo_id = $2::uuid
-      AND kind IN ('ci_fix', 'mr_rework')
+      AND kind = 'ci_fix'
       AND pipeline_ref = $5
       AND status NOT IN ('completed', 'failed', 'cancelled')
 )
@@ -56,16 +56,19 @@ type CreateAutoMRReworkRunParams struct {
 // (23505 → ErrActiveMRReworkExists). wait_on_limit is the owner's default (PRD #35).
 //
 // The create-time CROSS-KIND branch guard (Decision 6, the most severe review finding)
-// is this query's own single atomic INSERT … WHERE NOT EXISTS: the WHERE NOT EXISTS
-// predicate is byte-identical to the removed CountActiveBranchRunsForRef count — an
-// active ci_fix OR mr_rework run whose pipeline_ref equals the branch (agent/issue-N)
-// means the branch is occupied. BOTH kinds write pipeline_ref AT INSERT, so — unlike
-// the old runs.branch count (NULL for a run's whole active life) — a freshly-created
-// sibling is seen. A committed sibling → zero rows inserted → pgx.ErrNoRows, which the
-// caller maps to ErrBranchInUse. A concurrent-window sibling not yet visible to this
+// is this query's own single atomic INSERT … WHERE NOT EXISTS. The WHERE NOT EXISTS
+// predicate is narrowed to the CROSS-KIND case only — an active ci_fix run whose
+// pipeline_ref equals the branch (agent/issue-N) means the branch is occupied by the
+// other kind. ci_fix writes pipeline_ref AT INSERT, so — unlike the old runs.branch
+// count (NULL for a run's whole active life) — a freshly-created cross-kind sibling is
+// seen. A committed ci_fix → zero rows inserted → pgx.ErrNoRows, which the caller maps
+// to ErrBranchInUse. A concurrent-window cross-kind race not yet visible to this
 // statement's snapshot slips past WHERE NOT EXISTS, and the durable spanning
 // uq_runs_one_active_branch_ref partial index arbitrates: the losing insert raises
-// 23505 on that constraint, which the caller likewise maps to ErrBranchInUse.
+// 23505 on that constraint, which the caller likewise maps to ErrBranchInUse. A same-MR
+// mr_rework DUPLICATE (same pipeline_ref) now proceeds PAST this predicate — it is no
+// longer swallowed as a false branch conflict — and is rejected by the
+// uq_runs_one_active_mr_rework (repo_id, mr_iid) index → 23505 → ErrActiveMRReworkExists.
 func (q *Queries) CreateAutoMRReworkRun(ctx context.Context, arg CreateAutoMRReworkRunParams) (Run, error) {
 	row := q.db.QueryRow(ctx, createAutoMRReworkRun,
 		arg.UserID,

--- a/api/internal/store/mr_rework.sql.go
+++ b/api/internal/store/mr_rework.sql.go
@@ -12,41 +12,21 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const countActiveBranchRunsForRef = `-- name: CountActiveBranchRunsForRef :one
-SELECT count(*) FROM runs
-WHERE repo_id = $1::uuid
-  AND kind IN ('ci_fix', 'mr_rework')
-  AND pipeline_ref = $2
-  AND status NOT IN ('completed', 'failed', 'cancelled')
-`
-
-type CountActiveBranchRunsForRefParams struct {
-	RepoID      uuid.UUID   `json:"repo_id"`
-	PipelineRef pgtype.Text `json:"pipeline_ref"`
-}
-
-// The create-time CROSS-KIND branch guard (Decision 6, the most severe review
-// finding): count active ci_fix OR mr_rework runs whose pipeline_ref equals the
-// branch (agent/issue-N). BOTH kinds write pipeline_ref AT INSERT, so — unlike the
-// old CountActiveRunsWithBranch, which keys on runs.branch (NULL for a run's whole
-// active life) — this sees a freshly-created sibling. CreateAutoMRReworkRun calls it
-// BEFORE insert and returns ErrBranchInUse on > 0; the detector swallows and retries
-// next tick. The uq_runs_one_active_branch_ref partial index is the durable backstop.
-func (q *Queries) CountActiveBranchRunsForRef(ctx context.Context, arg CountActiveBranchRunsForRefParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countActiveBranchRunsForRef, arg.RepoID, arg.PipelineRef)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
 const createAutoMRReworkRun = `-- name: CreateAutoMRReworkRun :one
 INSERT INTO runs (
     user_id, repo_id, kind, issue_title, issue_description,
     pipeline_ref, mr_iid, target_run_id, review_comments, auto_approve, wait_on_limit, required_capabilities
-) VALUES (
+)
+SELECT
     $1, $2::uuid, 'mr_rework', $3, $4,
     $5, $6, $7, $8::jsonb, true, $9,
     COALESCE((SELECT rp.required_capabilities FROM repos rp WHERE rp.id = $2::uuid), '{}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM runs
+    WHERE repo_id = $2::uuid
+      AND kind IN ('ci_fix', 'mr_rework')
+      AND pipeline_ref = $5
+      AND status NOT IN ('completed', 'failed', 'cancelled')
 )
 RETURNING id, user_id, repo_id, issue_iid, issue_title, issue_description, status, requeue_count, worker_id, session_id, last_seq, branch, mr_iid, failure_reason, plan_md, iteration_count, claimed_at, started_at, finished_at, created_at, updated_at, origin_column, board_column, move_pending_since, mr_state, auto_approve, autopilot_commented_at, kind, pipeline_id, pipeline_ref, failure_snapshot, fix_verdict, stop_kind, agent_source, agent_exclusions, repo_agents, title, resume_of_run_id, last_activity_at, health, health_reason, health_since, health_notified_at, target_run_id, mr_web_url, prd_done_path, prd_patch_settled_at, anthropic_secret_id, anthropic_secret_label, anthropic_select_reason, anthropic_headroom_pct, wait_on_limit, limit_resets_at, retry_not_before, limit_wait_count, rate_limit_type, open_question_id, revise_count, plan_source, planned_base_commit, require_base_match, milestones_candidate, milestones_frozen, milestones_completed, milestones_in_progress, budget_max_iterations, budget_wall_seconds, schedule_id, limit_dead_secret_id, report_only, report_md, ci_config_paths, model, override_subagent_model, fail_origin, priority, summary_intent, summary_plan, summary_deltas, issue_comments, base_branch, open_mr, dispatched_at, review_target_run_id, review_requested, then_fix_requested, then_fix_of_run_id, preserved_patch, required_capabilities, stop_reason, required_tools, size_class, interactive, open_followup_id, plan_changed_files, scope_ceiling, status_since, review_comments, budget_paused_seconds, lineage_epoch
 `
@@ -74,6 +54,18 @@ type CreateAutoMRReworkRunParams struct {
 // is true (Decision 1 — the run resolves its own plan gate). The
 // uq_runs_one_active_mr_rework index rejects a second active rework for the same MR
 // (23505 → ErrActiveMRReworkExists). wait_on_limit is the owner's default (PRD #35).
+//
+// The create-time CROSS-KIND branch guard (Decision 6, the most severe review finding)
+// is this query's own single atomic INSERT … WHERE NOT EXISTS: the WHERE NOT EXISTS
+// predicate is byte-identical to the removed CountActiveBranchRunsForRef count — an
+// active ci_fix OR mr_rework run whose pipeline_ref equals the branch (agent/issue-N)
+// means the branch is occupied. BOTH kinds write pipeline_ref AT INSERT, so — unlike
+// the old runs.branch count (NULL for a run's whole active life) — a freshly-created
+// sibling is seen. A committed sibling → zero rows inserted → pgx.ErrNoRows, which the
+// caller maps to ErrBranchInUse. A concurrent-window sibling not yet visible to this
+// statement's snapshot slips past WHERE NOT EXISTS, and the durable spanning
+// uq_runs_one_active_branch_ref partial index arbitrates: the losing insert raises
+// 23505 on that constraint, which the caller likewise maps to ErrBranchInUse.
 func (q *Queries) CreateAutoMRReworkRun(ctx context.Context, arg CreateAutoMRReworkRunParams) (Run, error) {
 	row := q.db.QueryRow(ctx, createAutoMRReworkRun,
 		arg.UserID,
@@ -296,10 +288,10 @@ type ListMRReworkCandidatesRow struct {
 
 // MR review watcher (PRD #700 M3) ---------------------------------------------
 // The candidate enumeration + loop-guard ledger the poller detector
-// (poller/mr_review_watch.go) consumes, plus the create-time cross-kind branch
-// guard and the mr_rework create path. Detection lives in the poller, never in
-// forgesvc — forgesvc's sync methods are shared with the manual board Refresh and
-// must never spawn runs.
+// (poller/mr_review_watch.go) consumes, plus the mr_rework create path whose
+// single atomic INSERT … WHERE NOT EXISTS is itself the create-time cross-kind
+// branch guard. Detection lives in the poller, never in forgesvc — forgesvc's
+// sync methods are shared with the manual board Refresh and must never spawn runs.
 // The completed issue runs in a repo whose OPEN MR is eligible for an automatic
 // mr_rework, one row per branch. Gates (Decision 9/10):
 //  1. Only issue runs open an MR review loop (chat/judge/self_improve are out of

--- a/api/internal/store/mr_rework_livedb_test.go
+++ b/api/internal/store/mr_rework_livedb_test.go
@@ -2,11 +2,13 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/vtmocanu/uzi/api/internal/store"
@@ -107,21 +109,29 @@ func TestMRReworkLiveDB(t *testing.T) {
 		t.Fatalf("green head pipeline not joined: %+v", c)
 	}
 
-	// SC4 — the create-time CROSS-KIND branch guard keys on the pipeline_ref COLUMN. An
-	// active ci_fix run created with pipeline_ref=agent/issue-7 (populated AT INSERT,
-	// NOT back-filled onto runs.branch) must be seen by CountActiveBranchRunsForRef.
+	// SC4 — the create-time CROSS-KIND branch guard is the create query's own atomic
+	// INSERT … WHERE NOT EXISTS, keyed on the pipeline_ref COLUMN. An active ci_fix run
+	// created with pipeline_ref=agent/issue-7 (populated AT INSERT, NOT back-filled onto
+	// runs.branch) occupies the branch, so a CreateAutoMRReworkRun for that SAME
+	// occupied ref matches zero rows (WHERE NOT EXISTS) and the generated :one returns
+	// pgx.ErrNoRows — the caller maps that to ErrBranchInUse. mr_iid=700 is distinct from
+	// every active mr_rework here, so the ONLY thing blocking the insert is the occupied
+	// branch, not the same-MR unique index.
 	exec(`INSERT INTO runs (id, user_id, repo_id, kind, issue_title, issue_description, pipeline_id, pipeline_ref, status)
 	      VALUES ($1, $2, $3, 'ci_fix', 't', 'd', 4242, 'agent/issue-7', 'running')`,
 		uuid.New(), inUser, repoID)
-	n, err := q.CountActiveBranchRunsForRef(ctx, store.CountActiveBranchRunsForRefParams{
-		RepoID:      repoID,
-		PipelineRef: pgtype.Text{String: "agent/issue-7", Valid: true},
-	})
-	if err != nil {
-		t.Fatalf("CountActiveBranchRunsForRef: %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("cross-kind guard must see the active ci_fix on pipeline_ref, got count %d", n)
+	if _, err := q.CreateAutoMRReworkRun(ctx, store.CreateAutoMRReworkRunParams{
+		UserID:           inUser,
+		RepoID:           repoID,
+		IssueTitle:       "Rework MR review (occupied)",
+		IssueDescription: "d",
+		PipelineRef:      pgtype.Text{String: "agent/issue-7", Valid: true},
+		MrIid:            pgtype.Int8{Int64: 700, Valid: true},
+		TargetRunID:      pgtype.UUID{Bytes: src7, Valid: true},
+		ReviewComments:   []byte(`{"comments":[{"id":120}],"truncated":false}`),
+		WaitOnLimit:      false,
+	}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("CreateAutoMRReworkRun on an occupied branch: err = %v, want pgx.ErrNoRows (WHERE NOT EXISTS → 0 rows)", err)
 	}
 
 	// The runs_kind_shape CHECK accepts a valid mr_rework row (repo_id, pipeline_ref,

--- a/api/internal/store/queries/mr_rework.sql
+++ b/api/internal/store/queries/mr_rework.sql
@@ -123,16 +123,19 @@ WHERE repo_id = @repo_id::uuid AND ref <> ALL(@keep_refs::text[]);
 -- (23505 → ErrActiveMRReworkExists). wait_on_limit is the owner's default (PRD #35).
 --
 -- The create-time CROSS-KIND branch guard (Decision 6, the most severe review finding)
--- is this query's own single atomic INSERT … WHERE NOT EXISTS: the WHERE NOT EXISTS
--- predicate is byte-identical to the removed CountActiveBranchRunsForRef count — an
--- active ci_fix OR mr_rework run whose pipeline_ref equals the branch (agent/issue-N)
--- means the branch is occupied. BOTH kinds write pipeline_ref AT INSERT, so — unlike
--- the old runs.branch count (NULL for a run's whole active life) — a freshly-created
--- sibling is seen. A committed sibling → zero rows inserted → pgx.ErrNoRows, which the
--- caller maps to ErrBranchInUse. A concurrent-window sibling not yet visible to this
+-- is this query's own single atomic INSERT … WHERE NOT EXISTS. The WHERE NOT EXISTS
+-- predicate is narrowed to the CROSS-KIND case only — an active ci_fix run whose
+-- pipeline_ref equals the branch (agent/issue-N) means the branch is occupied by the
+-- other kind. ci_fix writes pipeline_ref AT INSERT, so — unlike the old runs.branch
+-- count (NULL for a run's whole active life) — a freshly-created cross-kind sibling is
+-- seen. A committed ci_fix → zero rows inserted → pgx.ErrNoRows, which the caller maps
+-- to ErrBranchInUse. A concurrent-window cross-kind race not yet visible to this
 -- statement's snapshot slips past WHERE NOT EXISTS, and the durable spanning
 -- uq_runs_one_active_branch_ref partial index arbitrates: the losing insert raises
--- 23505 on that constraint, which the caller likewise maps to ErrBranchInUse.
+-- 23505 on that constraint, which the caller likewise maps to ErrBranchInUse. A same-MR
+-- mr_rework DUPLICATE (same pipeline_ref) now proceeds PAST this predicate — it is no
+-- longer swallowed as a false branch conflict — and is rejected by the
+-- uq_runs_one_active_mr_rework (repo_id, mr_iid) index → 23505 → ErrActiveMRReworkExists.
 INSERT INTO runs (
     user_id, repo_id, kind, issue_title, issue_description,
     pipeline_ref, mr_iid, target_run_id, review_comments, auto_approve, wait_on_limit, required_capabilities
@@ -144,7 +147,7 @@ SELECT
 WHERE NOT EXISTS (
     SELECT 1 FROM runs
     WHERE repo_id = @repo_id::uuid
-      AND kind IN ('ci_fix', 'mr_rework')
+      AND kind = 'ci_fix'
       AND pipeline_ref = @pipeline_ref
       AND status NOT IN ('completed', 'failed', 'cancelled')
 )

--- a/api/internal/store/queries/mr_rework.sql
+++ b/api/internal/store/queries/mr_rework.sql
@@ -1,9 +1,9 @@
 -- MR review watcher (PRD #700 M3) ---------------------------------------------
 -- The candidate enumeration + loop-guard ledger the poller detector
--- (poller/mr_review_watch.go) consumes, plus the create-time cross-kind branch
--- guard and the mr_rework create path. Detection lives in the poller, never in
--- forgesvc — forgesvc's sync methods are shared with the manual board Refresh and
--- must never spawn runs.
+-- (poller/mr_review_watch.go) consumes, plus the mr_rework create path whose
+-- single atomic INSERT … WHERE NOT EXISTS is itself the create-time cross-kind
+-- branch guard. Detection lives in the poller, never in forgesvc — forgesvc's
+-- sync methods are shared with the manual board Refresh and must never spawn runs.
 
 -- name: ListMRReworkCandidates :many
 -- The completed issue runs in a repo whose OPEN MR is eligible for an automatic
@@ -109,20 +109,6 @@ SET halt_notified = true,
 DELETE FROM mr_rework_ledger
 WHERE repo_id = @repo_id::uuid AND ref <> ALL(@keep_refs::text[]);
 
--- name: CountActiveBranchRunsForRef :one
--- The create-time CROSS-KIND branch guard (Decision 6, the most severe review
--- finding): count active ci_fix OR mr_rework runs whose pipeline_ref equals the
--- branch (agent/issue-N). BOTH kinds write pipeline_ref AT INSERT, so — unlike the
--- old CountActiveRunsWithBranch, which keys on runs.branch (NULL for a run's whole
--- active life) — this sees a freshly-created sibling. CreateAutoMRReworkRun calls it
--- BEFORE insert and returns ErrBranchInUse on > 0; the detector swallows and retries
--- next tick. The uq_runs_one_active_branch_ref partial index is the durable backstop.
-SELECT count(*) FROM runs
-WHERE repo_id = @repo_id::uuid
-  AND kind IN ('ci_fix', 'mr_rework')
-  AND pipeline_ref = @pipeline_ref
-  AND status NOT IN ('completed', 'failed', 'cancelled');
-
 -- name: CreateAutoMRReworkRun :one
 -- Queue an mr_rework run (PRD #700 M3, sibling of CreateCIFixRun). issue_iid stays
 -- NULL (kind='mr_rework'); issue_title/issue_description carry the synthesized human
@@ -135,12 +121,31 @@ WHERE repo_id = @repo_id::uuid
 -- is true (Decision 1 — the run resolves its own plan gate). The
 -- uq_runs_one_active_mr_rework index rejects a second active rework for the same MR
 -- (23505 → ErrActiveMRReworkExists). wait_on_limit is the owner's default (PRD #35).
+--
+-- The create-time CROSS-KIND branch guard (Decision 6, the most severe review finding)
+-- is this query's own single atomic INSERT … WHERE NOT EXISTS: the WHERE NOT EXISTS
+-- predicate is byte-identical to the removed CountActiveBranchRunsForRef count — an
+-- active ci_fix OR mr_rework run whose pipeline_ref equals the branch (agent/issue-N)
+-- means the branch is occupied. BOTH kinds write pipeline_ref AT INSERT, so — unlike
+-- the old runs.branch count (NULL for a run's whole active life) — a freshly-created
+-- sibling is seen. A committed sibling → zero rows inserted → pgx.ErrNoRows, which the
+-- caller maps to ErrBranchInUse. A concurrent-window sibling not yet visible to this
+-- statement's snapshot slips past WHERE NOT EXISTS, and the durable spanning
+-- uq_runs_one_active_branch_ref partial index arbitrates: the losing insert raises
+-- 23505 on that constraint, which the caller likewise maps to ErrBranchInUse.
 INSERT INTO runs (
     user_id, repo_id, kind, issue_title, issue_description,
     pipeline_ref, mr_iid, target_run_id, review_comments, auto_approve, wait_on_limit, required_capabilities
-) VALUES (
+)
+SELECT
     @user_id, @repo_id::uuid, 'mr_rework', @issue_title, @issue_description,
     @pipeline_ref, @mr_iid, @target_run_id, sqlc.narg('review_comments')::jsonb, true, @wait_on_limit,
     COALESCE((SELECT rp.required_capabilities FROM repos rp WHERE rp.id = @repo_id::uuid), '{}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM runs
+    WHERE repo_id = @repo_id::uuid
+      AND kind IN ('ci_fix', 'mr_rework')
+      AND pipeline_ref = @pipeline_ref
+      AND status NOT IN ('completed', 'failed', 'cancelled')
 )
 RETURNING *;

--- a/api/internal/workersvc/mr_rework.go
+++ b/api/internal/workersvc/mr_rework.go
@@ -38,15 +38,21 @@ var ErrActiveMRReworkExists = errors.New("an active MR-rework run already exists
 // explicitly (Decision 8), NOT via CreateRun's issue-comment fetch — and may be nil
 // (stored NULL).
 //
-// Two guards run before the insert:
-//   - the create-time CROSS-KIND branch guard (CountActiveBranchRunsForRef counts
-//     active ci_fix OR mr_rework runs on the same pipeline_ref) → ErrBranchInUse, so a
-//     ci_fix and an mr_rework never share one worktree (they fire on opposite CI
-//     states, so this only bites a genuine race);
-//   - the one-active-mr_rework-per-MR unique index (a second rework on the same MR →
-//     ErrActiveMRReworkExists).
+// A single atomic guard runs AS the insert: CreateAutoMRReworkRun is an
+// INSERT … WHERE NOT EXISTS whose predicate matches an active ci_fix OR mr_rework run
+// on the same pipeline_ref (Decision 6, the create-time CROSS-KIND branch guard), so a
+// ci_fix and an mr_rework never share one worktree (they fire on opposite CI states, so
+// this only bites a genuine race). It reports the branch is occupied two ways:
+//   - a committed sibling → zero rows inserted → pgx.ErrNoRows → ErrBranchInUse (the
+//     sequential path);
+//   - a concurrent-window sibling the INSERT's snapshot could not see → the durable
+//     uq_runs_one_active_branch_ref spanning index arbitrates and the losing insert
+//     raises 23505 on it → ErrBranchInUse.
 //
-// The detector swallows both and retries next tick, exactly as ci-autofix does.
+// A second active rework on the SAME MR is a distinct constraint: the
+// uq_runs_one_active_mr_rework unique index (23505 → ErrActiveMRReworkExists).
+//
+// The detector swallows all of these and retries next tick, exactly as ci-autofix does.
 func (s *Service) CreateAutoMRReworkRun(ctx context.Context, userID, repoID uuid.UUID, ref string, mrIID int64, sourceRunID uuid.UUID, title, description string, snapshot *ReviewCommentsSnapshot) (store.Run, error) {
 	// Repo-ownership / existence check, mirroring createCIFixRun so an unknown repo is
 	// a clean ErrRepoNotFound rather than an FK error at INSERT.
@@ -55,21 +61,6 @@ func (s *Service) CreateAutoMRReworkRun(ctx context.Context, userID, repoID uuid
 			return store.Run{}, ErrRepoNotFound
 		}
 		return store.Run{}, err
-	}
-
-	// Cross-kind create-time branch guard (Decision 6). pipeline_ref is populated AT
-	// INSERT for both ci_fix and mr_rework, so this count sees a freshly-created
-	// sibling — unlike the legacy runs.branch count, which is NULL for a run's whole
-	// active life.
-	active, err := s.q.CountActiveBranchRunsForRef(ctx, store.CountActiveBranchRunsForRefParams{
-		RepoID:      repoID,
-		PipelineRef: pgtype.Text{String: ref, Valid: true},
-	})
-	if err != nil {
-		return store.Run{}, err
-	}
-	if active > 0 {
-		return store.Run{}, ErrBranchInUse
 	}
 
 	// The MR review snapshot rides the create path explicitly (Decision 8). A nil
@@ -99,7 +90,18 @@ func (s *Service) CreateAutoMRReworkRun(ctx context.Context, userID, repoID uuid
 		WaitOnLimit: s.resolveWaitOnLimit(ctx, userID, nil),
 	})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// WHERE NOT EXISTS matched an active ci_fix/mr_rework sibling on this pipeline_ref:
+			// the branch is occupied. (Sequential path — a committed sibling is visible.)
+			return store.Run{}, ErrBranchInUse
+		}
+		if uniqueViolationOn(err, "uq_runs_one_active_branch_ref") {
+			// Concurrent-window race: the durable cross-kind spanning index arbitrated and
+			// this insert lost. A ci_fix (or another mr_rework) holds the branch → ErrBranchInUse.
+			return store.Run{}, ErrBranchInUse
+		}
 		if isUniqueViolation(err) {
+			// uq_runs_one_active_mr_rework: a second active rework on the same MR.
 			return store.Run{}, ErrActiveMRReworkExists
 		}
 		return store.Run{}, err

--- a/api/internal/workersvc/mr_rework.go
+++ b/api/internal/workersvc/mr_rework.go
@@ -105,7 +105,14 @@ func (s *Service) CreateAutoMRReworkRun(ctx context.Context, userID, repoID uuid
 			return store.Run{}, ErrBranchInUse
 		}
 		if isUniqueViolation(err) {
-			// uq_runs_one_active_mr_rework: a second active rework on the same MR.
+			// uq_runs_one_active_mr_rework: a second active rework on the same MR. A same-MR
+			// duplicate actually trips BOTH partial indexes at once (same MR ⇒ same
+			// pipeline_ref), so this branch is reached only because Postgres reports the
+			// violation on uq_runs_one_active_mr_rework FIRST — it is created before
+			// uq_runs_one_active_branch_ref in migration 00167 (lower OID), so the
+			// uq_runs_one_active_branch_ref check above does not match. That ordering is
+			// pinned by TestCreateAutoMRReworkRunSameMRDuplicateIsActiveExistsLiveDB; a
+			// migration that recreated the two indexes in reverse order would regress this.
 			return store.Run{}, ErrActiveMRReworkExists
 		}
 		return store.Run{}, err

--- a/api/internal/workersvc/mr_rework.go
+++ b/api/internal/workersvc/mr_rework.go
@@ -39,18 +39,22 @@ var ErrActiveMRReworkExists = errors.New("an active MR-rework run already exists
 // (stored NULL).
 //
 // A single atomic guard runs AS the insert: CreateAutoMRReworkRun is an
-// INSERT … WHERE NOT EXISTS whose predicate matches an active ci_fix OR mr_rework run
-// on the same pipeline_ref (Decision 6, the create-time CROSS-KIND branch guard), so a
-// ci_fix and an mr_rework never share one worktree (they fire on opposite CI states, so
-// this only bites a genuine race). It reports the branch is occupied two ways:
-//   - a committed sibling → zero rows inserted → pgx.ErrNoRows → ErrBranchInUse (the
+// INSERT … WHERE NOT EXISTS whose predicate matches an active ci_fix run on the same
+// pipeline_ref (Decision 6, the create-time CROSS-KIND branch guard — narrowed to the
+// cross-kind case only), so a ci_fix and an mr_rework never share one worktree (they
+// fire on opposite CI states, so this only bites a genuine race). It reports the branch
+// is occupied by the other kind two ways:
+//   - a committed ci_fix → zero rows inserted → pgx.ErrNoRows → ErrBranchInUse (the
 //     sequential path);
-//   - a concurrent-window sibling the INSERT's snapshot could not see → the durable
+//   - a concurrent-window ci_fix the INSERT's snapshot could not see → the durable
 //     uq_runs_one_active_branch_ref spanning index arbitrates and the losing insert
 //     raises 23505 on it → ErrBranchInUse.
 //
-// A second active rework on the SAME MR is a distinct constraint: the
-// uq_runs_one_active_mr_rework unique index (23505 → ErrActiveMRReworkExists).
+// A second active rework on the SAME MR is a distinct constraint: because the predicate
+// above no longer matches mr_rework, a same-MR duplicate proceeds past WHERE NOT EXISTS
+// and reaches the uq_runs_one_active_mr_rework unique index (23505 →
+// ErrActiveMRReworkExists) — previously that path was shadowed by the broader predicate,
+// which returned ErrBranchInUse for a same-MR duplicate.
 //
 // The detector swallows all of these and retries next tick, exactly as ci-autofix does.
 func (s *Service) CreateAutoMRReworkRun(ctx context.Context, userID, repoID uuid.UUID, ref string, mrIID int64, sourceRunID uuid.UUID, title, description string, snapshot *ReviewCommentsSnapshot) (store.Run, error) {
@@ -91,7 +95,7 @@ func (s *Service) CreateAutoMRReworkRun(ctx context.Context, userID, repoID uuid
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			// WHERE NOT EXISTS matched an active ci_fix/mr_rework sibling on this pipeline_ref:
+			// WHERE NOT EXISTS matched an active cross-kind ci_fix sibling on this pipeline_ref:
 			// the branch is occupied. (Sequential path — a committed sibling is visible.)
 			return store.Run{}, ErrBranchInUse
 		}

--- a/api/internal/workersvc/mr_rework_branch_guard_livedb_test.go
+++ b/api/internal/workersvc/mr_rework_branch_guard_livedb_test.go
@@ -1,0 +1,178 @@
+package workersvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// TestMRReworkBranchGuardForcedInterleaveLiveDB is the acceptance test for the create-time
+// cross-kind branch guard's CONCURRENT-WINDOW arm against a REAL Postgres. It is a
+// deterministic forced interleave (no sleep, no wall-clock assertion):
+//
+//  1. an uncommitted tx (tx1) inserts an active ci_fix on pipeline_ref=agent/issue-N,
+//     leaving an uncommitted uq_runs_one_active_branch_ref index entry;
+//  2. a goroutine calls svc.CreateAutoMRReworkRun for the SAME ref. Its atomic
+//     INSERT … WHERE NOT EXISTS runs under READ COMMITTED, so its subquery cannot see
+//     tx1's uncommitted ci_fix — WHERE NOT EXISTS is true and it proceeds to insert an
+//     mr_rework row on the same (repo_id, pipeline_ref), which BLOCKS on tx1's
+//     uncommitted spanning-index entry;
+//  3. tx1 commits — the ci_fix becomes the one active branch run and the blocked insert
+//     is arbitrated by the durable uq_runs_one_active_branch_ref index, raising 23505;
+//  4. the service maps that constraint-named 23505 to ErrBranchInUse.
+//
+// This is the acceptance criterion: against the pre-fix read-then-insert code, the losing
+// insert's generic 23505 was mapped to ErrActiveMRReworkExists, so this test FAILS before
+// the fix (uniqueViolationOn + the WHERE NOT EXISTS insert) and PASSES after it.
+//
+// The mr_iid on the mr_rework (7600) does not collide with any active mr_rework — there are
+// none — so the ONLY conflict is the branch-ref index, making the 23505 unambiguously on
+// uq_runs_one_active_branch_ref.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres (per the store
+// live-DB harness). If the goroutine never blocks within the bound the run is INVALID
+// (t.Fatalf), not a red.
+func TestMRReworkBranchGuardForcedInterleaveLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via the store live-DB harness for coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+	svc := New(q, nil, Params{})
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	// The repo-ownership check (GetRepoForUser) needs users + forge_connections + repos.
+	userID, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+	exec(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`, userID, fmt.Sprintf("bg-%s@e2e", userID))
+	exec(`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+	      VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, userID, []byte{0x1})
+	exec(`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+	      VALUES ($1, $2, 1, $3, 'https://forge.e2e/g/bg', 'main', true)`, repoID, connID, fmt.Sprintf("g/bg-%s", repoID))
+
+	// A completed source issue run with an opened MR on the branch, serving as target_run_id
+	// (runs_kind_shape requires an mr_rework to carry a non-null target_run_id).
+	const branch = "agent/issue-760"
+	sourceRunID := uuid.New()
+	exec(`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status)
+	      VALUES ($1, $2, $3, 'issue', 760, 't', 'd', $4, 7600, 'opened', 'completed')`,
+		sourceRunID, userID, repoID, branch)
+
+	// tx1: insert an active ci_fix on the SAME pipeline_ref, leaving an UNCOMMITTED
+	// uq_runs_one_active_branch_ref entry. ci_fix's shape needs repo_id + pipeline_id +
+	// pipeline_ref.
+	tx1, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx1: %v", err)
+	}
+	defer tx1.Rollback(ctx) //nolint:errcheck // no-op after Commit
+	if _, err := tx1.Exec(ctx,
+		`INSERT INTO runs (id, user_id, repo_id, kind, issue_title, issue_description, pipeline_id, pipeline_ref, status)
+		 VALUES ($1, $2, $3, 'ci_fix', 't', 'd', 4242, $4, 'running')`,
+		uuid.New(), userID, repoID, branch); err != nil {
+		t.Fatalf("tx1 insert ci_fix: %v", err)
+	}
+
+	// The goroutine's create blocks on tx1's uncommitted spanning-index entry.
+	type result struct {
+		run store.Run
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		run, err := svc.CreateAutoMRReworkRun(ctx, userID, repoID, branch, 7600, sourceRunID, "Rework MR review", "desc", nil)
+		ch <- result{run, err}
+	}()
+
+	if !waitBlockedOnCreateMRRework(ctx, t, pool) {
+		t.Fatalf("the create goroutine never blocked on a lock within 15s — interleave NOT established, this run is INVALID (not a red)")
+	}
+
+	// Commit tx1: the ci_fix is now THE one active branch run, and the blocked mr_rework
+	// insert loses to the durable index.
+	if err := tx1.Commit(ctx); err != nil {
+		t.Fatalf("commit tx1: %v", err)
+	}
+
+	r := <-ch
+	// Post-fix: the concurrent-window loser is typed ErrBranchInUse (pre-fix: this was the
+	// generic mapping's ErrActiveMRReworkExists — the bug this test pins).
+	if !errors.Is(r.err, ErrBranchInUse) {
+		t.Fatalf("concurrent-window create err = %v, want ErrBranchInUse", r.err)
+	}
+
+	// Exactly one create succeeded: the ci_fix committed via tx1. The mr_rework was
+	// refused, so no mr_rework row exists on the branch and the ci_fix is the sole active
+	// branch run.
+	var mrReworkRows int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM runs WHERE repo_id = $1 AND kind = 'mr_rework' AND pipeline_ref = $2`,
+		repoID, branch).Scan(&mrReworkRows); err != nil {
+		t.Fatalf("count mr_rework rows: %v", err)
+	}
+	if mrReworkRows != 0 {
+		t.Fatalf("mr_rework row count = %d, want 0 (the branch-in-use loser must not have inserted)", mrReworkRows)
+	}
+	var activeBranchRuns int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM runs
+		 WHERE repo_id = $1 AND pipeline_ref = $2
+		   AND kind IN ('ci_fix', 'mr_rework')
+		   AND status NOT IN ('completed', 'failed', 'cancelled')`,
+		repoID, branch).Scan(&activeBranchRuns); err != nil {
+		t.Fatalf("count active branch runs: %v", err)
+	}
+	if activeBranchRuns != 1 {
+		t.Fatalf("active branch-run count = %d, want exactly 1 (the committed ci_fix)", activeBranchRuns)
+	}
+}
+
+// waitBlockedOnCreateMRRework proves, from a THIRD connection, that the racing
+// CreateAutoMRReworkRun is parked on a lock rather than merely slow. Returns false if it
+// cannot establish that within the bound; the caller must then invalidate the run rather
+// than report a red. Mirrors store.repro106WaitBlockedOnLock.
+func waitBlockedOnCreateMRRework(ctx context.Context, t *testing.T, pool *pgxpool.Pool) bool {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		// The generated const carries its own `-- name: CreateAutoMRReworkRun :one` header,
+		// so pg_stat_activity.query identifies the waiter unambiguously.
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND state = 'active'
+			  AND wait_event_type = 'Lock'
+			  AND query LIKE '%CreateAutoMRReworkRun%'`).Scan(&n); err != nil {
+			t.Fatalf("pg_stat_activity: %v", err)
+		}
+		if n > 0 {
+			t.Logf("confirmed: %d caller(s) blocked with wait_event_type=Lock on CreateAutoMRReworkRun", n)
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/api/internal/workersvc/mr_rework_branch_guard_livedb_test.go
+++ b/api/internal/workersvc/mr_rework_branch_guard_livedb_test.go
@@ -149,6 +149,82 @@ func TestMRReworkBranchGuardForcedInterleaveLiveDB(t *testing.T) {
 	}
 }
 
+// TestCreateAutoMRReworkRunSameMRDuplicateIsActiveExistsLiveDB pins the restored contract
+// after the create-query predicate was narrowed to the CROSS-KIND case only: a repeated
+// create for the SAME merge request (same pipeline_ref = agent/issue-N, same mr_iid) must
+// fall through the WHERE NOT EXISTS guard and be rejected by the uq_runs_one_active_mr_rework
+// (repo_id, mr_iid) unique index → ErrActiveMRReworkExists, NOT the branch guard's
+// ErrBranchInUse.
+//
+// Before the fix the predicate matched kind IN ('ci_fix','mr_rework'), so the first
+// (committed) mr_rework made the second create see a same-kind sibling → zero rows →
+// pgx.ErrNoRows → ErrBranchInUse, wrongly shadowing the same-MR duplicate. This is the
+// sequential, committed-path counterpart to the concurrent-window test above; both calls
+// commit through the pool, so no goroutines or sleeps are needed.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres (per the store
+// live-DB harness).
+func TestCreateAutoMRReworkRunSameMRDuplicateIsActiveExistsLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via the store live-DB harness for coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+	svc := New(q, nil, Params{})
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	// The repo-ownership check (GetRepoForUser) needs users + forge_connections + repos.
+	userID, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+	exec(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`, userID, fmt.Sprintf("dup-%s@e2e", userID))
+	exec(`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+	      VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, userID, []byte{0x1})
+	exec(`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+	      VALUES ($1, $2, 1, $3, 'https://forge.e2e/g/dup', 'main', true)`, repoID, connID, fmt.Sprintf("g/dup-%s", repoID))
+
+	// A completed source issue run with an opened MR on the branch, serving as target_run_id
+	// (runs_kind_shape requires an mr_rework to carry a non-null target_run_id).
+	const branch = "agent/issue-760"
+	const mrIID int64 = 7600
+	sourceRunID := uuid.New()
+	exec(`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status)
+	      VALUES ($1, $2, $3, 'issue', 760, 't', 'd', $4, $5, 'opened', 'completed')`,
+		sourceRunID, userID, repoID, branch, mrIID)
+
+	// First create SUCCEEDS: no active branch run, no active rework → the WHERE NOT EXISTS
+	// guard passes and the row inserts.
+	run, err := svc.CreateAutoMRReworkRun(ctx, userID, repoID, branch, mrIID, sourceRunID, "Rework MR review", "desc", nil)
+	if err != nil {
+		t.Fatalf("first CreateAutoMRReworkRun err = %v, want success", err)
+	}
+	if run.Kind != RunKindMRRework {
+		t.Fatalf("first run.Kind = %q, want %q", run.Kind, RunKindMRRework)
+	}
+
+	// Second create for the SAME branch + SAME mr_iid: the narrowed predicate no longer
+	// matches the committed mr_rework, so this proceeds past WHERE NOT EXISTS and is rejected
+	// by uq_runs_one_active_mr_rework (repo_id, mr_iid) → ErrActiveMRReworkExists (NOT
+	// ErrBranchInUse, which was the pre-fix behavior).
+	_, err = svc.CreateAutoMRReworkRun(ctx, userID, repoID, branch, mrIID, sourceRunID, "Rework MR review", "desc", nil)
+	if !errors.Is(err, ErrActiveMRReworkExists) {
+		t.Fatalf("same-MR duplicate create err = %v, want ErrActiveMRReworkExists", err)
+	}
+}
+
 // waitBlockedOnCreateMRRework proves, from a THIRD connection, that the racing
 // CreateAutoMRReworkRun is parked on a lock rather than merely slow. Returns false if it
 // cannot establish that within the bound; the caller must then invalidate the run rather

--- a/api/internal/workersvc/mr_rework_test.go
+++ b/api/internal/workersvc/mr_rework_test.go
@@ -69,20 +69,34 @@ func TestCreateAutoMRReworkRunNilSnapshotStoresNull(t *testing.T) {
 }
 
 func TestCreateAutoMRReworkRunRefusesBranchInUse(t *testing.T) {
-	// The create-time CROSS-KIND branch guard: an active ci_fix OR mr_rework run on the
-	// ref's pipeline_ref blocks the create with ErrBranchInUse (the detector swallows it).
-	fs := &fakeStore{repoRow: aValidRepoRow(), activeBranchRefRuns: 1}
+	// The create-time CROSS-KIND branch guard is now the create query's own atomic
+	// INSERT … WHERE NOT EXISTS. When a committed active ci_fix OR mr_rework sibling
+	// occupies the ref's pipeline_ref, the insert matches zero rows and the generated
+	// :one returns pgx.ErrNoRows, which the service maps to ErrBranchInUse (the detector
+	// swallows it). The insert now RUNS (the old "block before the insert" no longer holds).
+	fs := &fakeStore{repoRow: aValidRepoRow(), mrReworkRunErr: pgx.ErrNoRows}
 	svc := New(fs, newBox(t), testParams())
 	if _, err := svc.CreateAutoMRReworkRun(context.Background(), uuid.New(), uuid.New(), "agent/issue-9", 9, uuid.New(), "t", "d", sampleReviewSnapshot()); err != ErrBranchInUse {
 		t.Fatalf("err = %v, want ErrBranchInUse", err)
 	}
-	if fs.mrReworkRunParams != nil {
-		t.Fatal("the branch guard must block BEFORE the insert")
+}
+
+func TestCreateAutoMRReworkRunBranchRefConflictIsBranchInUse(t *testing.T) {
+	// Concurrent-window race: the atomic INSERT's snapshot could not see a racing sibling,
+	// so it slipped past WHERE NOT EXISTS and the durable spanning index arbitrated —
+	// raising 23505 on uq_runs_one_active_branch_ref. That maps to ErrBranchInUse, NOT
+	// ErrActiveMRReworkExists (the pre-fix generic mapping got this wrong).
+	fs := &fakeStore{repoRow: aValidRepoRow(), mrReworkRunErr: &pgconn.PgError{Code: "23505", ConstraintName: "uq_runs_one_active_branch_ref"}}
+	svc := New(fs, newBox(t), testParams())
+	if _, err := svc.CreateAutoMRReworkRun(context.Background(), uuid.New(), uuid.New(), "agent/issue-9", 9, uuid.New(), "t", "d", sampleReviewSnapshot()); err != ErrBranchInUse {
+		t.Fatalf("err = %v, want ErrBranchInUse", err)
 	}
 }
 
 func TestCreateAutoMRReworkRunMapsDuplicate(t *testing.T) {
-	fs := &fakeStore{repoRow: aValidRepoRow(), mrReworkRunErr: &pgconn.PgError{Code: "23505"}}
+	// A 23505 on uq_runs_one_active_mr_rework — a second active rework on the same MR —
+	// maps to ErrActiveMRReworkExists.
+	fs := &fakeStore{repoRow: aValidRepoRow(), mrReworkRunErr: &pgconn.PgError{Code: "23505", ConstraintName: "uq_runs_one_active_mr_rework"}}
 	svc := New(fs, newBox(t), testParams())
 	if _, err := svc.CreateAutoMRReworkRun(context.Background(), uuid.New(), uuid.New(), "agent/issue-7", 55, uuid.New(), "t", "d", sampleReviewSnapshot()); err != ErrActiveMRReworkExists {
 		t.Fatalf("err = %v, want ErrActiveMRReworkExists", err)

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -310,7 +310,6 @@ type Store interface {
 	// MR review-watcher rework runs (PRD #700 M3): the create path + its create-time
 	// cross-kind branch guard.
 	CreateAutoMRReworkRun(ctx context.Context, arg store.CreateAutoMRReworkRunParams) (store.Run, error)
-	CountActiveBranchRunsForRef(ctx context.Context, arg store.CountActiveBranchRunsForRefParams) (int64, error)
 	// Self-improvement runs (PRD #46 Decision 10).
 	CreateSelfImproveRun(ctx context.Context, arg store.CreateSelfImproveRunParams) (store.Run, error)
 	// Scheduled prompt runs (PRD #241).
@@ -6405,4 +6404,10 @@ func coalesceInt(v pgtype.Int4, def int) int {
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// uniqueViolationOn reports whether err is a Postgres 23505 raised on the named constraint.
+func uniqueViolationOn(err error, constraint string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == constraint
 }

--- a/api/internal/workersvc/service_test.go
+++ b/api/internal/workersvc/service_test.go
@@ -344,12 +344,12 @@ type fakeStore struct {
 	ciFixRunParams *store.CreateCIFixRunParams
 
 	// MR review-watcher rework (PRD #700 M3). mrReworkRunParams stays nil until the
-	// insert runs, so the cross-kind branch guard can be asserted to block before it.
-	// activeBranchRefRuns drives CountActiveBranchRunsForRef (the cross-kind guard).
-	mrReworkRunResult   store.Run
-	mrReworkRunErr      error
-	mrReworkRunParams   *store.CreateAutoMRReworkRunParams
-	activeBranchRefRuns int64
+	// insert runs; the create-time cross-kind branch guard is now the create query's own
+	// atomic INSERT … WHERE NOT EXISTS, so mrReworkRunErr models its outcomes
+	// (pgx.ErrNoRows or a 23505 on uq_runs_one_active_branch_ref → ErrBranchInUse).
+	mrReworkRunResult store.Run
+	mrReworkRunErr    error
+	mrReworkRunParams *store.CreateAutoMRReworkRunParams
 
 	// Scheduled prompt (PRD #241). promptRunParams stays nil until CreatePromptRun's
 	// insert runs, so a #66 guardrail test can assert the gate blocked before the insert.
@@ -1074,9 +1074,6 @@ func (f *fakeStore) CreateCIFixRun(_ context.Context, arg store.CreateCIFixRunPa
 func (f *fakeStore) CreateAutoMRReworkRun(_ context.Context, arg store.CreateAutoMRReworkRunParams) (store.Run, error) {
 	f.mrReworkRunParams = &arg
 	return f.mrReworkRunResult, f.mrReworkRunErr
-}
-func (f *fakeStore) CountActiveBranchRunsForRef(context.Context, store.CountActiveBranchRunsForRefParams) (int64, error) {
-	return f.activeBranchRefRuns, nil
 }
 func (f *fakeStore) CreatePromptRun(_ context.Context, arg store.CreatePromptRunParams) (store.Run, error) {
 	f.promptRunParams = &arg


### PR DESCRIPTION
Implements issue #760.

Closes #760

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-760`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch conflict handling when creating MR rework runs.
  * Prevented conflicting runs from being created during simultaneous requests.
  * Preserved distinct errors for branch conflicts and duplicate active MR rework runs.
  * Ensured conflicts with active CI fix runs are detected correctly without misclassifying duplicate MR rework requests.

* **Tests**
  * Added coverage for cross-kind branch conflicts, duplicate requests, and concurrent creation scenarios.
  * Updated validation to confirm accurate conflict results and active-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->