### PR TITLE
GitHub review-thread + comment fetch truncates at 100 (add GraphQL cursor pagination)

### DIFF
--- a/api/internal/forge/github.go
+++ b/api/internal/forge/github.go
@@ -914,56 +914,156 @@ func (g *github) ListMergeRequestComments(ctx context.Context, projectID, mrIID 
 // map from each thread comment's REST databaseId to the thread's node id — the
 // join key ListMergeRequestComments uses to attach a resolve anchor to a REST
 // inline comment (Resolved facts). It reuses the driver's graphqlDo helper (auth +
-// endpoint + redaction), never a hand-rolled POST.
+// endpoint + redaction), never a hand-rolled POST. It pages BOTH connections: the
+// outer reviewThreads cursor here, and — for any thread with more than one page of
+// comments — the inner comments cursor via reviewThreadCommentDBIDs, so neither a
+// PR with >100 review threads nor a thread with >100 comments silently drops a
+// ResolveID anchor. Both loops are backstopped by maxForgeItems/maxForgePages.
 func (g *github) reviewThreadIDsByDatabaseID(ctx context.Context, slug repoSlug, number int) (map[int64]string, error) {
-	const query = `query($owner: String!, $name: String!, $number: Int!) {
+	const query = `query($owner: String!, $name: String!, $number: Int!, $threadCursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $threadCursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
-          isResolved
-          isOutdated
-          path
-          line
-          comments(first: 100) { nodes { databaseId } }
+          comments(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes { databaseId }
+          }
         }
       }
     }
   }
 }`
-	var out struct {
-		Repository struct {
-			PullRequest struct {
-				ReviewThreads struct {
-					Nodes []struct {
-						ID       string `json:"id"`
-						Comments struct {
-							Nodes []struct {
-								DatabaseID int64 `json:"databaseId"`
-							} `json:"nodes"`
-						} `json:"comments"`
-					} `json:"nodes"`
-				} `json:"reviewThreads"`
-			} `json:"pullRequest"`
-		} `json:"repository"`
-	}
-	vars := map[string]any{"owner": slug.owner, "name": slug.repo, "number": number}
-	if err := g.graphqlDo(ctx, query, vars, &out); err != nil {
-		return nil, err
-	}
 	m := map[int64]string{}
-	for _, node := range out.Repository.PullRequest.ReviewThreads.Nodes {
-		if node.ID == "" {
-			continue
+	var threadCursor *string
+	page := 0
+	for {
+		page++
+		var resp struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+						Nodes []struct {
+							ID       string `json:"id"`
+							Comments struct {
+								PageInfo struct {
+									HasNextPage bool   `json:"hasNextPage"`
+									EndCursor   string `json:"endCursor"`
+								} `json:"pageInfo"`
+								Nodes []struct {
+									DatabaseID int64 `json:"databaseId"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
 		}
