### PR TITLE
chore: move tone_instructions to root in .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,9 @@
 
 # Reduce review noise by focusing on actionable issues
 reviews:
-  # Request changes only for critical/major issues
+  # Two-step review: submit "Request changes" while issues are open, auto-switch
+  # to "Approve" once they are resolved. (Not a severity filter; it can request
+  # changes for lower-severity comments too.)
   request_changes_workflow: true
 
   # Reduce comment verbosity
@@ -65,9 +67,6 @@ reviews:
       - "fix(deps)"
       - "build(deps)"
 
-  # Reduce nitpick comments
-  tone_instructions: "Focus only on critical bugs, security issues, and architectural concerns. Skip style nitpicks and minor improvements unless they significantly impact code quality or maintainability."
-
   # Path-specific instructions
   path_instructions:
     # Tests: correctness/coverage only, and specifically hunt the vacuous-assertion
@@ -109,6 +108,10 @@ reviews:
 # Limit review scope
 language: "en-US"
 early_access: false
+
+# Reduce nitpick comments (root-level per the CodeRabbit schema; it is ignored
+# when nested under reviews:).
+tone_instructions: "Focus only on critical bugs, security issues, and architectural concerns. Skip style nitpicks and minor improvements unless they significantly impact code quality or maintainability."
 
 # Custom review instructions
 chat:


### PR DESCRIPTION
CodeRabbit's schema defines `tone_instructions` as a **root** property, not a `reviews.*` one. uzi's config had it nested under `reviews:`, where CodeRabbit silently ignores it, so the "focus on critical bugs / skip nitpicks" tone guidance was never actually applied.

## Changes
- Move `tone_instructions` from under `reviews:` to the repo root, beside `language`/`early_access`.
- Fix the `request_changes_workflow` comment: it's a two-step request-changes then auto-approve workflow, not a severity filter.

## How this surfaced
Porting this config to the fj-queue repo and letting CodeRabbit review the port; CR flagged both (verified against the official schema at `storage.googleapis.com/coderabbit_public_assets/schema.v2.json`: `tone_instructions` exists at root, absent under `reviews`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review configuration documentation to clarify the request-changes workflow.
  * Removed an outdated nested tone setting and consolidated the instruction at the top level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->