### PR TITLE
Lint ratchet base clamp (#262/#313) is undone by a later `git fetch origin main` in the worker, so stale-mirror false-reds recur

### DIFF
--- a/adr/0363-runner-clone-ratchet-refspec.md
+++ b/adr/0363-runner-clone-ratchet-refspec.md
@@ -1,0 +1,54 @@
+# ADR-0363: The worker runner-clone lint-ratchet base is made durable by removing the tracking-fetch refspec
+
+**Status**: Accepted
+**Date**: 2026-08-18
+**Origin**: vtmocanu/uzi#363, the durability gap in the worker lint-ratchet base fix that landed across #262 (advance the runner clone's `origin/main` to the fresh default head) and #313 (clamp the ratchet base to the true branch base). Both were applied once at clone setup and were not durable.
+
+## Decision (summary)
+
+In `agent/src/git.ts` `runnerCloneForBranch`, after the existing #262/#313 clamp (`update-ref refs/remotes/origin/<default>`), unset the runner clone's `remote.origin.fetch` refspec (as the runner uid, matching the surrounding runner-owned config writes).
+
+That single config removal makes the clamp durable by construction. The only mechanism that moved `refs/remotes/origin/<default>` off the clamped base was the configured refspec `+refs/heads/*:refs/remotes/origin/*` that `git clone` writes into the runner clone: it maps a fetch of the bare's frozen `refs/heads/<default>` back onto the runner clone's `refs/remotes/origin/<default>`. With no configured refspec, an agent-initiated `git fetch origin main`, `git fetch origin`, `git pull origin main`, or `git remote update` updates only `FETCH_HEAD` and never touches any remote-tracking ref, so the ratchet base the linter reads stays exactly where git.ts planted it.
+
+The runner clone's `origin` is the local, deliberately frozen worker bare (`git clone --shared` from the bare). Its remote-tracking refs into that frozen bare are stale by design and are never authoritative; the fresh values live in the bare's own `refs/remotes/origin/*`, and git.ts hand-plants the one ref the ratchet needs. Auto-syncing tracking refs from a frozen source was the defect; removing the refspec states that.
+
+## Context
+
+`.golangci.yml`'s ratchet gates on findings the branch introduces by computing `merge-base(origin/main, HEAD)`. `origin/main` is a movable remote-tracking ref, chosen deliberately so local and CI read the same base (PRD #103 Success Criterion 1); a bespoke ref name is not an option, because it would not resolve in CI's detached-HEAD checkout. So the fix must keep `refs/remotes/origin/<default>` itself correct in the runner clone; it may not repoint the ratchet.
+
+The worker bare is a frozen mirror: `cloneBare` rewrites the bare's fetch refspec to `+refs/heads/*:refs/remotes/origin/*`, so the bare's own `refs/heads/*` freeze at first clone while `refs/remotes/origin/*` track fresh. This frozen layout is load-bearing for `RunnerClone.baseCommit` / `defaultBranchCommit` resolution and the resume/checkpoint base machinery. The bare's frozen refs must not be touched.
+
+The gap: nothing re-applied the clamp. A later `git fetch origin main` inside the runner clone (the exact action root `CLAUDE.md` prescribes to local contributors when the ratchet reports a large backlog) fetched the bare's frozen `refs/heads/main` and forced `refs/remotes/origin/main` backward, so `merge-base(origin/main, HEAD)` regressed and `whole-files: true` re-reported the pre-existing backlog as branch-introduced. The judge re-raised this in 11 runs; it recurred twice on 2026-08-16, papered over by agents hand-repointing the ref and persisting per-run memory.
+
+The cross-context conflict is resolved rather than forbidden: `CLAUDE.md`'s "run `git fetch origin main`" advice is correct on a dev machine and corrupting in a worker. This decision makes that same command harmless in the worker (it updates `FETCH_HEAD`, the ratchet base is untouched), so the local advice needs no carve-out.
+
+### Evidence (measured, git 2.55.0, frozen-mirror topology reproduced)
+
+`FORK` = fresh branch base (clamped value); `C0` = frozen bare `refs/heads/main`, an ancestor of `FORK`.
+
+| Runner-clone `remote.origin.fetch` | `git fetch origin main` | ratchet base after |
+|---|---|---|
+| `+refs/heads/*:refs/remotes/origin/*` (today) | rc=0, silent `origin/main` FORK to C0 | corrupted to C0 |
+| (unset), the decision | rc=0, updates `FETCH_HEAD` only | stays FORK |
+| `refs/heads/*:...` (drop the `+`) | rc=1, rejected non-fast-forward | stays FORK |
+| `+...` plus `^refs/heads/main` (negative) | rc=0, forced update | corrupted to C0 |
+
+## Rejected alternatives
+
+- **Drop the `+` (non-forced refspec).** Preserves the clamp, but `git fetch origin main` then exits rc=1 with a rejected non-fast-forward message; a reasonable agent reads that as a failed command. Rejected on agent experience.
+- **Negative refspec `^refs/heads/main`.** Refuted by measurement: an explicit `git fetch origin main` still applied a forced update and corrupted the ref. Does not work.
+- **Re-apply the clamp after every fetch via a hook.** Git has no client-side post-fetch hook; a `reference-transaction` hook contends with the worker's `core.hooksPath` neutralization guardrail. Rejected: never add a mechanism that fights a guardrail layer when a config change suffices.
+- **Guardrail-rewrite/deny the fetch.** Wrong layer: the guardrail exists for the primary directive (no push, no credential/proc read), not ratchet correctness. It would need a fragile enumeration of fetch/pull/remote-update in a safety-critical screener and would contradict `CLAUDE.md`'s own advice. Rejected.
+- **Freshen (unfreeze) the mirror.** Would break the mirror-layout fallback that base/resume/checkpoint resolution depend on and would not fully close the race. Rejected as invasive and off-target.
+
+## What this ADR does NOT decide
+
+- It does not defend against a deliberately-forced explicit command-line refspec (`git fetch --force origin main`, or an explicit `+refs/heads/main:refs/remotes/origin/main`). Those override any config; defending them needs a `reference-transaction` hook, which contends with hook neutralization, and they are not a realistic agent action. Accepted residual.
+- It does not change that the runner clone cannot see fresh `main` (its `origin` is the frozen bare). Pre-existing design, out of scope.
+- It does not change `.golangci.yml`, the bare's refspec, `CLAUDE.md`'s local advice, or any guardrail layer.
+
+## Consequences
+
+- The clamp becomes durable for the run's lifetime regardless of how many times the agent fetches.
+- The runner clone no longer opportunistically updates any remote-tracking ref from a fetch. This is benign: those refs pointed at the frozen bare and were stale-and-unused; the worker's push path runs in the bare and does not read the runner clone's `refs/remotes/origin/*`, and `git merge`/`git rebase`/`git pull` continue to work off `FETCH_HEAD`.
+- Invariant a future change would break: the runner clone's `refs/remotes/origin/<default>` is authoritative only as git.ts plants it; nothing may re-introduce a `remote.origin.fetch` mapping that lets a fetch of the frozen bare overwrite it. Any future need to track additional refs must use an explicit, curated refspec, never the `+refs/heads/*` wildcard.

--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -792,6 +792,10 @@ export class GitCache {
       // clone, exactly as #262. The no-resolvable-default-branch edge keeps today's skip (origin/main
       // keeps whatever the plain clone copied); it is governed by the Taskfile merge-base pre-flight,
       // out of scope here.
+      // Issue #363 — the clamp below is made DURABLE by removing the clone's `remote.origin.fetch`
+      // refspec right after it, so a later agent-initiated `git fetch origin main` / `git fetch
+      // origin` / `git pull` updates only FETCH_HEAD and cannot move `refs/remotes/origin/<default>`
+      // back to the frozen bare mirror head, which would undo the clamp and re-corrupt the ratchet base.
       // PRD #759 M2: clamp against effectiveBase — the real fork point after a wip(park)
       // reset --soft (== baseSha on every non-marker leg, so byte-identical there).
       const defaultBranch = await this.defaultBranchName(barePath);
@@ -810,6 +814,19 @@ export class GitCache {
           });
         }
       }
