### PR TITLE
uzi handoff (PRD #400) v1.1 hardening: 7 follow-up findings from #401 review

### DIFF
--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -1133,11 +1133,15 @@ export class GitCache {
 
   /**
    * The unified diff of the reviewed `branch` against `base` (three-dot: the changes on
-   * `branch` since it diverged from `base`), for a PRD #400 M4b diff-review run. Both refs
-   * are resolved as the bare's remote-tracking refs (`refs/remotes/origin/<name>`, which
-   * every fetch updates — the same namespace `changedFiles` reads), so the caller must have
-   * fetched the bare (ensureClone) first; the reviewed task branch and its base are both
-   * pushed to origin (M2), so both exist there.
+   * `branch` since it diverged from `base`), for a PRD #400 M4b diff-review run. `branch` is
+   * resolved as the bare's remote-tracking ref (`refs/remotes/origin/<name>`, which every
+   * fetch updates — the same namespace `changedFiles` reads), so the caller must have
+   * fetched the bare (ensureClone) first; the reviewed task branch is pushed to origin (M2),
+   * so it exists there. `base` may be EITHER a branch name (resolved the same way, under
+   * `refs/remotes/origin/`) OR a commit-ish — the seed commit sha a handoff records as its
+   * base when created without --base (issue #403 F3), which does not exist under
+   * `refs/remotes/origin/` but is present in the mirror as an ancestor of the reviewed
+   * branch.
    *
    * The result is CAPPED at REVIEW_DIFF_MAX_BYTES with a truncation marker: a pathological
    * diff must not blow the reviewer model's context or the worker's memory. `--no-color`
@@ -1147,7 +1151,13 @@ export class GitCache {
    * `--name-only`; a real patch must disable it explicitly.
    */
   async reviewDiff(barePath: string, base: string, branch: string): Promise<string> {
-    const baseRef = `refs/remotes/origin/${base}`;
+    // issue #403 F3: `base` is usually a branch name (resolved under refs/remotes/origin/), but a
+    // handoff created without --base records the SEED COMMIT sha as its base so the review diffs
+    // only the worker's commits, not the user's seeded HEAD. A raw sha does not resolve under
+    // refs/remotes/origin/, so fall back to using `base` verbatim — the seed commit is present in
+    // the mirror as an ancestor of the reviewed branch.
+    const remoteBaseRef = `refs/remotes/origin/${base}`;
+    const baseRef = (await this.refExists(barePath, remoteBaseRef)) ? remoteBaseRef : base;
     const branchRef = `refs/remotes/origin/${branch}`;
     const out = await this.runGit(barePath, ["diff", "--no-color", "--no-ext-diff", `${baseRef}...${branchRef}`]);
     const buf = Buffer.from(out, "utf8");

--- a/agent/test/git.test.ts
+++ b/agent/test/git.test.ts
@@ -964,6 +964,40 @@ describe("reviewDiff (PRD #400 M4b diff-review)", () => {
     const diff = await git.reviewDiff(bare, "main", "uzi/task/same");
     assert.equal(diff.trim(), "");
   });
+
+  // issue #403 F3: a handoff created without --base records the SEED COMMIT sha (not a branch
+  // name) as its base, so the review diffs only the worker's commits on top of the seed, not
+  // the user's seeded HEAD. That raw sha never resolves under refs/remotes/origin/<sha>, so
+  // reviewDiff must fall back to using it verbatim as a commit-ish present in the mirror.
+  it("resolves a raw commit sha base (the handoff seed commit) — diffs only the post-seed commits", async () => {
+    // Build the branch: a SEED commit (the user's seeded HEAD), then two worker commits on top.
+    gitIn(fx.originPath, ["checkout", "-b", "uzi/task/sha", "main"]);
+    fs.writeFileSync(path.join(fx.originPath, "SEED.txt"), "seeded\n");
+    gitIn(fx.originPath, ["add", "SEED.txt"]);
+    gitIn(fx.originPath, ["commit", "-m", "seed commit"]);
+    const seedSha = gitIn(fx.originPath, ["rev-parse", "HEAD"]);
+    // Worker commits ON TOP of the seed.
+    fs.writeFileSync(path.join(fx.originPath, "WORK1.txt"), "one\n");
+    gitIn(fx.originPath, ["add", "WORK1.txt"]);
+    gitIn(fx.originPath, ["commit", "-m", "worker commit 1"]);
+    fs.writeFileSync(path.join(fx.originPath, "WORK2.txt"), "two\n");
+    gitIn(fx.originPath, ["add", "WORK2.txt"]);
+    gitIn(fx.originPath, ["commit", "-m", "worker commit 2"]);
+    gitIn(fx.originPath, ["checkout", "main"]); // leave origin on main
+
+    const bare = await git.ensureClone(fx.originPath);
+    // Precondition: the seed sha is present in the mirror (as an ancestor of the reviewed
+    // branch) but NOT under refs/remotes/origin/<sha> — the exact shape the fallback handles.
+    assert.strictEqual(gitIn(bare, ["cat-file", "-t", seedSha]), "commit");
+    const diff = await git.reviewDiff(bare, seedSha, "uzi/task/sha");
+
+    // Only the worker's post-seed commits appear; the seed's own content is the base and absent.
+    assert.match(diff, /WORK1\.txt/);
+    assert.match(diff, /WORK2\.txt/);
+    assert.match(diff, /\+one/);
+    assert.match(diff, /\+two/);
+    assert.ok(!diff.includes("SEED.txt"), "the seed commit's own content is the base, absent from the diff");
+  });
 });
 
 describe("planChangedFiles (PRD #212)", () => {

--- a/api/cmd/uzi/handoff.go
+++ b/api/cmd/uzi/handoff.go
@@ -112,8 +112,22 @@ func runHandoffCreate(env Env, gf *globalFlags, cmd *cobra.Command) error {
 		return err
 	}
 
+	// issue #403 F3: the auto-review diffs against base_branch; when --base is omitted the seed is
+	// local HEAD, so record HEAD's commit SHA as the review base. Otherwise the review defaults to
+	// the repo's default branch and its diff would include the user's own seeded commits — findings
+	// against code the user wrote, and --then-fix would try to "fix" the seed. When --base IS given
+	// the seed already IS that ref, so its name stays the base (the push source is that ref too).
+	baseBranch := strings.TrimSpace(base)
+	if baseBranch == "" {
+		if head, herr := env.Git(".", "rev-parse", "HEAD"); herr == nil {
+			baseBranch = strings.TrimSpace(head)
+		}
+		// On rev-parse failure fall back to empty (today's behavior); the seed push below would
+		// fail anyway if HEAD is unresolvable, so nothing is silently created against a bad base.
+	}
+
 	// (1) Create — receive the id and the server-named uzi/task/<id> branch.
-	run, err := c.CreateTaskRun(cmd.Context(), repoID, context, strings.TrimSpace(base), mr, reviewRequested, thenFix, interactive)
+	run, err := c.CreateTaskRun(cmd.Context(), repoID, context, baseBranch, mr, reviewRequested, thenFix, interactive)
 	if err != nil {
 		return err
 	}

--- a/api/cmd/uzi/handoff.go
+++ b/api/cmd/uzi/handoff.go
@@ -352,15 +352,26 @@ func runHandoffRm(env Env, gf *globalFlags, cmd *cobra.Command, id string) error
 	if run.Kind != "task" {
 		return uzicli.Exitf(uzicli.ExitUsage, "run %s is not a handoff task (kind=%s)", id, run.Kind)
 	}
-	// An open merge request needs its source branch, so a task that ACTUALLY opened one
-	// (MrWebURL set once the worker opens it) is exempt. Keying on MrWebURL, not the
-	// OpenMr *intent* flag: a --mr handoff that failed at push/dispatch before the worker
-	// ever opened an MR carries OpenMr=true but has no MR — its branch would otherwise be
-	// orphaned with no CLI path to delete it (and the create-time failure hints recommend
-	// exactly this command).
-	if run.MrWebURL != nil {
+	// issue #403 F1: an open merge request needs its source branch. The exemption is BRANCH-WIDE
+	// (branch_has_open_mr) because a handoff's original task, its auto-review and its --then-fix
+	// fix run all SHARE the uzi/task/<id> branch — running rm against a review/fix child (whose
+	// own row has no MR) must not delete the open MR's source branch. `|| MrWebURL != nil` keeps
+	// the per-run exemption working against a pre-feature api pod that omits the branch field.
+	if run.BranchHasOpenMr || run.MrWebURL != nil {
 		return uzicli.Exitf(uzicli.ExitGeneric,
-			"task %s opened a merge request; its branch is exempt from rm — delete it via the merge request", id)
+			"task %s's branch has an open merge request; it is exempt from rm — delete it via the merge request", id)
+	}
+	// issue #403 F6: refuse rm while the branch is still in use. The run's own status catches a
+	// still-running original (and is robust to a pre-feature api pod that omits branch_has_active_run);
+	// branch_has_active_run catches an in-flight review/fix child pushing to the same branch after
+	// the original completed. Deleting under either races the worker's push.
+	if !isTerminalRunStatus(run.Status) {
+		return uzicli.Exitf(uzicli.ExitGeneric,
+			"task %s is not finished yet (status %s); wait for it to complete before rm", id, run.Status)
+	}
+	if run.BranchHasActiveRun {
+		return uzicli.Exitf(uzicli.ExitGeneric,
+			"task %s still has an active review or fix run on its branch; wait for it to finish before rm", id)
 	}
 	if run.Branch == nil || strings.TrimSpace(*run.Branch) == "" {
 		return uzicli.Exitf(uzicli.ExitGeneric, "task %s has no branch to delete", id)

--- a/api/cmd/uzi/handoff.go
+++ b/api/cmd/uzi/handoff.go
@@ -158,28 +158,47 @@ func resolveHandoffContext(env Env, msg, file string) (string, error) {
 	return resolveMessage(env, ""), nil
 }
 
-// resolveHandoffRepo returns the repo id for the handoff. --repo takes precedence;
-// otherwise the origin remote URL is parsed to owner/namespace and matched against the
-// caller's repos by PathWithNamespace. Exactly one match resolves; zero or many is a
-// usage error naming --repo as the escape hatch.
+// resolveHandoffRepo returns the repo id for the handoff. Handoff ALWAYS resolves origin,
+// because the seed push targets the local `origin` remote (runHandoffCreate step 2). When
+// --repo is set it is validated to name the SAME forge repo origin points at; otherwise the
+// origin path is matched against the caller's repos by PathWithNamespace (exactly one match
+// resolves, zero or many is a usage error naming --repo as the escape hatch).
 func resolveHandoffRepo(env Env, ctx context.Context, c uzicli.Client, repoFlag string) (string, error) {
-	if strings.TrimSpace(repoFlag) != "" {
-		return strings.TrimSpace(repoFlag), nil
-	}
+	// issue #403 F2: handoff pushes local HEAD to origin (git push origin …:refs/heads/<branch>),
+	// so the run's repo MUST be the same forge repo origin points at — else the worker clones a
+	// different repo, finds no seed branch, and silently seeds from that repo's default branch,
+	// dropping the user's HEAD. We therefore always resolve+parse origin and require --repo (when
+	// given) to match it; --repo remains only the disambiguator for an origin that matches several
+	// of the caller's repos, never a way to target a repo origin does NOT point at.
 	origin, err := env.Git(".", "remote", "get-url", "origin")
 	if err != nil {
 		return "", uzicli.Exitf(uzicli.ExitUsage,
-			"not in a git repo with an 'origin' remote (%v); run from a checkout or pass --repo <id> (see 'uzi repo list')", err)
+			"not in a git repo with an 'origin' remote (%v); handoff pushes local HEAD to origin, so run it from a checkout", err)
 	}
 	path := parseRepoPath(origin)
 	if path == "" {
 		return "", uzicli.Exitf(uzicli.ExitUsage,
-			"could not parse origin %q into an owner/repo path; pass --repo <id> (see 'uzi repo list')", origin)
+			"could not parse origin %q into an owner/repo path; handoff pushes local HEAD to origin, so it must be a resolvable remote", origin)
 	}
 	repos, err := c.ListRepos(ctx)
 	if err != nil {
 		return "", err
 	}
+
+	if repoFlag := strings.TrimSpace(repoFlag); repoFlag != "" {
+		for _, r := range repos {
+			if r.ID == repoFlag {
+				if r.PathWithNamespace != path {
+					return "", uzicli.Exitf(uzicli.ExitUsage,
+						"--repo %s (%s) does not match origin %s; handoff pushes local HEAD to origin, so they must be the same repo", repoFlag, r.PathWithNamespace, path)
+				}
+				return repoFlag, nil
+			}
+		}
+		return "", uzicli.Exitf(uzicli.ExitUsage,
+			"--repo %s is not one of your uzi repos (see 'uzi repo list')", repoFlag)
+	}
+
 	var matches []apitypes.RepoDTO
 	for _, r := range repos {
 		if r.PathWithNamespace == path {

--- a/api/cmd/uzi/handoff_test.go
+++ b/api/cmd/uzi/handoff_test.go
@@ -85,7 +85,9 @@ func TestHandoffHappyPath(t *testing.T) {
 		CreatedTaskRun: taskRun("r1", "uzi/task/r1"),
 		DispatchedRun:  taskRun("r1", "uzi/task/r1"),
 	}
-	rec := &handoffRecorder{}
+	// issue #403 F3: without --base the seed is local HEAD, so the CLI resolves HEAD's sha
+	// and records it as base_branch (the auto-review's diff base).
+	rec := &handoffRecorder{gitOut: map[string]string{"rev-parse HEAD": "c0ffee1234"}}
 	env, _ := handoffEnv(fc, rec)
 
 	out, _, code := runCLI(t, env, "handoff", "--repo", "p1", "-m", "do X")
@@ -100,8 +102,9 @@ func TestHandoffHappyPath(t *testing.T) {
 	if fc.LastCreateTaskContext != "do X" {
 		t.Errorf("create context = %q, want %q", fc.LastCreateTaskContext, "do X")
 	}
-	if fc.LastCreateTaskBaseBranch != "" {
-		t.Errorf("create base = %q, want empty", fc.LastCreateTaskBaseBranch)
+	// issue #403 F3: base_branch is HEAD's sha, so the review diffs only the worker's commits.
+	if fc.LastCreateTaskBaseBranch != "c0ffee1234" {
+		t.Errorf("create base = %q, want the seed commit sha c0ffee1234", fc.LastCreateTaskBaseBranch)
 	}
 	if fc.LastCreateTaskOpenMr {
 		t.Errorf("create open_mr = true, want false")
@@ -143,6 +146,34 @@ func TestHandoffBaseRef(t *testing.T) {
 	wantPush := []string{"push", "origin", "main:refs/heads/uzi/task/r2"}
 	if !hasGitCall(rec, wantPush) {
 		t.Errorf("push should use main as source; git calls %v", rec.gitCalls)
+	}
+}
+
+// issue #403 F3: if resolving HEAD's sha fails (rev-parse errors), a no---base handoff still
+// proceeds (create + push + dispatch) with base_branch empty — a graceful fallback to the
+// pre-F3 behavior rather than aborting the run.
+func TestHandoffSeedCommitFallbackOnRevParseError(t *testing.T) {
+	fc := &uzicli.FakeClient{
+		CreatedTaskRun: taskRun("r2b", "uzi/task/r2b"),
+		DispatchedRun:  taskRun("r2b", "uzi/task/r2b"),
+	}
+	rec := &handoffRecorder{gitErr: map[string]error{"rev-parse HEAD": errPushRejected}}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "--repo", "p1", "-m", "x")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0 (rev-parse failure must fall back gracefully)", code)
+	}
+	if fc.LastCreateTaskBaseBranch != "" {
+		t.Errorf("create base = %q, want empty on rev-parse failure", fc.LastCreateTaskBaseBranch)
+	}
+	// The run still proceeds through push and dispatch.
+	wantPush := []string{"push", "origin", "HEAD:refs/heads/uzi/task/r2b"}
+	if !hasGitCall(rec, wantPush) {
+		t.Errorf("no push %v in git calls %v", wantPush, rec.gitCalls)
+	}
+	if fc.LastDispatchRunID != "r2b" {
+		t.Errorf("dispatch run id = %q, want r2b", fc.LastDispatchRunID)
 	}
 }
 

--- a/api/cmd/uzi/handoff_test.go
+++ b/api/cmd/uzi/handoff_test.go
@@ -50,6 +50,18 @@ func (c *handoffClient) DispatchTaskRun(ctx context.Context, runID string) (apit
 
 // handoffEnv wires a fake client + a fake Git recorder into an Env.
 func handoffEnv(fc *uzicli.FakeClient, rec *handoffRecorder) (Env, *handoffClient) {
+	// issue #403 F2: resolveHandoffRepo now always resolves origin + ListRepos (even with
+	// --repo), so seed a resolvable origin and a matching repo "p1" when the test didn't set
+	// them — a test that needs specific values sets rec.gitOut / fc.Repos before calling.
+	if rec.gitOut == nil {
+		rec.gitOut = map[string]string{}
+	}
+	if _, ok := rec.gitOut["remote get-url origin"]; !ok {
+		rec.gitOut["remote get-url origin"] = "https://github.com/acme/widgets.git"
+	}
+	if len(fc.Repos) == 0 {
+		fc.Repos = []apitypes.RepoDTO{{ID: "p1", PathWithNamespace: "acme/widgets"}}
+	}
 	hc := &handoffClient{FakeClient: fc, rec: rec}
 	env := fakeEnv(hc)
 	env.Git = rec.git
@@ -308,6 +320,106 @@ func TestHandoffRepoAutoDetect(t *testing.T) {
 				t.Errorf("resolved repo = %q, want %q", fc.LastCreateTaskRepoID, tc.wantRepoID)
 			}
 		})
+	}
+}
+
+// issue #403 F2: --repo whose repo path MATCHES origin proceeds and resolves to that id.
+func TestHandoffRepoFlagMatchesOrigin(t *testing.T) {
+	fc := &uzicli.FakeClient{
+		Repos:          []apitypes.RepoDTO{{ID: "p1", PathWithNamespace: "acme/widgets"}},
+		CreatedTaskRun: taskRun("rf", "uzi/task/rf"),
+		DispatchedRun:  taskRun("rf", "uzi/task/rf"),
+	}
+	rec := &handoffRecorder{gitOut: map[string]string{"remote get-url origin": "https://github.com/acme/widgets.git"}}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "--repo", "p1", "-m", "x")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0 for --repo matching origin", code)
+	}
+	if fc.LastCreateTaskRepoID != "p1" {
+		t.Errorf("resolved repo = %q, want p1", fc.LastCreateTaskRepoID)
+	}
+	wantPush := []string{"push", "origin", "HEAD:refs/heads/uzi/task/rf"}
+	if !hasGitCall(rec, wantPush) {
+		t.Errorf("matching --repo should push; git calls %v", rec.gitCalls)
+	}
+}
+
+// issue #403 F2: --repo whose repo path does NOT match origin is a usage error, and nothing
+// is created or pushed — pushing local HEAD to origin while the run points at a different
+// repo would silently drop the user's HEAD.
+func TestHandoffRepoFlagMismatchOrigin(t *testing.T) {
+	fc := &uzicli.FakeClient{
+		Repos:          []apitypes.RepoDTO{{ID: "pB", PathWithNamespace: "other/thing"}},
+		CreatedTaskRun: taskRun("rf", "uzi/task/rf"),
+		DispatchedRun:  taskRun("rf", "uzi/task/rf"),
+	}
+	rec := &handoffRecorder{gitOut: map[string]string{"remote get-url origin": "https://github.com/acme/widgets.git"}}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "--repo", "pB", "-m", "x")
+	if code != uzicli.ExitUsage {
+		t.Fatalf("exit = %d, want %d (usage) for --repo mismatching origin", code, uzicli.ExitUsage)
+	}
+	if fc.LastCreateTaskRepoID != "" {
+		t.Errorf("no run should be created on a repo/origin mismatch; repo = %q", fc.LastCreateTaskRepoID)
+	}
+	if len(rec.gitCalls) != 1 { // only the origin resolve; no push
+		t.Errorf("a mismatch must not push (only the origin get-url); git calls %v", rec.gitCalls)
+	}
+	for _, s := range rec.seq {
+		if s == "create" || s == "dispatch" {
+			t.Errorf("mismatch must not create/dispatch: %v", rec.seq)
+		}
+	}
+}
+
+// issue #403 F2: --repo naming an id that is not one of the caller's repos is a usage error,
+// and nothing is created or pushed.
+func TestHandoffRepoFlagUnknown(t *testing.T) {
+	fc := &uzicli.FakeClient{
+		Repos:          []apitypes.RepoDTO{{ID: "p1", PathWithNamespace: "acme/widgets"}},
+		CreatedTaskRun: taskRun("rf", "uzi/task/rf"),
+		DispatchedRun:  taskRun("rf", "uzi/task/rf"),
+	}
+	rec := &handoffRecorder{gitOut: map[string]string{"remote get-url origin": "https://github.com/acme/widgets.git"}}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "--repo", "nope", "-m", "x")
+	if code != uzicli.ExitUsage {
+		t.Fatalf("exit = %d, want %d (usage) for an unknown --repo", code, uzicli.ExitUsage)
+	}
+	if fc.LastCreateTaskRepoID != "" {
+		t.Errorf("no run should be created for an unknown --repo; repo = %q", fc.LastCreateTaskRepoID)
+	}
+	for _, s := range rec.seq {
+		if s == "create" || s == "dispatch" {
+			t.Errorf("unknown --repo must not create/dispatch: %v", rec.seq)
+		}
+	}
+}
+
+// issue #403 F2: when origin matches TWO of the caller's repos, --repo picks the right ID —
+// the ambiguity escape hatch still works because both candidates pass the path check.
+func TestHandoffRepoFlagDisambiguates(t *testing.T) {
+	fc := &uzicli.FakeClient{
+		Repos: []apitypes.RepoDTO{
+			{ID: "p1", PathWithNamespace: "acme/widgets"},
+			{ID: "p2", PathWithNamespace: "acme/widgets"},
+		},
+		CreatedTaskRun: taskRun("rf", "uzi/task/rf"),
+		DispatchedRun:  taskRun("rf", "uzi/task/rf"),
+	}
+	rec := &handoffRecorder{gitOut: map[string]string{"remote get-url origin": "https://github.com/acme/widgets.git"}}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "--repo", "p2", "-m", "x")
+	if code != uzicli.ExitOK {
+		t.Fatalf("exit = %d, want 0 for --repo disambiguating an ambiguous origin", code)
+	}
+	if fc.LastCreateTaskRepoID != "p2" {
+		t.Errorf("resolved repo = %q, want p2 (the disambiguated id)", fc.LastCreateTaskRepoID)
 	}
 }
 

