### PR TITLE
Schedules page crashes to a black screen: labelless `assigned-sweep` catalog entry hits `null.map` in DefaultJobs

### DIFF
--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -213,6 +213,20 @@ describe("DefaultJobs — catalog row", () => {
     expect(within(nextRunCell).getByText("1 repo")).toBeTruthy();
   });
 
+  it("renders a labelless assigned sweep without crashing", () => {
+    // Regression for the /schedules black-screen: the shipped assigned-sweep default carries
+    // labels: null, and the options cell read entry.labels.map() unguarded (DefaultJobs.tsx
+    // :308), so the tab threw on first render. Rendering the row must not throw, and with no
+    // labels no "label …" chip is emitted.
+    renderTab({
+      catalog: catalog([entry({ slug: "assigned-sweep", name: "Assigned sweep", labels: null })]),
+    });
+    // The row rendered (so the chip assertion below is discriminating, not vacuous).
+    expect(screen.getByText("Assigned sweep")).toBeTruthy();
+    // No selector-label chip is rendered for a labelless sweep.
+    expect(screen.queryByText(/^label /)).toBeNull();
+  });
+
   it("row Enable fans out only the actionable subset of the selection", async () => {
     // The job is already enabled on repo-uzi. Picking BOTH repos should enable only the
     // actionable one (repo-atlas), never re-enable the already-materialized repo-uzi.

--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -215,9 +215,9 @@ describe("DefaultJobs — catalog row", () => {
 
   it("renders a labelless assigned sweep without crashing", () => {
     // Regression for the /schedules black-screen: the shipped assigned-sweep default carries
-    // labels: null, and the options cell read entry.labels.map() unguarded (DefaultJobs.tsx
-    // :308), so the tab threw on first render. Rendering the row must not throw, and with no
-    // labels no "label …" chip is emitted.
+    // labels: null, and the options cell read entry.labels.map() unguarded, so the tab threw
+    // on first render. Rendering the row must not throw, and with no labels no "label …" chip
+    // is emitted.
     renderTab({
       catalog: catalog([entry({ slug: "assigned-sweep", name: "Assigned sweep", labels: null })]),
     });

--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -227,6 +227,32 @@ describe("DefaultJobs — catalog row", () => {
     expect(screen.queryByText(/^label /)).toBeNull();
   });
 
+  it("Enable on a labelless assigned sweep runs the null-guarded enable handler without throwing", async () => {
+    // Covers the onEnable null guard (`entry.labels && entry.labels.length > 0`) that the
+    // sibling render-only test above never reaches: it exercises the Enable flow for a
+    // labelless entry, so a regression to an unguarded `entry.labels.length` would throw here.
+    const onEnable = vi.fn(async () => {});
+    renderTab({
+      catalog: catalog([entry({ slug: "assigned-sweep", name: "Assigned sweep", labels: null })]),
+      onEnable,
+    });
+
+    // Pick a repo so the row Enable button appears (it only renders for an actionable repo).
+    fireEvent.click(screen.getByLabelText("vtmocanu/uzi"));
+    fireEvent.click(await screen.findByRole("button", { name: /Enable/ }));
+
+    // The handler is called with the labelless entry and the selected repo id (the guard did
+    // not throw on entry.labels being null).
+    await waitFor(() =>
+      expect(onEnable).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "assigned-sweep", labels: null }),
+        ["repo-uzi"],
+      ),
+    );
+    // The row is still rendered after enabling — the null guard did not throw mid-render.
+    expect(screen.getByText("Assigned sweep")).toBeTruthy();
+  });
+
   it("row Enable fans out only the actionable subset of the selection", async () => {
     // The job is already enabled on repo-uzi. Picking BOTH repos should enable only the
     // actionable one (repo-atlas), never re-enable the already-materialized repo-uzi.

--- a/web/src/components/DefaultJobs.tsx
+++ b/web/src/components/DefaultJobs.tsx
@@ -89,12 +89,14 @@ export function DefaultJobs({
     await onEnable(entry, repoIds);
     // Auto-expand so the freshly-enabled repos are visible, and arm the sweep-warn.
     setExpanded((s) => new Set(s).add(entry.slug));
-    if (entry.target === "sweep" && entry.labels.length > 0) {
+    if (entry.target === "sweep" && entry.labels && entry.labels.length > 0) {
+      // Capture the narrowed non-null labels: TS drops the narrowing inside the map() closure.
+      const labels = entry.labels;
       setWarnTargets(
         repoIds.map((rid) => ({
           repoId: rid,
           repoPath: repos.find((r) => r.id === rid)?.path_with_namespace ?? "",
-          labels: entry.labels,
+          labels,
         })),
       );
     }
@@ -305,7 +307,7 @@ function CatalogRow({
       optionsCell={
         <div className="flex flex-wrap gap-1">
           {entry.model ? <Chip>model {entry.model}</Chip> : <Chip>inherit model</Chip>}
-          {entry.target === "sweep" && entry.labels.map((l) => <Chip key={l}>label {l}</Chip>)}
+          {entry.target === "sweep" && entry.labels?.map((l) => <Chip key={l}>label {l}</Chip>)}
           {entry.target === "sweep" && entry.max_issues > 0 && <Chip>max {entry.max_issues}</Chip>}
         </div>
       }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1296,8 +1296,8 @@ export interface CatalogEntry {
   model: string;
   // Baked prompt for a prompt entry; "" for a sweep entry.
   prompt: string;
-  // Sweep selector labels; [] for a prompt entry.
-  labels: string[];
+  // Sweep selector labels; null for an assigned sweep (selects by assignee), [] for a prompt entry.
+  labels: string[] | null;
   // Baked per-issue guidance for a sweep entry; "" for a prompt entry.
   guidance: string;
   // Sweep fan-out cap; 0 for a prompt entry.

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -1277,6 +1277,15 @@ const scheduleCatalog: CatalogEntry[] = [
       "Implement the sweep's planned-work issue. Treat the issue description (and any linked spec) as the specification, deliver the change end to end with tests, and run the project's gate before finishing. Keep the work scoped to what the issue asks for and stop to report if it turns out to depend on something not yet in place.",
   },
   {
+    slug: "assigned-sweep",
+    name: "Assigned-work sweep",
+    description: "Daily sweep over open issues assigned to the uzi bot account, starting a run for the oldest few.",
+    target: "sweep", cron: "0 2 * * *", timezone: "UTC", model: "",
+    prompt: "", labels: null, max_issues: 3, auto_approve: true, wait_on_limit: true,
+    guidance:
+      "Implement the sweep's assigned issue. This sweep selects by assignee rather than a label, so there is no selector label to match. Treat the issue description (and any linked spec) as the specification, deliver the change end to end with tests, and run the project's gate before finishing. Keep the work scoped to what the issue asks for and stop to report if it turns out to depend on something not yet in place.",
+  },
+  {
     // A self_improve entry (PRD #590) carries neither a prompt nor labels/guidance: the
     // orchestration lead resolves its own tracking issue at fire time. So it edits like a
     // prompt default (cadence/model only) but has no baked text to show.
@@ -1306,7 +1315,7 @@ function materializeDefault(
     repo_path: repo?.path_with_namespace ?? "",
     target: entry.target,
     issue_iid: null,
-    labels: entry.target === "sweep" ? [...entry.labels] : null,
+    labels: entry.target === "sweep" && entry.labels ? [...entry.labels] : null,
     prompt: entry.target === "prompt" ? entry.prompt : "",
     timing: "recurring",
     cron_expr: entry.cron,
@@ -4628,7 +4637,7 @@ export const mockApi = {
         schedule_id: s.id,
         enabled: s.enabled,
       }));
-    return delay({ entries: scheduleCatalog.map((e) => ({ ...e, labels: [...e.labels] })), enablements });
+    return delay({ entries: scheduleCatalog.map((e) => ({ ...e, labels: e.labels ? [...e.labels] : null })), enablements });
   },
   enableCatalogSchedule: async (repoId: string, slug: string, timezone?: string) => {
     requireSession();

--- a/web/src/mocks/scheduleCatalog.test.ts
+++ b/web/src/mocks/scheduleCatalog.test.ts
@@ -9,10 +9,10 @@ import { describe, expect, it } from "vitest";
 import { mockApi } from "./mockApi";
 
 describe("mock default-jobs catalog (PRD #589)", () => {
-  it("lists the 7 catalog entries and seeds a visible Layout-A demo state", async () => {
+  it("lists the 8 catalog entries and seeds a visible Layout-A demo state", async () => {
     const { entries, enablements } = await mockApi.listScheduleCatalog();
     expect(entries.map((e) => e.slug).sort()).toEqual(
-      ["bug-hunt", "bug-triage", "docs-hygiene", "feature-bingo", "planned-sweep", "self-improve", "test-improvement"].sort(),
+      ["assigned-sweep", "bug-hunt", "bug-triage", "docs-hygiene", "feature-bingo", "planned-sweep", "self-improve", "test-improvement"].sort(),
     );
     // bug-triage is enabled on TWO repos (Layout A), one of them paused.
     const bt = enablements.filter((e) => e.slug === "bug-triage");

--- a/web/src/mocks/scheduleCatalog.test.ts
+++ b/web/src/mocks/scheduleCatalog.test.ts
@@ -14,6 +14,8 @@ describe("mock default-jobs catalog (PRD #589)", () => {
     expect(entries.map((e) => e.slug).sort()).toEqual(
       ["assigned-sweep", "bug-hunt", "bug-triage", "docs-hygiene", "feature-bingo", "planned-sweep", "self-improve", "test-improvement"].sort(),
     );
+    // The assigned sweep selects by assignee, not by label, so its catalog labels stay null.
+    expect(entries.find((e) => e.slug === "assigned-sweep")?.labels).toBeNull();
     // bug-triage is enabled on TWO repos (Layout A), one of them paused.
     const bt = enablements.filter((e) => e.slug === "bug-triage");
     expect(bt.map((e) => e.repo_id).sort()).toEqual(["repo-atlas", "repo-uzi"]);


### PR DESCRIPTION
Implements issue #827.

Closes #827

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-827`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assigned sweeps without labels so they render correctly without crashing.
  * Prevented empty label chips from appearing when no labels are configured.
  * Preserved support for sweeps that select issues by assignee instead of label.
  * Catalog entries now accurately retain whether label selection is configured.

* **Tests**
  * Added regression coverage for assigned sweeps with no labels.
  * Updated catalog coverage for the new assigned-sweep scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->