+      // Issue #363 — make the clamp above durable. `git clone` writes a
+      // `remote.origin.fetch` refspec (`+refs/heads/*:refs/remotes/origin/*`); a later
+      // agent-initiated `git fetch origin main` / `git fetch origin` / `git pull` would
+      // re-apply it and force `refs/remotes/origin/<default>` backward to the frozen bare
+      // mirror head, undoing the clamp and re-corrupting the ratchet base. With no
+      // configured refspec, a fetch updates only FETCH_HEAD and touches no tracking ref, so
+      // the clamp holds for the run's lifetime. `git config --unset-all` exits 5 when the key
+      // is absent (a plain clone always has it, so exit 5 is only a defensive edge); treat
+      // ONLY exit 5 as non-fatal and rethrow anything else.
+      await this.runGitAsRunner(clonePath, ["config", "--unset-all", "remote.origin.fetch"]).catch((err: unknown) => {
+        if ((err as { code?: unknown }).code === 5) return;
+        throw err;
+      });
       // PRD #759 M2: baseCommit is the REAL fork point — effectiveBase, which is the
       // marker's parent when a wip(park) marker was reset --soft'd back to uncommitted, and
       // baseSha (byte-identical) on every other leg. wipRecovered surfaces the recovery to
@@ -1674,7 +1691,13 @@ export class GitCache {
       });
       return stdout;
     } catch (err) {
-      throw new Error(`git ${args.join(" ")} failed: ${gitErrorMessage(err)}`);
+      // Preserve git's numeric exit code on the wrapped error so a caller can discriminate
+      // an expected non-zero status (e.g. `config --unset-all` exit 5 = key absent) from a
+      // real failure — the same `.code` idiom `tryGit` reads off the raw execFile error.
+      const failure = new Error(`git ${args.join(" ")} failed: ${gitErrorMessage(err)}`);
+      const code = (err as { code?: unknown }).code;
+      if (typeof code === "number") (failure as { code?: number }).code = code;
+      throw failure;
     }
   }
 

