### PR TITLE
Sidebar dividers bound the wrong element (footer version line + powered-by header line)

### DIFF
--- a/web/src/components/AppShell.branding.test.tsx
+++ b/web/src/components/AppShell.branding.test.tsx
@@ -377,6 +377,20 @@ describe("AppShell branding — POWERED BY block", () => {
     expect(row.className).not.toMatch(/border-b/);
     expect(row.className).toMatch(/justify-end|text-right/);
   });
+
+  // Issue #828: the header divider belongs on the OUTER wrapper that bounds the
+  // wordmark Link AND the below "powered by" row, so both share one bottom border —
+  // NOT on the inner PoweredBy row. Assert the wrapper (row.parentElement) has
+  // border-b while the inner row still does not.
+  it("text-mode below block: the outer header wrapper carries the single border-b, not the row", async () => {
+    mockApi.branding.mockResolvedValue(brandingWith({ brand_mode: "text", brand_company: "Acme, Inc." }));
+    renderShell();
+    const label = (await screen.findAllByText(POWERED_BY_RE))[0];
+    const row = label.parentElement as HTMLElement;
+    const outer = row.parentElement as HTMLElement;
+    expect(row.className).not.toMatch(/border-b/);
+    expect(outer.className).toMatch(/border-b/);
+  });
 });
 
 // The M4 one-row footer (D-follow-up): the version badge (left) and the durable
@@ -397,6 +411,17 @@ describe("AppShell branding — one-row footer", () => {
     renderShell();
     const credit = await screen.findByTestId("license-credit");
     const row = credit.parentElement as HTMLElement;
+    expect(row.className).toMatch(/justify-between/);
+  });
+
+  // Issue #828: the top divider belongs on the full-width footer ROW, not on the
+  // half-width BuildInfoPopover host inside it. Pair the POSITIVE (border-t now on
+  // the row) with the retained justify-between so neither assertion goes vacuous.
+  it("expanded: the footer row carries the full-width border-t divider", async () => {
+    renderShell();
+    const credit = await screen.findByTestId("license-credit");
+    const row = credit.parentElement as HTMLElement;
+    expect(row.className).toMatch(/border-t/);
     expect(row.className).toMatch(/justify-between/);
   });
 });

--- a/web/src/components/AppShell.buildinfo.test.tsx
+++ b/web/src/components/AppShell.buildinfo.test.tsx
@@ -122,6 +122,33 @@ describe("AppShell build info wiring", () => {
   });
 });
 