-		for _, cn := range node.Comments.Nodes {
-			if cn.DatabaseID != 0 {
-				m[cn.DatabaseID] = node.ID
+		vars := map[string]any{"owner": slug.owner, "name": slug.repo, "number": number}
+		if threadCursor != nil {
+			vars["threadCursor"] = *threadCursor
+		} else {
+			vars["threadCursor"] = nil
+		}
+		if err := g.graphqlDo(ctx, query, vars, &resp); err != nil {
+			return nil, err
+		}
+		for _, node := range resp.Repository.PullRequest.ReviewThreads.Nodes {
+			if node.ID == "" {
+				continue
+			}
+			for _, cn := range node.Comments.Nodes {
+				if cn.DatabaseID != 0 {
+					m[cn.DatabaseID] = node.ID
+				}
+			}
+			if node.Comments.PageInfo.HasNextPage {
+				rest, err := g.reviewThreadCommentDBIDs(ctx, node.ID, node.Comments.PageInfo.EndCursor)
+				if err != nil {
+					return nil, err
+				}
+				for _, dbID := range rest {
+					if dbID != 0 {
+						m[dbID] = node.ID
+					}
+				}
 			}
 		}
+		if len(m) > maxForgeItems {
+			return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
+		}
+		if !resp.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage || resp.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor == "" {
+			break
+		}
+		if page >= maxForgePages {
+			return nil, g.redact.error(forgePaginationCapErr("page", maxForgePages))
+		}
+		next := resp.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor
+		threadCursor = &next
 	}
 	return m, nil
+}
+
+// reviewThreadCommentDBIDs pages the remaining comment databaseIds of one review
+// thread past the first page the outer reviewThreads query already returned. GitHub
+// cannot advance a nested connection cursor from the outer query, so it re-fetches
+// the thread node by id and walks its comments connection from afterCursor (the
+// outer page's comments.endCursor). It reuses graphqlDo and is backstopped by
+// maxForgePages exactly as the outer loop.
+func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCursor string) ([]int64, error) {
+	const query = `query($threadId: ID!, $commentCursor: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $commentCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { databaseId }
+      }
+    }
+  }
+}`
+	var out []int64
+	cursor := afterCursor
+	page := 0
+	for {
+		page++
+		var resp struct {
+			Node struct {
+				Comments struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+					Nodes []struct {
+						DatabaseID int64 `json:"databaseId"`
+					} `json:"nodes"`
+				} `json:"comments"`
+			} `json:"node"`
+		}
+		vars := map[string]any{"threadId": threadID, "commentCursor": cursor}
+		if err := g.graphqlDo(ctx, query, vars, &resp); err != nil {
+			return nil, err
+		}
+		for _, cn := range resp.Node.Comments.Nodes {
+			out = append(out, cn.DatabaseID)
+		}
+		if len(out) > maxForgeItems {
+			return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
+		}
+		if !resp.Node.Comments.PageInfo.HasNextPage || resp.Node.Comments.PageInfo.EndCursor == "" {
+			break
+		}
+		if page >= maxForgePages {
+			return nil, g.redact.error(forgePaginationCapErr("page", maxForgePages))
+		}
+		cursor = resp.Node.Comments.PageInfo.EndCursor
+	}
+	return out, nil
 }
 
 // ReplyMergeRequestComment posts an in-thread reply keyed on replyID, the REST

--- a/api/internal/forge/github.go
+++ b/api/internal/forge/github.go
@@ -983,20 +983,27 @@ func (g *github) reviewThreadIDsByDatabaseID(ctx context.Context, slug repoSlug,
 					m[cn.DatabaseID] = node.ID
 				}
 			}
+			// Enforce the item cap PER THREAD, not once per outer page: without this
+			// a single reviewThreads page of up to 100 threads could each fan out to
+			// reviewThreadCommentDBIDs and accumulate before the bound fired,
+			// amplifying the maxForgeItems ceiling by the page size.
+			if len(m) > maxForgeItems {
+				return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
+			}
 			if node.Comments.PageInfo.HasNextPage {
-				rest, err := g.reviewThreadCommentDBIDs(ctx, node.ID, node.Comments.PageInfo.EndCursor)
+				// Bound the inner fan-out by the GLOBAL remaining budget so one
+				// thread's overflow cannot exceed maxForgeItems either.
+				rest, err := g.reviewThreadCommentDBIDs(ctx, node.ID, node.Comments.PageInfo.EndCursor, maxForgeItems-len(m))
 				if err != nil {
 					return nil, err
 				}
 				for _, dbID := range rest {
-					if dbID != 0 {
-						m[dbID] = node.ID
-					}
+					m[dbID] = node.ID
+				}
+				if len(m) > maxForgeItems {
+					return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
 				}
 			}