--- a/agent/test/git.test.ts
+++ b/agent/test/git.test.ts
@@ -502,6 +502,114 @@ describe("runner clone lifecycle (PRD #51 M3, (b) separate-runner-clone)", () =>
     );
   });
 
+  // Issue #363 — the clamp (#262/#313) is UNDONE by a later `git fetch`. A plain `git clone`
+  // leaves a `remote.origin.fetch` refspec (`+refs/heads/*:refs/remotes/origin/*`) in the runner
+  // clone, so an agent that runs `git fetch origin main` / `git fetch origin` re-applies it and
+  // drags `refs/remotes/origin/main` back to the FROZEN bare mirror head — exactly the stale
+  // ancestor the clamp corrected — re-corrupting the ratchet base mid-run. The fix removes that
+  // refspec after clamping, so a fetch updates only FETCH_HEAD and moves no tracking ref. This
+  // test builds the SAME stale-ancestor topology as the #313 test, then fetches and re-asserts the
+  // clamp survives. RED without the git.ts refspec removal, GREEN with it.
+  const buildStaleAncestorClone = async (issue: number): Promise<{ rc: Awaited<ReturnType<GitCache["createOrAttachRunnerClone"]>>; frozen: string }> => {
+    const git = new GitCache(fx.dataDir, nullLogger());
+    const bare = await git.ensureClone(fx.originPath);
+    const initialHead = gitIn(fx.originPath, ["rev-parse", "HEAD"]);
+
+    // Advance the fixture ORIGIN's default branch so the branch's real base is FRESH.
+    fs.writeFileSync(path.join(fx.originPath, "ADVANCE.txt"), "moved on\n");
+    gitIn(fx.originPath, ["add", "ADVANCE.txt"]);
+    gitIn(fx.originPath, [...IDENT, "commit", "-m", "advance default"]);
+    const freshHead = gitIn(fx.originPath, ["rev-parse", "HEAD"]);
+    assert.notStrictEqual(freshHead, initialHead, "precondition: fresh head differs from initial");
+
+    // Seed a first runner clone off the FRESH default, commit, push agent/issue-<issue> to origin.
+    await git.ensureClone(fx.originPath);
+    const first = await git.createOrAttachRunnerClone(bare, issue);
+    assert.strictEqual(first.baseCommit, freshHead, "precondition: first seed is off the fresh default");
+    fs.writeFileSync(path.join(first.path, "WORK.txt"), "w\n");
+    gitIn(first.path, ["add", "WORK.txt"]);
+    gitIn(first.path, [...IDENT, "commit", "-m", "branch work"]);
+    const branchTip = gitIn(first.path, ["rev-parse", "HEAD"]);
+    await git.fetchAgentBranch(bare, first.path, `agent/issue-${issue}`, "run-fixture");
+    await git.pushBranch(bare, `agent/issue-${issue}`, "", fx.originPath);
+    await git.removeRunnerClone(first.path);
+
+    // Stale the fresh default tracking refs so defaultBranchRef falls through to the frozen
+    // refs/heads/main rung (still the initial commit) — the exact #313 stale-ancestor topology.
+    await git.ensureClone(fx.originPath);
+    gitIn(bare, ["symbolic-ref", "-d", "refs/remotes/origin/HEAD"]);
+    gitIn(bare, ["update-ref", "-d", "refs/remotes/origin/main"]);
+    const frozen = gitIn(bare, ["rev-parse", "refs/heads/main"]);
+    assert.strictEqual(frozen, initialHead, "precondition: frozen mirror is the initial commit");
+
+    // Reseed: a resume whose defaultBranchCommit resolves through the frozen rung to the stale
+    // initial commit, so the clamp fires and pins origin/main to the fresh branch base.
+    const rc = await git.createOrAttachRunnerClone(bare, issue);
+    assert.strictEqual(rc.baseCommit, branchTip, "precondition: resume base is the fresh branch tip");
+    assert.notStrictEqual(rc.defaultBranchCommit, rc.baseCommit, "precondition: stale STRICT ancestor, not equal");
+    return { rc, frozen };
+  };
+
+  it("the clamp survives a later `git fetch origin main` / `git fetch origin` (no refspec re-applies it) (#363)", async () => {
+    const { rc } = await buildStaleAncestorClone(363);
+
+    // The clamp is applied: origin/main is the branch base, not the stale frozen ancestor.
+    assert.strictEqual(
+      gitIn(rc.path, ["rev-parse", "refs/remotes/origin/main"]),
+      rc.baseCommit,
+      "precondition: origin/main is clamped to the branch base before any fetch",
+    );
+
+    // An agent runs BOTH fetch shapes inside the runner clone. Without the refspec removal these
+    // drag origin/main back to the frozen mirror head; with it, they touch only FETCH_HEAD.
+    gitIn(rc.path, ["fetch", "origin", "main"]);
+    gitIn(rc.path, ["fetch", "origin"]);
+
+    // The clamp still holds — origin/main is the branch base, and merge-base(origin/main, HEAD)
+    // is the branch base, so the ratchet still gates only branch-introduced findings.
+    assert.strictEqual(
+      gitIn(rc.path, ["rev-parse", "refs/remotes/origin/main"]),
+      rc.baseCommit,
+      "origin/main must STILL be the branch base after fetch — a re-applied refspec would move it back",
+    );
+    assert.strictEqual(
+      gitIn(rc.path, ["merge-base", "refs/remotes/origin/main", "HEAD"]),
+      rc.baseCommit,
+      "merge-base(origin/main, HEAD) must still be the branch base after fetch (ratchet base intact)",
+    );
+  });
+
+  // Negative control: with the wildcard refspec RE-ADDED to the very same clone, the identical
+  // `git fetch origin main` DOES drag origin/main back to the frozen bare mirror head — proving the
+  // corruption is real and that the test above cannot pass vacuously. It is the ABSENCE of the
+  // refspec (the #363 fix) that protects the clamp, nothing else in the topology.
+  it("negative control: re-adding the wildcard refspec lets `git fetch` corrupt origin/main back to the frozen mirror (#363)", async () => {
+    const { rc, frozen } = await buildStaleAncestorClone(3631);
+
+    assert.strictEqual(
+      gitIn(rc.path, ["rev-parse", "refs/remotes/origin/main"]),
+      rc.baseCommit,
+      "precondition: origin/main is clamped to the branch base before the refspec is re-added",
+    );
+    assert.notStrictEqual(rc.baseCommit, frozen, "precondition: the branch base differs from the frozen mirror head");
+
+    // Re-add the exact refspec a plain clone carries, which the #363 fix removed.
+    gitIn(rc.path, ["config", "--add", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"]);
+    gitIn(rc.path, ["fetch", "origin", "main"]);
+
+    // The refspec dragged origin/main back to the frozen mirror head — the clamp is undone.
+    assert.strictEqual(
+      gitIn(rc.path, ["rev-parse", "refs/remotes/origin/main"]),
+      frozen,
+      "with the refspec present, fetch moves origin/main to the frozen bare mirror head",
+    );
+    assert.notStrictEqual(
+      gitIn(rc.path, ["rev-parse", "refs/remotes/origin/main"]),
+      rc.baseCommit,
+      "with the refspec present, origin/main is no longer the branch base — the clamp is corrupted",
+    );
+  });
+
   // Issue #134 (the production half of #127). Any git that writes into a repo spawns a
   // DETACHED `git maintenance run --auto --detach` that outlives the awaited process and keeps
   // writing inside `.git`. removeRunnerClone() (runner.ts:454) `fs.rm`s the clone moments after


### PR DESCRIPTION
Implements issue #363.

Closes #363

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-363`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented subsequent repository fetches from restoring stale branch references after the ratchet base is clamped.
  - Improved handling of missing fetch configuration during runner operations.
  - Preserved numeric exit codes when reporting Git command failures.

- **Documentation**
  - Added an architectural decision record explaining the updated fetch behavior, limitations, and validation results.

- **Tests**
  - Added regression coverage for fetch scenarios that could previously corrupt the preserved ratchet base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->