--- a/api/cmd/uzi/handoff_test.go
+++ b/api/cmd/uzi/handoff_test.go
@@ -59,7 +59,10 @@ func handoffEnv(fc *uzicli.FakeClient, rec *handoffRecorder) (Env, *handoffClien
 // taskRun builds a created/dispatched task-run DTO with a server-named branch.
 func taskRun(id, branch string) apitypes.RunDTO {
 	b := branch
-	return apitypes.RunDTO{ID: id, Kind: "task", Branch: &b}
+	// Status defaults to "completed" — a finished handoff, the natural rm fixture. rm now
+	// refuses a non-terminal status (issue #403 F6), and this is harmless to the
+	// create/dispatch tests, which do not assert status.
+	return apitypes.RunDTO{ID: id, Kind: "task", Branch: &b, Status: "completed"}
 }
 
 // TestHandoffHappyPath is the Decision-6 core: a --repo handoff creates the run, pushes
@@ -432,6 +435,62 @@ func TestHandoffRmMRExempt(t *testing.T) {
 	}
 }
 
+// issue #403 F1: rm on a review/fix CHILD id (own row carries no MrWebURL) whose BRANCH's
+// owning task opened an MR is refused branch-wide — the open MR's source branch must not be
+// deleted through a child that shares it. Keys on BranchHasOpenMr with MrWebURL nil.
+func TestHandoffRmBranchMRExempt(t *testing.T) {
+	run := taskRun("r7c", "uzi/task/r7c")
+	run.BranchHasOpenMr = true // branch's owning task opened an MR; this row's MrWebURL is nil
+	fc := &uzicli.FakeClient{RunByID: map[string]apitypes.RunDTO{"r7c": run}}
+	rec := &handoffRecorder{}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "rm", "r7c")
+	if code == uzicli.ExitOK {
+		t.Fatalf("rm of a branch whose owning task opened an MR must be refused, got exit 0")
+	}
+	if len(rec.gitCalls) != 0 {
+		t.Errorf("a branch-MR-exempt rm must not run git: %v", rec.gitCalls)
+	}
+}
+
+// issue #403 F6: rm on a run that is not yet finished (a still-running original) is refused
+// and runs no git — deleting under it would race the worker's push.
+func TestHandoffRmRefusesRunning(t *testing.T) {
+	run := taskRun("r7d", "uzi/task/r7d")
+	run.Status = "running"
+	fc := &uzicli.FakeClient{RunByID: map[string]apitypes.RunDTO{"r7d": run}}
+	rec := &handoffRecorder{}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "rm", "r7d")
+	if code == uzicli.ExitOK {
+		t.Fatalf("rm of a non-terminal run must be refused, got exit 0")
+	}
+	if len(rec.gitCalls) != 0 {
+		t.Errorf("an unfinished-run rm must not run git: %v", rec.gitCalls)
+	}
+}
+
+// issue #403 F6: rm on a finished original whose BRANCH still has a live review/fix child
+// (BranchHasActiveRun) is refused and runs no git — the in-flight child is still pushing.
+func TestHandoffRmRefusesActiveChild(t *testing.T) {
+	run := taskRun("r7e", "uzi/task/r7e")
+	run.Status = "completed"
+	run.BranchHasActiveRun = true
+	fc := &uzicli.FakeClient{RunByID: map[string]apitypes.RunDTO{"r7e": run}}
+	rec := &handoffRecorder{}
+	env, _ := handoffEnv(fc, rec)
+
+	_, _, code := runCLI(t, env, "handoff", "rm", "r7e")
+	if code == uzicli.ExitOK {
+		t.Fatalf("rm while an active review/fix child runs on the branch must be refused, got exit 0")
+	}
+	if len(rec.gitCalls) != 0 {
+		t.Errorf("an active-child rm must not run git: %v", rec.gitCalls)
+	}
+}
+
 // A --base that starts with '-' is rejected (it would be misparsed by git push as an
 // option in the refspec argv element): usage error, and nothing is pushed or dispatched.
 func TestHandoffBaseLeadingDashRejected(t *testing.T) {
@@ -466,7 +525,10 @@ func TestHandoffBaseLeadingDashRejected(t *testing.T) {
 func TestHandoffRmRefusesNonNamespacedBranch(t *testing.T) {
 	rogue := "main"
 	fc := &uzicli.FakeClient{RunByID: map[string]apitypes.RunDTO{
-		"r8b": {ID: "r8b", Kind: "task", Branch: &rogue},
+		// Status completed + no active/MR so the F1/F6 checks pass and the refusal is the
+		// namespace guard specifically (issue #403: without a terminal status this would
+		// short-circuit at the F6 status check and no longer exercise the guard under test).
+		"r8b": {ID: "r8b", Kind: "task", Branch: &rogue, Status: "completed"},
 	}}
 	rec := &handoffRecorder{}
 	env, _ := handoffEnv(fc, rec)

--- a/api/internal/apitypes/run.go
+++ b/api/internal/apitypes/run.go
@@ -119,6 +119,10 @@ type RunDTO struct {
 	// when it inherited the caller's local HEAD, and on every non-task run); OpenMr is
 	// whether the worker opens an MR at the end (false by default and for every
 	// non-task run — a plain handoff produces commits on the branch, not an MR).
+	// For a handoff created without --base (issue #403 F3), BaseBranch is the resolved
+	// SEED COMMIT sha (the local HEAD the CLI pushed as the branch tip), which the
+	// auto-review uses as its diff base so it covers only the worker's commits, not the
+	// user's own seeded HEAD.
 	BaseBranch *string `json:"base_branch"`
 	OpenMr     bool    `json:"open_mr"`
 	// Interactive marks a long-lived, conversational task run (PRD #517 M1): the worker

--- a/api/internal/apitypes/run.go
+++ b/api/internal/apitypes/run.go
@@ -137,6 +137,16 @@ type RunDTO struct {
 	// it directly through isHttpsUrl and only falls back to the legacy GitLab URL
 	// reconstruction for those null rows — it is the only correct link on Forgejo.
 	MrWebURL *string `json:"mr_web_url"`
+	// BranchHasActiveRun and BranchHasOpenMr are server-computed `uzi handoff rm` preconditions
+	// (issue #403 F1/F6), stamped ONLY on the owner/admin GetRun detail read for a kind='task'
+	// run — false on every non-task run, on the list/create/worker DTO paths, and on a
+	// pre-feature api pod. A handoff's original task, its auto-review and its --then-fix fix run
+	// all share one uzi/task/<id> branch, so the CLI keys `rm` on these BRANCH-wide facts, not
+	// the passed run's own row: BranchHasActiveRun is true while ANY run on the branch is
+	// non-terminal (rm would race a live push); BranchHasOpenMr is true when the branch's owning
+	// task opened an MR (rm exempt — the MR needs its source branch). Always on the wire (bool).
+	BranchHasActiveRun bool `json:"branch_has_active_run"`
+	BranchHasOpenMr    bool `json:"branch_has_open_mr"`
 	// IssueWebURL is the forge-supplied issue web URL (PRD #411), nil for issue-less
 	// runs or when the issue is no longer cached; rendered through isHttpsUrl on the web.
 	IssueWebURL *string `json:"issue_web_url"`

--- a/api/internal/apitypes/wire_test.go
+++ b/api/internal/apitypes/wire_test.go
@@ -103,6 +103,9 @@ var runDTOKeys = []string{
 	// non-task run and on a task run not yet dispatched). Always on the wire.
 	"dispatched_at",
 	"mr_iid", "mr_web_url", "mr_state", "failure_reason",
+	// issue #403 F1/F6: branch-wide `uzi handoff rm` preconditions, server-computed on the
+	// GetRun detail read for a task run (false elsewhere). Always on the wire (bool).
+	"branch_has_active_run", "branch_has_open_mr",
 	// PRD #411: the forge issue's web URL for the run's clickable #<iid> link. Null for
 	// issue-less runs and when the issue is no longer cached. Always on the wire.
 	"issue_web_url",

--- a/api/internal/handler/workers.go
+++ b/api/internal/handler/workers.go
@@ -1158,6 +1158,23 @@ func (h *Handler) GetRun(w http.ResponseWriter, r *http.Request) {
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		slog.Error("get run usage total", "run_id", run.ID, "error", err)
 	}
+	// issue #403 F1/F6: stamp the branch-wide `uzi handoff rm` preconditions for a task run so
+	// the CLI can refuse rm when the branch still has a live run (a running original or an
+	// in-flight review/fix child) or belongs to a task that opened an MR. Owner-scoped query.
+	// FAIL-CLOSED: on a lookup error leave BranchHasActiveRun=true so rm refuses rather than
+	// deletes a branch under uncertainty.
+	if run.Kind == "task" && run.Branch.Valid && run.Branch.String != "" {
+		if stats, err := h.q.TaskBranchRmStats(r.Context(), store.TaskBranchRmStatsParams{
+			UserID: run.UserID,
+			Branch: run.Branch,
+		}); err != nil {
+			slog.Error("task branch rm stats", "run_id", run.ID, "error", err)
+			dto.BranchHasActiveRun = true // fail closed
+		} else {
+			dto.BranchHasActiveRun = stats.ActiveCount > 0
+			dto.BranchHasOpenMr = stats.MrCount > 0
+		}
+	}
 	httpx.JSON(w, http.StatusOK, map[string]any{"run": dto})
 }
 

--- a/api/internal/store/queries/task.sql
+++ b/api/internal/store/queries/task.sql
@@ -168,3 +168,17 @@ UPDATE runs
 SET dispatched_at = now(), updated_at = now()
 WHERE id = @run_id AND user_id = @user_id AND kind = 'task' AND dispatched_at IS NULL
 RETURNING *;
+
+-- name: TaskBranchRmStats :one
+-- Branch-scoped safety stats for `uzi handoff rm` (issue #403 F1/F6). A handoff's original
+-- task, its auto-review and its --then-fix fix run are all kind='task' sharing the SAME
+-- uzi/task/<orig> branch, so "is this branch safe to delete?" is branch-scoped, not
+-- run-scoped: active_count > 0 means some run on the branch is still live (the original still
+-- running, or an in-flight review/fix child pushing to it); mr_count > 0 means the branch's
+-- owning task opened an MR (only an open_mr original ever sets mr_web_url), which exempts the
+-- branch from rm. Owner-scoped (@user_id) so it never reports on a foreign branch.
+SELECT
+    COUNT(*) FILTER (WHERE status NOT IN ('completed', 'failed', 'cancelled')) AS active_count,
+    COUNT(*) FILTER (WHERE mr_web_url IS NOT NULL) AS mr_count
+FROM runs
+WHERE user_id = @user_id AND kind = 'task' AND branch = @branch;

--- a/api/internal/store/task.sql.go
+++ b/api/internal/store/task.sql.go
@@ -832,6 +832,38 @@ func (q *Queries) ListTaskReviewFindings(ctx context.Context, reviewID uuid.UUID
 	return items, nil
 }
 
+const taskBranchRmStats = `-- name: TaskBranchRmStats :one
+SELECT
+    COUNT(*) FILTER (WHERE status NOT IN ('completed', 'failed', 'cancelled')) AS active_count,
+    COUNT(*) FILTER (WHERE mr_web_url IS NOT NULL) AS mr_count
+FROM runs
+WHERE user_id = $1 AND kind = 'task' AND branch = $2
+`
+
+type TaskBranchRmStatsParams struct {
+	UserID uuid.UUID   `json:"user_id"`
+	Branch pgtype.Text `json:"branch"`
+}
+
+type TaskBranchRmStatsRow struct {
+	ActiveCount int64 `json:"active_count"`
+	MrCount     int64 `json:"mr_count"`
+}
+
+// Branch-scoped safety stats for `uzi handoff rm` (issue #403 F1/F6). A handoff's original
+// task, its auto-review and its --then-fix fix run are all kind='task' sharing the SAME
+// uzi/task/<orig> branch, so "is this branch safe to delete?" is branch-scoped, not
+// run-scoped: active_count > 0 means some run on the branch is still live (the original still
+// running, or an in-flight review/fix child pushing to it); mr_count > 0 means the branch's
+// owning task opened an MR (only an open_mr original ever sets mr_web_url), which exempts the
+// branch from rm. Owner-scoped (@user_id) so it never reports on a foreign branch.
+func (q *Queries) TaskBranchRmStats(ctx context.Context, arg TaskBranchRmStatsParams) (TaskBranchRmStatsRow, error) {
+	row := q.db.QueryRow(ctx, taskBranchRmStats, arg.UserID, arg.Branch)
+	var i TaskBranchRmStatsRow
+	err := row.Scan(&i.ActiveCount, &i.MrCount)
+	return i, err
+}
+
 const upsertTaskReviewWithFindings = `-- name: UpsertTaskReviewWithFindings :one
 WITH upserted AS (
     INSERT INTO task_reviews (target_run_id, review_run_id, user_id, status, summary_md)

--- a/api/internal/store/task_branch_rm_stats_livedb_test.go
+++ b/api/internal/store/task_branch_rm_stats_livedb_test.go
@@ -1,0 +1,125 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// TestTaskBranchRmStatsLiveDB pins the issue #403 F1/F6 branch-scoped safety query against a
+// REAL Postgres. TaskBranchRmStats answers "is this uzi/task/<orig> branch safe to rm?" over
+// EVERY kind='task' run sharing the branch (original + auto-review + --then-fix fix), so it
+// cannot be modeled by the in-memory fakes — it exercises the FILTER aggregates and the
+// user/kind/branch scoping directly:
+//
+//	(a) a branch whose runs are all terminal and none opened an MR → active_count 0, mr_count 0;
+//	(b) a branch with a still-running review child → active_count ≥ 1;
+//	(c) a branch whose original set mr_web_url → mr_count ≥ 1;
+//	(d) rows on a DIFFERENT branch or a DIFFERENT user are excluded.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres (named OUTSIDE the uzi-
+// namespace, per the store live-DB harness). A package that prints `ok` with PASS=0 is INVALID.
+func TestTaskBranchRmStatsLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	// seedUser creates a user + forge connection + repo and returns the user and repo ids.
+	seedUser := func() (uuid.UUID, uuid.UUID) {
+		userID, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+		exec(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`, userID, fmt.Sprintf("rm-%s@e2e", userID))
+		exec(`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+		      VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, userID, []byte{0x1})
+		exec(`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+		      VALUES ($1, $2, 1, $3, $4, 'main', true)`, repoID, connID, fmt.Sprintf("g/%s", repoID), fmt.Sprintf("https://forge.e2e/g/%s", repoID))
+		return userID, repoID
+	}
+	// insertRun inserts a kind='task' run on the given branch with the given status; mrWebURL
+	// non-empty sets mr_web_url (only an open_mr original ever does).
+	insertRun := func(userID, repoID uuid.UUID, branch, status, mrWebURL string) {
+		t.Helper()
+		var mr any
+		if mrWebURL != "" {
+			mr = mrWebURL
+		}
+		exec(`INSERT INTO runs (id, user_id, repo_id, kind, branch, issue_title, issue_description, status, auto_approve, mr_web_url)
+		      VALUES ($1, $2, $3, 'task', $4, 'do the thing', 'ctx', $5, true, $6)`,
+			uuid.New(), userID, repoID, branch, status, mr)
+	}
+
+	userA, repoA := seedUser()
+	userB, repoB := seedUser()
+
+	// ── (a) a branch: original + review + fix all terminal, no MR → 0 active, 0 mr. ──
+	branchClean := "uzi/task/" + uuid.New().String()
+	insertRun(userA, repoA, branchClean, "completed", "") // original
+	insertRun(userA, repoA, branchClean, "completed", "") // auto-review child
+	insertRun(userA, repoA, branchClean, "cancelled", "") // fix child
+	// Noise that MUST be excluded: another branch (userA) and the same-shaped branch on userB.
+	insertRun(userA, repoA, "uzi/task/"+uuid.New().String(), "running", "https://forge/mr/9")
+	insertRun(userB, repoB, branchClean, "running", "https://forge/mr/8")
+
+	stats, err := q.TaskBranchRmStats(ctx, store.TaskBranchRmStatsParams{UserID: userA, Branch: pgtype.Text{String: branchClean, Valid: true}})
+	if err != nil {
+		t.Fatalf("clean-branch stats: %v", err)
+	}
+	if stats.ActiveCount != 0 {
+		t.Errorf("clean branch active_count = %d, want 0 (all runs terminal; foreign-branch/foreign-user rows must be excluded)", stats.ActiveCount)
+	}
+	if stats.MrCount != 0 {
+		t.Errorf("clean branch mr_count = %d, want 0 (no run on this branch opened an MR)", stats.MrCount)
+	}
+
+	// ── (b) a still-running review child makes the branch active. ──
+	branchActive := "uzi/task/" + uuid.New().String()
+	insertRun(userA, repoA, branchActive, "completed", "") // original finished
+	insertRun(userA, repoA, branchActive, "running", "")   // review child still live
+	stats, err = q.TaskBranchRmStats(ctx, store.TaskBranchRmStatsParams{UserID: userA, Branch: pgtype.Text{String: branchActive, Valid: true}})
+	if err != nil {
+		t.Fatalf("active-branch stats: %v", err)
+	}
+	if stats.ActiveCount < 1 {
+		t.Errorf("active branch active_count = %d, want >= 1 (a running review child is live)", stats.ActiveCount)
+	}
+	if stats.MrCount != 0 {
+		t.Errorf("active branch mr_count = %d, want 0", stats.MrCount)
+	}
+
+	// ── (c) an original that opened an MR makes the branch MR-exempt. ──
+	branchMR := "uzi/task/" + uuid.New().String()
+	insertRun(userA, repoA, branchMR, "completed", "https://forge/mr/1") // original opened an MR
+	insertRun(userA, repoA, branchMR, "completed", "")                   // review child (no MR of its own)
+	stats, err = q.TaskBranchRmStats(ctx, store.TaskBranchRmStatsParams{UserID: userA, Branch: pgtype.Text{String: branchMR, Valid: true}})
+	if err != nil {
+		t.Fatalf("mr-branch stats: %v", err)
+	}
+	if stats.MrCount < 1 {
+		t.Errorf("mr branch mr_count = %d, want >= 1 (the original opened an MR)", stats.MrCount)
+	}
+	if stats.ActiveCount != 0 {
+		t.Errorf("mr branch active_count = %d, want 0 (both runs terminal)", stats.ActiveCount)
+	}
+}

--- a/api/internal/workersvc/claim.go
+++ b/api/internal/workersvc/claim.go
@@ -87,8 +87,10 @@ type ClaimPayload struct {
 	// BaseBranch is the source ref a task run was branched from (PRD #400 M2),
 	// meaningful only for kind='task'. It is carried for context/review — the worker
 	// works the pre-seeded, server-named Branch (uzi/task/<run-id>), not this ref —
-	// so an MR/review can name what the task diverged from. Read from runs.base_branch
-	// (pgtype.Text); nil/omitted for every run that has none.
+	// so an MR/review can name what the task diverged from. For a no---base handoff
+	// (issue #403 F3) it may be the seed commit sha (the local HEAD the CLI pushed),
+	// not a branch name. Read from runs.base_branch (pgtype.Text); nil/omitted for
+	// every run that has none.
 	BaseBranch *string `json:"base_branch"`
 	// ReviewTargetRunID is the reviewed TASK run when THIS task run is a diff-review
 	// (PRD #400 M4a). Non-nil ⇒ the worker (M4b) routes this claim to a review executor:

--- a/api/internal/workersvc/task.go
+++ b/api/internal/workersvc/task.go
@@ -88,6 +88,14 @@ func (s *Service) CreateTaskRun(ctx context.Context, userID, repoID uuid.UUID, i
 		return store.Run{}, ErrTaskBaseBranchTooLong
 	}
 
+	// --then-fix IMPLIES --review server-side (issue #403 F5): the CLI applies this
+	// (reviewRequested := review || thenFix), but a direct API caller — the second
+	// consumer of this API — could set then_fix without review, silently getting no
+	// auto-review and thus no fix run. Enforce the invariant at this shared choke point.
+	if thenFixRequested {
+		reviewRequested = true
+	}
+
 	// #66 D1 layer 2: the shared service-layer guardrail, same as the other PAT-bearing
 	// inserts. A refused repo never gets a run.
 	if err := s.guardDefaultBranch(ctx, row); err != nil {
@@ -240,6 +248,21 @@ func (s *Service) CreateThenFixRun(ctx context.Context, userID, repoID, original
 	// auto-spawned fix cannot alter the fix's budget, and the fix phase of a long
 	// non-interactive handoff keeps the same allowance instead of reverting to the global
 	// default. NULL (global fallback) exactly when the original's was NULL.
+	// issue #403 F4: the composed findings description is server-generated and can exceed
+	// MaxIssueDescriptionBytes (up to ~200 findings). Every other creator caps issue_description;
+	// mirror that here. TRUNCATE rather than error (as CreateTaskRun does): the caller
+	// (maybeEnqueueThenFix) is best-effort and swallows errors, so erroring would silently drop
+	// the entire fix — a truncated-but-present fix is the better outcome, and the prompt stays bounded.
+	description, _ = stripNUL(description)
+	if len(description) > MaxIssueDescriptionBytes {
+		const marker = "\n… findings truncated at the description cap …\n"
+		keep := MaxIssueDescriptionBytes - len(marker)
+		if keep < 0 {
+			keep = 0
+		}
+		description = strings.ToValidUTF8(description[:keep], "") + marker
+	}
+
 	run, err := s.q.CreateThenFixRun(ctx, store.CreateThenFixRunParams{
 		RunID:               id,
 		UserID:              userID,
@@ -296,8 +319,8 @@ const maxTaskTitleRunes = 120
 // deriveTaskTitle picks a short, human-readable title from the inline context: the
 // first non-empty line, trimmed and truncated to maxTaskTitleRunes runes. A blank
 // context falls back to a stable placeholder so the run view header is never empty.
-func deriveTaskTitle(context string) string {
-	for _, line := range strings.Split(context, "\n") {
+func deriveTaskTitle(text string) string {
+	for _, line := range strings.Split(text, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/api/internal/workersvc/task_test.go
+++ b/api/internal/workersvc/task_test.go
@@ -383,6 +383,30 @@ func TestCreateThenFixRunCapsDescription(t *testing.T) {
 		}
 	})
 
+	t.Run("under-cap description with embedded NUL is stripped, not truncated", func(t *testing.T) {
+		// The over-cap case above cannot prove stripNUL ran: its NUL sits past the cap, so
+		// truncation drops the byte even if stripNUL regressed. This case keeps the input
+		// UNDER the cap so no truncation occurs — the persisted description is NUL-free ONLY
+		// if stripNUL (which runs before the cap check) actually stripped it.
+		fs := &fakeStore{userByID: store.User{ID: owner}}
+		svc := New(fs, newBox(t), testParams())
+		const withNUL = "abc\x00def" // well under MaxIssueDescriptionBytes; the NUL must be removed, not preserved
+		if _, err := svc.CreateThenFixRun(context.Background(), owner, uuid.New(), uuid.New(), "uzi/task/abc", "main", withNUL,
+			pgtype.Int4{}, pgtype.Int4{}); err != nil {
+			t.Fatalf("CreateThenFixRun: %v", err)
+		}
+		got := fs.thenFixRunParams
+		if got == nil {
+			t.Fatal("insert did not run")
+		}
+		if strings.Contains(got.IssueDescription, "\x00") {
+			t.Error("issue_description still contains a NUL byte; stripNUL did not run before persistence")
+		}
+		if got.IssueDescription != "abcdef" {
+			t.Errorf("issue_description = %q, want the NUL-stripped %q (no truncation for an under-cap value)", got.IssueDescription, "abcdef")
+		}
+	})
+
 	t.Run("short description passes through unchanged", func(t *testing.T) {
 		fs := &fakeStore{userByID: store.User{ID: owner}}
 		svc := New(fs, newBox(t), testParams())

--- a/api/internal/workersvc/task_test.go
+++ b/api/internal/workersvc/task_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -306,6 +307,98 @@ func TestCreateThenFixRunCopiesOriginalBudget(t *testing.T) {
 	if !got.WaitOnLimit {
 		t.Error("wait_on_limit = false for an opted-in owner — the fix run fell to the column default instead of resolveWaitOnLimit (PRD #35)")
 	}
+}
+
+// TestCreateTaskRunThenFixImpliesReview: issue #403 F5. --then-fix implies --review is
+// enforced SERVER-SIDE, not only in the CLI, so a direct API caller that sets
+// then_fix_requested without review_requested still gets an auto-review (and thus a fix).
+func TestCreateTaskRunThenFixImpliesReview(t *testing.T) {
+	user, repo := uuid.New(), uuid.New()
+
+	t.Run("then-fix without review forces review true", func(t *testing.T) {
+		fs := &fakeStore{repoRow: aValidRepoRow()}
+		svc := New(fs, newBox(t), testParams())
+		svc.SetRepoGuard(&fakeGuard{res: privcheck.GuardResult{Blocked: false}})
+		// reviewRequested=false, thenFixRequested=true
+		if _, err := svc.CreateTaskRun(context.Background(), user, repo, "do it", "", false, false, true, false); err != nil {
+			t.Fatalf("CreateTaskRun: %v", err)
+		}
+		if fs.taskRunParams == nil {
+			t.Fatal("insert did not run")
+		}
+		if !fs.taskRunParams.ReviewRequested {
+			t.Fatal("review_requested = false with then_fix_requested = true — the server-side " +
+				"then-fix-implies-review invariant (issue #403 F5) did not fire")
+		}
+		if !fs.taskRunParams.ThenFixRequested {
+			t.Fatal("then_fix_requested = false, want true when passed")
+		}
+	})
+
+	t.Run("neither review nor then-fix leaves review false", func(t *testing.T) {
+		fs := &fakeStore{repoRow: aValidRepoRow()}
+		svc := New(fs, newBox(t), testParams())
+		svc.SetRepoGuard(&fakeGuard{res: privcheck.GuardResult{Blocked: false}})
+		if _, err := svc.CreateTaskRun(context.Background(), user, repo, "do it", "", false, false, false, false); err != nil {
+			t.Fatalf("CreateTaskRun: %v", err)
+		}
+		if fs.taskRunParams == nil {
+			t.Fatal("insert did not run")
+		}
+		if fs.taskRunParams.ReviewRequested {
+			t.Fatal("review_requested = true with both flags false — the implication over-fired")
+		}
+	})
+}
+
+// TestCreateThenFixRunCapsDescription: issue #403 F4. The server-composed findings
+// description is capped to MaxIssueDescriptionBytes, kept valid UTF-8 and NUL-free, so
+// the fix prompt stays bounded (the every-other-creator invariant). A short description
+// passes through unchanged.
+func TestCreateThenFixRunCapsDescription(t *testing.T) {
+	owner := uuid.New()
+
+	t.Run("over-cap description is truncated to the cap", func(t *testing.T) {
+		fs := &fakeStore{userByID: store.User{ID: owner}}
+		svc := New(fs, newBox(t), testParams())
+		// Build an over-cap description of multi-byte runes so a naive byte-slice truncation
+		// would split a rune; the cap logic must still yield valid UTF-8.
+		big := strings.Repeat("é", MaxIssueDescriptionBytes) + "\x00tail" // é is 2 bytes → well over the cap, plus a NUL
+		if _, err := svc.CreateThenFixRun(context.Background(), owner, uuid.New(), uuid.New(), "uzi/task/abc", "main", big,
+			pgtype.Int4{}, pgtype.Int4{}); err != nil {
+			t.Fatalf("CreateThenFixRun: %v", err)
+		}
+		got := fs.thenFixRunParams
+		if got == nil {
+			t.Fatal("insert did not run")
+		}
+		if len(got.IssueDescription) > MaxIssueDescriptionBytes {
+			t.Errorf("issue_description = %d bytes, want <= %d (the cap)", len(got.IssueDescription), MaxIssueDescriptionBytes)
+		}
+		if !utf8.ValidString(got.IssueDescription) {
+			t.Error("issue_description is not valid UTF-8 after truncation")
+		}
+		if strings.Contains(got.IssueDescription, "\x00") {
+			t.Error("issue_description still contains a NUL byte")
+		}
+	})
+
+	t.Run("short description passes through unchanged", func(t *testing.T) {
+		fs := &fakeStore{userByID: store.User{ID: owner}}
+		svc := New(fs, newBox(t), testParams())
+		const desc = "fix the two findings"
+		if _, err := svc.CreateThenFixRun(context.Background(), owner, uuid.New(), uuid.New(), "uzi/task/abc", "main", desc,
+			pgtype.Int4{}, pgtype.Int4{}); err != nil {
+			t.Fatalf("CreateThenFixRun: %v", err)
+		}
+		got := fs.thenFixRunParams
+		if got == nil {
+			t.Fatal("insert did not run")
+		}
+		if got.IssueDescription != desc {
+			t.Errorf("issue_description = %q, want the unchanged %q", got.IssueDescription, desc)
+		}
+	})
 }
 
 // TestCreateTaskRunSanitizesAndCaps: NUL bytes are stripped from both context and


### PR DESCRIPTION
Implements issue #403.

Closes #403

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-403`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Handoffs without an explicit base now use the resolved seed commit for more accurate reviews.
  - Run details show whether a branch has active runs or an open merge request.
  - Repository and origin validation is enforced for handoff operations.

- **Bug Fixes**
  - Branch removal is prevented while related work is active or a merge request remains open.
  - Review requests are automatically included with follow-up fixes.
  - Follow-up descriptions are sanitized, UTF-8 validated, and length-limited.
  - Review comparisons now support raw commit IDs reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->