-		}
-		if len(m) > maxForgeItems {
-			return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
 		}
 		if !resp.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage || resp.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor == "" {
 			break
@@ -1015,8 +1022,10 @@ func (g *github) reviewThreadIDsByDatabaseID(ctx context.Context, slug repoSlug,
 // cannot advance a nested connection cursor from the outer query, so it re-fetches
 // the thread node by id and walks its comments connection from afterCursor (the
 // outer page's comments.endCursor). It reuses graphqlDo and is backstopped by
-// maxForgePages exactly as the outer loop.
-func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCursor string) ([]int64, error) {
+// maxForgePages exactly as the outer loop; budget is the caller's remaining global
+// item allowance, so one thread's comment fan-out cannot push the total past
+// maxForgeItems.
+func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCursor string, budget int) ([]int64, error) {
 	const query = `query($threadId: ID!, $commentCursor: String) {
   node(id: $threadId) {
     ... on PullRequestReviewThread {
@@ -1050,9 +1059,11 @@ func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCu
 			return nil, err
 		}
 		for _, cn := range resp.Node.Comments.Nodes {
-			out = append(out, cn.DatabaseID)
+			if cn.DatabaseID != 0 {
+				out = append(out, cn.DatabaseID)
+			}
 		}
-		if len(out) > maxForgeItems {
+		if len(out) > budget {
 			return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
 		}
 		if !resp.Node.Comments.PageInfo.HasNextPage || resp.Node.Comments.PageInfo.EndCursor == "" {

--- a/api/internal/forge/github.go
+++ b/api/internal/forge/github.go
@@ -939,6 +939,12 @@ func (g *github) reviewThreadIDsByDatabaseID(ctx context.Context, slug repoSlug,
 	m := map[int64]string{}
 	var threadCursor *string
 	page := 0
+	// fetched counts every comment NODE returned (including databaseId==0 and
+	// duplicate ids), accumulated across outer pages — not the deduplicated map
+	// size. The cap must key off nodes actually fetched, because a single outer
+	// page carrying duplicate or zero databaseIds can pull far more than
+	// maxForgeItems nodes while len(m) stays under the ceiling.
+	fetched := 0
 	for {
 		page++
 		var resp struct {
@@ -979,28 +985,34 @@ func (g *github) reviewThreadIDsByDatabaseID(ctx context.Context, slug repoSlug,
 				continue
 			}
 			for _, cn := range node.Comments.Nodes {
+				fetched++
 				if cn.DatabaseID != 0 {
 					m[cn.DatabaseID] = node.ID
 				}
 			}
-			// Enforce the item cap PER THREAD, not once per outer page: without this
-			// a single reviewThreads page of up to 100 threads could each fan out to
+			// Enforce the item cap PER THREAD, not once per outer page, and key it
+			// off FETCHED comment nodes (duplicate and zero databaseIds included),
+			// not the deduplicated map size: without this a single reviewThreads
+			// page of up to 100 threads could each fan out to
 			// reviewThreadCommentDBIDs and accumulate before the bound fired,
-			// amplifying the maxForgeItems ceiling by the page size.
-			if len(m) > maxForgeItems {
+			// amplifying the maxForgeItems ceiling by the page size, and duplicate
+			// or zero ids collapsing in the map could keep len(m) under the cap
+			// while far more nodes were actually fetched.
+			if fetched > maxForgeItems {
 				return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
 			}
 			if node.Comments.PageInfo.HasNextPage {
 				// Bound the inner fan-out by the GLOBAL remaining budget so one
 				// thread's overflow cannot exceed maxForgeItems either.
-				rest, err := g.reviewThreadCommentDBIDs(ctx, node.ID, node.Comments.PageInfo.EndCursor, maxForgeItems-len(m))
+				rest, restFetched, err := g.reviewThreadCommentDBIDs(ctx, node.ID, node.Comments.PageInfo.EndCursor, maxForgeItems-fetched)
 				if err != nil {
 					return nil, err
 				}
 				for _, dbID := range rest {
 					m[dbID] = node.ID
 				}
-				if len(m) > maxForgeItems {
+				fetched += restFetched
+				if fetched > maxForgeItems {
 					return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
 				}
 			}
@@ -1024,8 +1036,11 @@ func (g *github) reviewThreadIDsByDatabaseID(ctx context.Context, slug repoSlug,
 // outer page's comments.endCursor). It reuses graphqlDo and is backstopped by
 // maxForgePages exactly as the outer loop; budget is the caller's remaining global
 // item allowance, so one thread's comment fan-out cannot push the total past
-// maxForgeItems.
-func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCursor string, budget int) ([]int64, error) {
+// maxForgeItems. It counts every comment NODE fetched (duplicate and zero
+// databaseIds included) against budget — not distinct ids — and returns that
+// fetched-node count as its second return so the caller can accumulate it into the
+// outer per-page fetched total.
+func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCursor string, budget int) ([]int64, int, error) {
 	const query = `query($threadId: ID!, $commentCursor: String) {
   node(id: $threadId) {
     ... on PullRequestReviewThread {
@@ -1039,6 +1054,7 @@ func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCu
 	var out []int64
 	cursor := afterCursor
 	page := 0
+	fetched := 0
 	for {
 		page++
 		var resp struct {
@@ -1056,25 +1072,26 @@ func (g *github) reviewThreadCommentDBIDs(ctx context.Context, threadID, afterCu
 		}
 		vars := map[string]any{"threadId": threadID, "commentCursor": cursor}
 		if err := g.graphqlDo(ctx, query, vars, &resp); err != nil {
-			return nil, err
+			return nil, fetched, err
 		}
 		for _, cn := range resp.Node.Comments.Nodes {
+			fetched++
 			if cn.DatabaseID != 0 {
 				out = append(out, cn.DatabaseID)
 			}
 		}
-		if len(out) > budget {
-			return nil, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
+		if fetched > budget {
+			return nil, fetched, g.redact.error(forgePaginationCapErr("item", maxForgeItems))
 		}
 		if !resp.Node.Comments.PageInfo.HasNextPage || resp.Node.Comments.PageInfo.EndCursor == "" {
 			break
 		}
 		if page >= maxForgePages {
-			return nil, g.redact.error(forgePaginationCapErr("page", maxForgePages))
+			return nil, fetched, g.redact.error(forgePaginationCapErr("page", maxForgePages))
 		}
 		cursor = resp.Node.Comments.PageInfo.EndCursor
 	}
-	return out, nil
+	return out, fetched, nil
 }
 
 // ReplyMergeRequestComment posts an in-thread reply keyed on replyID, the REST

--- a/api/internal/forge/mr_comments_test.go
+++ b/api/internal/forge/mr_comments_test.go
@@ -239,6 +239,88 @@ func TestGitHubListMergeRequestComments(t *testing.T) {
 	}
 }
 
+// TestGitHubReviewThreadPaginationSpansMultiplePages pins that
+// reviewThreadIDsByDatabaseID pages BOTH GraphQL connections: the outer
+// reviewThreads cursor AND, for a thread whose first comment page is not the last,
+// the inner comments cursor via the node(id:) re-fetch helper. The cursor-aware
+// mock serves outer page 1 (thread T1 with more comments to come), outer page 2
+// (thread T2), and inner page 2 for T1. Against the pre-fix single-page code — which
+// sends no threadCursor and never issues the node() query — 201 (outer page 2) and
+// 102 (inner page 2 of T1) never enter the map, so this fails; after the fix all
+// three anchors are present.
+func TestGitHubReviewThreadPaginationSpansMultiplePages(t *testing.T) {
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		graphqlRoute: func(w http.ResponseWriter, r *http.Request) {
+			req := readGQL(t, r)
+			threadCursor, _ := req.Variables["threadCursor"].(string)
+			switch {
+			case strings.Contains(req.Query, "reviewThreads") && threadCursor == "":
+				// Outer page 1: T1, whose comments have a next page.
+				writeGQLData(w, map[string]any{
+					"repository": map[string]any{
+						"pullRequest": map[string]any{
+							"reviewThreads": map[string]any{
+								"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "TCUR1"},
+								"nodes": []map[string]any{
+									{"id": "T1", "comments": map[string]any{
+										"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "CCUR1"},
+										"nodes":    []map[string]any{{"databaseId": 101}},
+									}},
+								},
+							},
+						},
+					},
+				})
+			case strings.Contains(req.Query, "reviewThreads") && threadCursor == "TCUR1":
+				// Outer page 2: T2, single comment page.
+				writeGQLData(w, map[string]any{
+					"repository": map[string]any{
+						"pullRequest": map[string]any{
+							"reviewThreads": map[string]any{
+								"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+								"nodes": []map[string]any{
+									{"id": "T2", "comments": map[string]any{
+										"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+										"nodes":    []map[string]any{{"databaseId": 201}},
+									}},
+								},
+							},
+						},
+					},
+				})
+			case strings.Contains(req.Query, "node(") &&
+				req.Variables["threadId"] == "T1" && req.Variables["commentCursor"] == "CCUR1":
+				// Inner page 2 for T1.
+				writeGQLData(w, map[string]any{
+					"node": map[string]any{
+						"comments": map[string]any{
+							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+							"nodes":    []map[string]any{{"databaseId": 102}},
+						},
+					},
+				})
+			default:
+				t.Fatalf("unexpected graphql request: query=%q vars=%+v", req.Query, req.Variables)
+			}
+		},
+	})
+	d := newGitHubRawDriver(t, m, "ghp_classicTokenValue1234567890")
+
+	got, err := d.reviewThreadIDsByDatabaseID(context.Background(), repoSlug{owner: "acme", repo: "widgets"}, 13)
+	if err != nil {
+		t.Fatalf("reviewThreadIDsByDatabaseID: %v", err)
+	}
+	if got[101] != "T1" {
+		t.Errorf("m[101] = %q, want T1 (outer page-1 comment)", got[101])
+	}
+	if got[201] != "T2" {
+		t.Errorf("m[201] = %q, want T2 (outer page-2 thread dropped without thread pagination)", got[201])
+	}
+	if got[102] != "T1" {
+		t.Errorf("m[102] = %q, want T1 (inner page-2 comment dropped without comment pagination)", got[102])
+	}
+}
+
 // TestGitHubReplyMergeRequestComment pins the reply keyed on the REST databaseId
 // (the reply anchor): CreateCommentInReplyTo POSTs with in_reply_to set.
 func TestGitHubReplyMergeRequestComment(t *testing.T) {

--- a/api/internal/forge/mr_comments_test.go
+++ b/api/internal/forge/mr_comments_test.go
@@ -391,6 +391,70 @@ func TestGitHubReviewThreadInnerFanOutRespectsGlobalItemCap(t *testing.T) {
 	}
 }
 
+// TestGitHubReviewThreadOuterPageCountsFetchedNodes pins that the OUTER per-page
+// item cap keys off the number of comment NODES actually fetched, not the size of
+// the deduplicated map. A SINGLE outer reviewThreads page carries two threads whose
+// comments DUPLICATE ids across the threads (T1: 101,102; T2: 101,102) plus a
+// databaseId==0 node — 5 fetched nodes — while the distinct map holds only {101,102}
+// (2 entries). With maxForgeItems=3 the fetched count (5) exceeds the cap but the
+// distinct map (2) does not, so the pre-fix `len(m) > maxForgeItems` check never
+// fires and no error is returned (the test would be vacuous against that code).
+// Only counting fetched nodes catches it, which is exactly the fix. No inner
+// fan-out: every thread advertises hasNextPage:false so this stays focused on the
+// outer per-page fetched-node accounting. Lowers maxForgeItems, restored in a defer.
+func TestGitHubReviewThreadOuterPageCountsFetchedNodes(t *testing.T) {
+	defer func(o int) { maxForgeItems = o }(maxForgeItems)
+	maxForgeItems = 3
+
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		graphqlRoute: func(w http.ResponseWriter, r *http.Request) {
+			req := readGQL(t, r)
+			switch {
+			case strings.Contains(req.Query, "reviewThreads"):
+				// One outer page, two threads with DUPLICATE ids across them plus a
+				// zero-id node: 5 fetched nodes, distinct map only {101,102}.
+				writeGQLData(w, map[string]any{
+					"repository": map[string]any{
+						"pullRequest": map[string]any{
+							"reviewThreads": map[string]any{
+								"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+								"nodes": []map[string]any{
+									{"id": "T1", "comments": map[string]any{
+										"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+										"nodes": []map[string]any{
+											{"databaseId": 101}, {"databaseId": 102}, {"databaseId": 0},
+										},
+									}},
+									{"id": "T2", "comments": map[string]any{
+										"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+										"nodes": []map[string]any{
+											{"databaseId": 101}, {"databaseId": 102},
+										},
+									}},
+								},
+							},
+						},
+					},
+				})
+			default:
+				t.Fatalf("unexpected graphql request: query=%q vars=%+v", req.Query, req.Variables)
+			}
+		},
+	})
+	d := newGitHubRawDriver(t, m, "ghp_classicTokenValue1234567890")
+
+	got, err := d.reviewThreadIDsByDatabaseID(context.Background(), repoSlug{owner: "acme", repo: "widgets"}, 13)
+	if err == nil {
+		t.Fatalf("expected an item-cap error from the outer per-page fetched-node count, got nil (returned %d anchors)", len(got))
+	}
+	if got != nil {
+		t.Errorf("on backstop-exceed the driver must return a nil map, not a partial one (got %d)", len(got))
+	}
+	if !strings.Contains(err.Error(), "backstop") {
+		t.Errorf("error must name the backstop, got %q", err.Error())
+	}
+}
+
 // TestGitHubReplyMergeRequestComment pins the reply keyed on the REST databaseId
 // (the reply anchor): CreateCommentInReplyTo POSTs with in_reply_to set.
 func TestGitHubReplyMergeRequestComment(t *testing.T) {

--- a/api/internal/forge/mr_comments_test.go
+++ b/api/internal/forge/mr_comments_test.go
@@ -322,11 +322,16 @@ func TestGitHubReviewThreadPaginationSpansMultiplePages(t *testing.T) {
 }
 
 // TestGitHubReviewThreadInnerFanOutRespectsGlobalItemCap pins that a single
-// thread's comment fan-out cannot push the accumulated map past maxForgeItems: the
-// per-thread budget passed into reviewThreadCommentDBIDs trips the shared backstop
-// rather than letting the inner loop accumulate a fresh maxForgeItems on top of the
-// outer page. Without the budget, a hostile/buggy forge could amplify the ceiling by
-// the outer page size. Lowers maxForgeItems and restores it in a defer.
+// thread's comment fan-out cannot push the FETCHED item count past maxForgeItems:
+// the per-thread budget passed into reviewThreadCommentDBIDs trips the shared
+// backstop rather than letting the inner loop accumulate a fresh maxForgeItems on
+// top of the outer page. The inner page returns ids that DUPLICATE page-1 on
+// purpose: the distinct map stays at 3, so the outer per-thread `len(m) >
+// maxForgeItems` check does NOT fire — only the budget bound (which counts fetched
+// items) can catch this, which is exactly the mechanism this hardening adds. A
+// non-duplicate id here would also trip the distinct-map check and make the test
+// pass against the pre-hardening code (vacuous). Lowers maxForgeItems, restored in a
+// defer.
 func TestGitHubReviewThreadInnerFanOutRespectsGlobalItemCap(t *testing.T) {
 	defer func(o int) { maxForgeItems = o }(maxForgeItems)
 	maxForgeItems = 3
@@ -356,12 +361,14 @@ func TestGitHubReviewThreadInnerFanOutRespectsGlobalItemCap(t *testing.T) {
 					},
 				})
 			case strings.Contains(req.Query, "node("):