+// Issue #828 footer divider. This file (not AppShell.branding.test.tsx) is the home
+// for the COLLAPSED case: there the module-scope version promise is pinned PENDING by
+// that file's first test, so the popover never renders; here it resolves, so the
+// collapsed BuildInfoPopover mounts standalone and its host div can be asserted.
+describe("AppShell build info — footer divider (issue #828)", () => {
+  afterEach(() => window.localStorage.clear());
+
+  it("collapsed: the standalone BuildInfoPopover host keeps its own border-t", async () => {
+    // Collapsing the rail drops the full-width footer ROW; the popover renders as the
+    // whole footer, so the top divider must live on ITS host (the cx() collapsed arm).
+    window.localStorage.setItem("uzi.sidebar.collapsed", "true");
+    renderShell();
+    const trigger = await screen.findByRole("button", { name: "v0.4.2" });
+    const host = trigger.parentElement as HTMLElement;
+    expect(host.className).toMatch(/border-t/);
+  });
+
+  it("expanded: the popover host does NOT carry the border-t (the footer row does)", async () => {
+    // Counterpart: expanded, the divider moved up to the full-width footer row, so the
+    // popover's own host must NOT re-draw it (that was the half-width bug).
+    renderShell();
+    const trigger = await screen.findByRole("button", { name: "v0.4.2" });
+    const host = trigger.parentElement as HTMLElement;
+    expect(host.className).not.toMatch(/border-t/);
+  });
+});
+
 // The failure case lives in AppShell.buildinfo.failure.test.tsx, NOT here — and it
 // was written here first, which is how the hazard proved itself: the module-scope
 // promise is already resolved by the tests above, so a mockRejectedValue in a

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -642,45 +642,50 @@ function SidebarContent({
 
   return (
     <div className="flex h-full flex-col">
-      <Link
-        to="/dashboard"
-        onClick={onNavigate}
-        title={collapsed ? (showName ? "uzi · uzinele întunecate" : "app logo") : undefined}
-        className={cx(
-          "flex items-center border-b border-edge py-4",
-          collapsed ? "justify-center px-2" : "gap-2.5 px-4",
-        )}
-      >
-        <AppMark branding={branding} className="h-8 w-8 rounded-lg text-lg" />
-        {!collapsed && (
-          <>
-            {showName && (
-              <span className="min-w-0">
-                <span className="block text-sm font-semibold leading-tight tracking-tight">uzi</span>
-                <span className="block truncate text-[11px] leading-tight text-faint">
-                  uzinele întunecate
+      {/* Header cluster: the app wordmark/logo Link and the below-wordmark "powered
+          by" row share ONE bottom divider, so the border bounds the whole cluster
+          rather than only the Link (issue #828). */}
+      <div className="border-b border-edge">
+        <Link
+          to="/dashboard"
+          onClick={onNavigate}
+          title={collapsed ? (showName ? "uzi · uzinele întunecate" : "app logo") : undefined}
+          className={cx(
+            "flex items-center py-4",
+            collapsed ? "justify-center px-2" : "gap-2.5 px-4",
+          )}
+        >
+          <AppMark branding={branding} className="h-8 w-8 rounded-lg text-lg" />
+          {!collapsed && (
+            <>
+              {showName && (
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold leading-tight tracking-tight">uzi</span>
+                  <span className="block truncate text-[11px] leading-tight text-faint">
+                    uzinele întunecate
+                  </span>
                 </span>
-              </span>
-            )}
-            {MOCK_MODE && (
-              <span
-                title="This build runs entirely in your browser on demo data — no backend."
-                className="ml-auto rounded-md border border-brand/40 bg-brand/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand"
-              >
-                demo
-              </span>
-            )}
-          </>
-        )}
-        {/* POWERED BY, top-right placement (PRD #685 M3b): logo-only, no label,
-            sharing the header row. Self-gates on placement/mode/collapsed. */}
-        <PoweredBy branding={branding} collapsed={collapsed} slot="topright" />
-      </Link>
+              )}
+              {MOCK_MODE && (
+                <span
+                  title="This build runs entirely in your browser on demo data — no backend."
+                  className="ml-auto rounded-md border border-brand/40 bg-brand/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-brand"
+                >
+                  demo
+                </span>
+              )}
+            </>
+          )}
+          {/* POWERED BY, top-right placement (PRD #685 M3b): logo-only, no label,
+              sharing the header row. Self-gates on placement/mode/collapsed. */}
+          <PoweredBy branding={branding} collapsed={collapsed} slot="topright" />
+        </Link>
 
-      {/* POWERED BY, below-wordmark placement (PRD #685 M3b, the default): a row
-          under the header carrying the faint uppercase label + text or logo.
-          Self-gates on placement/mode/collapsed. */}
-      <PoweredBy branding={branding} collapsed={collapsed} slot="below" />
+        {/* POWERED BY, below-wordmark placement (PRD #685 M3b, the default): a row
+            under the header carrying the faint uppercase label + text or logo.
+            Self-gates on placement/mode/collapsed. */}
+        <PoweredBy branding={branding} collapsed={collapsed} slot="below" />
+      </div>
 
       <nav className="flex-1 space-y-1 overflow-y-auto px-2 pb-4 lg:space-y-0.5 lg:pb-2">
         <div className="space-y-0.5 pt-3 lg:pt-2">
@@ -915,7 +920,7 @@ function SidebarContent({
             />
           )
         ) : (
-          <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-1">
+          <div className="flex items-center justify-between gap-2 border-t border-edge px-3 pb-2 pt-1">
             {build?.status === "ok" && build.info.version ? (
               <BuildInfoPopover
                 info={build.info}

--- a/web/src/components/BuildInfoPopover.tsx
+++ b/web/src/components/BuildInfoPopover.tsx
@@ -301,7 +301,7 @@ export function BuildInfoPopover({
 
   return (
     <div
-      className="relative border-t border-edge"
+      className={cx("relative", collapsed && "border-t border-edge")}
       // Hover on the HOST, not the button, so the popover does not vanish the
       // instant the pointer crosses from the trigger onto the panel above it.
       onMouseEnter={() => setOpen(true)}


### PR DESCRIPTION
Implements issue #828.

Closes #828

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-828`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar divider placement in signed-in layouts.
  * Header dividers now extend consistently beneath logo and powered-by content.
  * Expanded footer build-information rows now display the divider across the full width.
  * Collapsed sidebar build-information popovers retain the appropriate top divider without adding an extra divider in expanded layouts.
* **Tests**
  * Added regression coverage for header, footer, and build-information divider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->