-				// Inner page: one more comment beyond the now-zero remaining budget.
+				// Inner page: comments beyond the now-zero remaining budget, but
+				// DUPLICATING page-1 ids so the distinct map never grows — only the
+				// fetched-count budget bound can catch this.
 				writeGQLData(w, map[string]any{
 					"node": map[string]any{
 						"comments": map[string]any{
 							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
-							"nodes":    []map[string]any{{"databaseId": 104}},
+							"nodes":    []map[string]any{{"databaseId": 101}, {"databaseId": 102}},
 						},
 					},
 				})

--- a/api/internal/forge/mr_comments_test.go
+++ b/api/internal/forge/mr_comments_test.go
@@ -321,6 +321,69 @@ func TestGitHubReviewThreadPaginationSpansMultiplePages(t *testing.T) {
 	}
 }
 
+// TestGitHubReviewThreadInnerFanOutRespectsGlobalItemCap pins that a single
+// thread's comment fan-out cannot push the accumulated map past maxForgeItems: the
+// per-thread budget passed into reviewThreadCommentDBIDs trips the shared backstop
+// rather than letting the inner loop accumulate a fresh maxForgeItems on top of the
+// outer page. Without the budget, a hostile/buggy forge could amplify the ceiling by
+// the outer page size. Lowers maxForgeItems and restores it in a defer.
+func TestGitHubReviewThreadInnerFanOutRespectsGlobalItemCap(t *testing.T) {
+	defer func(o int) { maxForgeItems = o }(maxForgeItems)
+	maxForgeItems = 3
+
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		graphqlRoute: func(w http.ResponseWriter, r *http.Request) {
+			req := readGQL(t, r)
+			switch {
+			case strings.Contains(req.Query, "reviewThreads"):
+				// Single outer page: T1's page-1 comments exactly fill the budget
+				// (3), and it advertises more comments to fan out into.
+				writeGQLData(w, map[string]any{
+					"repository": map[string]any{
+						"pullRequest": map[string]any{
+							"reviewThreads": map[string]any{
+								"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+								"nodes": []map[string]any{
+									{"id": "T1", "comments": map[string]any{
+										"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "CCUR1"},
+										"nodes": []map[string]any{
+											{"databaseId": 101}, {"databaseId": 102}, {"databaseId": 103},
+										},
+									}},
+								},
+							},
+						},
+					},
+				})
+			case strings.Contains(req.Query, "node("):
+				// Inner page: one more comment beyond the now-zero remaining budget.
+				writeGQLData(w, map[string]any{
+					"node": map[string]any{
+						"comments": map[string]any{
+							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+							"nodes":    []map[string]any{{"databaseId": 104}},
+						},
+					},
+				})
+			default:
+				t.Fatalf("unexpected graphql request: query=%q vars=%+v", req.Query, req.Variables)
+			}
+		},
+	})
+	d := newGitHubRawDriver(t, m, "ghp_classicTokenValue1234567890")
+
+	got, err := d.reviewThreadIDsByDatabaseID(context.Background(), repoSlug{owner: "acme", repo: "widgets"}, 13)
+	if err == nil {
+		t.Fatalf("expected an item-cap error from the inner fan-out, got nil (returned %d anchors)", len(got))
+	}
+	if got != nil {
+		t.Errorf("on backstop-exceed the driver must return a nil map, not a partial one (got %d)", len(got))
+	}
+	if !strings.Contains(err.Error(), "backstop") {
+		t.Errorf("error must name the backstop, got %q", err.Error())
+	}
+}
+
 // TestGitHubReplyMergeRequestComment pins the reply keyed on the REST databaseId
 // (the reply anchor): CreateCommentInReplyTo POSTs with in_reply_to set.
 func TestGitHubReplyMergeRequestComment(t *testing.T) {


### PR DESCRIPTION
Implements issue #761.

Closes #761

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-761`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub review-thread retrieval across multiple pages of threads and comments.
  * Corrected pagination limits to account for every fetched comment, including duplicate or missing identifiers.
  * Added safeguards to stop excessive data retrieval and prevent incomplete thread mappings.
  * Improved handling of pagination and API errors while protecting sensitive error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->