### PR TITLE
fix(settings): serialize admin settings PUTs with an advisory lock (#831)

### DIFF
--- a/api/internal/handler/settings.go
+++ b/api/internal/handler/settings.go
@@ -212,10 +212,24 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback(ctx) //nolint:errcheck // no-op after a successful Commit
 	qtx := h.q.WithTx(tx)
 
-	// Authoritative cross-key check (Decision 8) against committed state: lock the
-	// settings rows FOR UPDATE, so a concurrent PUT blocks here and we read its
-	// committed values rather than a possibly-stale cache snapshot. Only non-secret
-	// updates merge into the label map (Effective already excludes secrets).
+	// Serialize all settings writes globally (issue #831). This MUST be the first
+	// statement of the transaction: it is a mutex that holds regardless of which
+	// rows exist, which the ListAppSettingsForUpdate FOR UPDATE below is not — a
+	// label key at its compiled-in default has no row for FOR UPDATE to lock, so two
+	// concurrent PUTs could each insert a NEW row invisible to the other's READ
+	// COMMITTED snapshot and both pass the cross-key check, committing equal labels.
+	// See store.SettingsMutationLockKey for the full reasoning.
+	if _, err := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", store.SettingsMutationLockKey); err != nil {
+		slog.Error("update settings: acquire lock", "error", err)
+		httpx.Error(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Authoritative cross-key check (Decision 8) against committed state: read the
+	// settings rows FOR UPDATE. With the advisory lock held this no longer races (a
+	// concurrent PUT is blocked at the lock above), and reading the committed rows
+	// here still avoids a possibly-stale cache snapshot. Only non-secret updates
+	// merge into the label map (Effective already excludes secrets).
 	locked, err := qtx.ListAppSettingsForUpdate(ctx)
 	if err != nil {
 		slog.Error("update settings: lock rows", "error", err)

--- a/api/internal/handler/settings_race_livedb_test.go
+++ b/api/internal/handler/settings_race_livedb_test.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vtmocanu/uzi/api/internal/settings"
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// Issue #831 regression, per-change coverage for a race the nightly compose E2E
+// exercised but no CI job did. Two concurrent admin settings PUTs — one setting
+// uzi_label, one setting autopilot_label — to the SAME value would together violate
+// the cross-key invariant (uzi_label != autopilot_label, settings.ValidateMerged).
+// Exactly one must be accepted and the other rejected; the two labels must never both
+// commit equal.
+//
+// The transaction's own guard, ListAppSettingsForUpdate (SELECT ... FOR UPDATE), is
+// NOT sufficient when the contended key has no stored row: FOR UPDATE locks only rows
+// that exist, so the loser's READ COMMITTED snapshot cannot see the winner's freshly
+// INSERTED row and both pass the check. store.SettingsMutationLockKey (a
+// pg_advisory_xact_lock taken first in the tx) is the fix — a mutex that holds
+// regardless of which rows exist.
+//
+// This test DELETES the uzi_label row before each race, reproducing the exact #831
+// condition (a fresh DB has no uzi_label row: 00036 seeded the retired prd_label, and
+// PRD #764 renamed the key). That makes the advisory lock, not the 00178 seed row, the
+// thing under test.
+//
+// It runs the race raceIterations times because WITHOUT the lock the defect is only
+// ~50% per race: FOR UPDATE serializes the two transactions via the existing
+// autopilot_label row lock, so the collision is missed only when the uzi_label writer
+// (the one INSERTing a NEW row invisible to the loser's snapshot) wins that ordering.
+// The winner-INSERTs case is a coin flip, so a single race is a weak discriminator and
+// would be flaky. Over raceIterations flips, an unlocked handler fails with
+// overwhelming probability while the fixed one is deterministic (the loser always
+// blocks at the advisory lock and re-reads after commit), so this test is both
+// non-flaky in the fixed state and a reliable catcher of a regression.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres;
+// ./e2e/run-store-it.sh provides one and sweeps this package for the LiveDB suffix.
+const raceIterations = 16
+
+func TestConcurrentCrossKeyLabelPutLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via ./e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	admin := mkSecretUser(t, pool)
+	h := &Handler{
+		pool:     pool,
+		q:        store.New(pool),
+		box:      newHandlerTestBox(t),
+		settings: settings.New(store.New(pool), time.Minute),
+	}
+
+	put := func(key string) int {
+		body, _ := json.Marshal(map[string]any{"settings": map[string]string{key: "SHARED"}})
+		rec := httptest.NewRecorder()
+		h.UpdateSettings(rec, userReq(http.MethodPut, "/api/admin/settings", string(body), admin, nil))
+		return rec.Code
+	}
+
+	for iter := 0; iter < raceIterations; iter++ {
+		// Reproduce the #831 starting state each iteration: no uzi_label row (so a write
+		// to it is an INSERT of a new row), autopilot_label back at its default. This is
+		// a shared DB, so reset explicitly rather than assuming a clean slate.
+		if _, err := pool.Exec(ctx, `DELETE FROM app_settings WHERE key IN ('uzi_label','prd_label')`); err != nil {
+			t.Fatalf("iter %d: reset uzi_label: %v", iter, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO app_settings (key, value) VALUES ('autopilot_label','autopilot')
+			 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`); err != nil {
+			t.Fatalf("iter %d: reset autopilot_label: %v", iter, err)
+		}
+		h.settings.Invalidate()
+
+		var wg sync.WaitGroup
+		codes := make([]int, 2)
+		start := make(chan struct{})
+		keys := [2]string{settings.KeyUziLabel, settings.KeyAutopilotLabel}
+		for i, key := range keys {
+			wg.Add(1)
+			go func(i int, key string) {
+				defer wg.Done()
+				<-start
+				codes[i] = put(key)
+			}(i, key)
+		}
+		close(start)
+		wg.Wait()
+
+		ok, bad := 0, 0
+		for _, c := range codes {
+			switch c {
+			case http.StatusOK:
+				ok++
+			case http.StatusBadRequest:
+				bad++
+			default:
+				t.Fatalf("iter %d: unexpected settings PUT status: %d (codes=%v)", iter, c, codes)
+			}
+		}
+		if ok != 1 || bad != 1 {
+			t.Fatalf("iter %d: concurrent cross-key PUT: want exactly one 200 + one 400, got codes=%v", iter, codes)
+		}
+
+		// The committed state must never hold the two labels equal — the invariant the
+		// whole transaction exists to protect. Read effective values straight from the DB.
+		h.settings.Invalidate()
+		rows, err := store.New(pool).ListAppSettings(ctx)
+		if err != nil {
+			t.Fatalf("iter %d: read back: %v", iter, err)
+		}
+		eff := settings.Effective(rows)
+		if eff[settings.KeyUziLabel] == eff[settings.KeyAutopilotLabel] {
+			t.Fatalf("iter %d: invariant broken: uzi_label == autopilot_label == %q after the race", iter, eff[settings.KeyUziLabel])
+		}
+	}
+}

--- a/api/internal/handler/settings_race_livedb_test.go
+++ b/api/internal/handler/settings_race_livedb_test.go
@@ -80,9 +80,12 @@ func TestConcurrentCrossKeyLabelPutLiveDB(t *testing.T) {
 	for iter := 0; iter < raceIterations; iter++ {
 		// Reproduce the #831 starting state each iteration: no uzi_label row (so a write
 		// to it is an INSERT of a new row), autopilot_label back at its default. This is
-		// a shared DB, so reset explicitly rather than assuming a clean slate.
-		if _, err := pool.Exec(ctx, `DELETE FROM app_settings WHERE key IN ('uzi_label','prd_label')`); err != nil {
-			t.Fatalf("iter %d: reset uzi_label: %v", iter, err)
+		// a shared DB, so reset explicitly rather than assuming a clean slate. finding_label
+		// is cleared too: ValidateMerged also rejects uzi_label == finding_label, so a
+		// leftover finding_label == "SHARED" from prior state would 400 the uzi writer for
+		// an unrelated reason and make the assertion vacuous.
+		if _, err := pool.Exec(ctx, `DELETE FROM app_settings WHERE key IN ('uzi_label','prd_label','finding_label')`); err != nil {
+			t.Fatalf("iter %d: reset label rows: %v", iter, err)
 		}
 		if _, err := pool.Exec(ctx,
 			`INSERT INTO app_settings (key, value) VALUES ('autopilot_label','autopilot')

--- a/api/internal/store/migrate.go
+++ b/api/internal/store/migrate.go
@@ -68,6 +68,30 @@ const HostedProvisionLockClass int32 = 0x757A6877 // "uzhw"
 // rollback, no unlock to forget.
 const SecretMutationLockClass int32 = 0x757A736B // "uzsk"
 
+// SettingsMutationLockKey is the fixed key passed to pg_advisory_xact_lock as the
+// first statement of every app_settings write transaction (issue #831). It
+// serializes all settings PUTs globally so the cross-key label invariant
+// (uzi_label != autopilot_label != finding_label, ValidateMerged) can never be
+// broken by two concurrent PUTs.
+//
+// It exists because the transaction's own guard — ListAppSettingsForUpdate, a
+// `SELECT ... FOR UPDATE` — is INSUFFICIENT here for the SAME reason spelled out on
+// SecretMutationLockClass above: FOR UPDATE locks only rows that already exist, so
+// when a label key has no stored row yet (its value is the compiled-in default),
+// the loser of a race cannot see the winner's newly-INSERTED row under READ
+// COMMITTED and both PUTs pass the check. That was the live bug: a fresh DB has no
+// uzi_label row (00036 seeded the now-retired prd_label; PRD #764 renamed the key
+// without reseeding), so two concurrent PUTs could commit uzi_label == SHARED and
+// autopilot_label == SHARED. An advisory lock is a mutex regardless of which rows
+// exist, so the second transaction runs its check only after the first commits.
+//
+// Single-bigint space, like RegistrationLockKey (settings are global, not
+// per-user, so no objid). Its value differs from RegistrationLockKey's, and the
+// one-bigint space is disjoint from the two-int space the *LockClass constants use,
+// so none can collide. XACT-scoped: released on commit or rollback, no unlock to
+// forget.
+const SettingsMutationLockKey int64 = 0x757A7365 // "uzse"
+
 // Migrate runs all pending goose migrations against the database at dsn. It
 // retries the initial connection so the API can start slightly ahead of
 // Postgres becoming ready.

--- a/api/internal/store/migrate.go
+++ b/api/internal/store/migrate.go
@@ -90,6 +90,14 @@ const SecretMutationLockClass int32 = 0x757A736B // "uzsk"
 // one-bigint space is disjoint from the two-int space the *LockClass constants use,
 // so none can collide. XACT-scoped: released on commit or rollback, no unlock to
 // forget.
+//
+// Depends on the pool's default READ COMMITTED isolation (OpenPool sets none): the
+// loser acquires the lock only after the winner commits, and its NEXT statement then
+// takes a fresh snapshot that sees the winner's committed row. At REPEATABLE READ or
+// SERIALIZABLE the transaction snapshot would instead be fixed at this lock statement
+// — taken while the loser is still blocked, before the winner commits — so the loser
+// would miss the new row and the race would reopen. The sibling locks above make the
+// same assumption; do not add an isolation level to the DSN without revisiting this.
 const SettingsMutationLockKey int64 = 0x757A7365 // "uzse"
 
 // Migrate runs all pending goose migrations against the database at dsn. It

--- a/api/internal/store/migrations/00178_uzi_label_seed.sql
+++ b/api/internal/store/migrations/00178_uzi_label_seed.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+
+-- Reconcile the app_settings label seed with PRD #764, which renamed the
+-- run-eligibility key prd_label -> uzi_label (settings.KeyUziLabel) but shipped no
+-- data migration. Two consequences this closes (issue #831):
+--
+--   1. Migration 00036 seeded prd_label, which is now an UNKNOWN key: settings.Effective
+--      ignores any row whose key is not in settings.Defaults, so the row is dead weight.
+--   2. A fresh DB has NO uzi_label row. The settings-PUT cross-key check reads rows
+--      SELECT ... FOR UPDATE, which locks only rows that EXIST; with no uzi_label row a
+--      concurrent PUT that inserts it is invisible to the loser's READ COMMITTED
+--      snapshot, so two PUTs could commit uzi_label == autopilot_label. The advisory
+--      lock added alongside this migration (store.SettingsMutationLockKey) is the
+--      authoritative fix; seeding the row additionally restores the pre-#764 shape and,
+--      like 00036's original intent, makes the admin Settings page show a concrete value.
+--
+-- Behaviour-neutral: the accessor already falls back to DefaultUziLabel ("uzi"), so
+-- seeding that value changes no effective setting. A prd_label an admin had customised
+-- pre-#764 is already inert after #764 and is not carried over (that was #764's decision,
+-- not this migration's to reverse). This literal MUST match settings.DefaultUziLabel.
+INSERT INTO app_settings (key, value) VALUES ('uzi_label', 'uzi')
+    ON CONFLICT (key) DO NOTHING;
+
+DELETE FROM app_settings WHERE key = 'prd_label';
+
+-- +goose Down
+
+-- Reverse the reconcile: restore the retired prd_label seed and drop the uzi_label
+-- seed. Uses the 00036 default 'PRD' for prd_label; only removes a uzi_label row that
+-- still carries the seeded default (an admin-customised value is left intact).
+INSERT INTO app_settings (key, value) VALUES ('prd_label', 'PRD')
+    ON CONFLICT (key) DO NOTHING;
+
+DELETE FROM app_settings WHERE key = 'uzi_label' AND value = 'uzi';

--- a/api/internal/store/migrations/00178_uzi_label_seed.sql
+++ b/api/internal/store/migrations/00178_uzi_label_seed.sql
@@ -21,14 +21,20 @@
 INSERT INTO app_settings (key, value) VALUES ('uzi_label', 'uzi')
     ON CONFLICT (key) DO NOTHING;
 
-DELETE FROM app_settings WHERE key = 'prd_label';
+-- Remove ONLY the untouched 00036 seed row, never an admin-customised prd_label. The
+-- value guard spares a customisation to a non-default string even if its author was
+-- later deleted (updated_by is ON DELETE SET NULL, so it cannot alone mean "pristine");
+-- updated_by IS NULL additionally spares a deliberate 'PRD' set by an existing admin. A
+-- deliberate 'PRD' by a since-deleted admin is indistinguishable from the seed and is
+-- the one unavoidable case.
+DELETE FROM app_settings WHERE key = 'prd_label' AND value = 'PRD' AND updated_by IS NULL;
 
 -- +goose Down
 
--- Reverse the reconcile: restore the retired prd_label seed and drop the uzi_label
--- seed. Uses the 00036 default 'PRD' for prd_label; only removes a uzi_label row that
--- still carries the seeded default (an admin-customised value is left intact).
+-- Reverse the reconcile: restore the retired prd_label seed and drop the uzi_label seed.
+-- Symmetric with the Up delete: only a uzi_label row that still looks like the untouched
+-- seed is removed, so an admin-set uzi_label survives a rollback.
 INSERT INTO app_settings (key, value) VALUES ('prd_label', 'PRD')
     ON CONFLICT (key) DO NOTHING;
 
-DELETE FROM app_settings WHERE key = 'uzi_label' AND value = 'uzi';
+DELETE FROM app_settings WHERE key = 'uzi_label' AND value = 'uzi' AND updated_by IS NULL;


### PR DESCRIPTION
## Problem

The nightly compose E2E (`e2e/run-e2e.sh`) fails intermittently on the concurrent cross-key settings assertion:

```
FAIL concurrent cross-key PUT: expected one 200 + one 400, got 200 and 200
```

It is flaky, not hard-broken (this assertion passed on the 2026-08-28 nightly, failed 2026-08-30), and it is the only job that exercises the concurrent-PUT path.

## Root cause

Two concurrent admin PUTs, one setting `uzi_label` and one setting `autopilot_label` to the same value, could both commit and leave the two labels equal, violating the cross-key invariant the handler doc claims ("a two-key swap can never leave the two labels transiently equal", `handler/settings.go`).

The transaction's authoritative check reads rows with `ListAppSettingsForUpdate` (`SELECT ... FOR UPDATE`), which locks only rows that already exist. PRD #764 renamed the run-eligibility key `prd_label` to `uzi_label` but shipped no data migration, so a fresh DB has no `uzi_label` row (migration 00036 seeded `prd_label`). A write to `uzi_label` is then an INSERT of a new row that the loser of the race cannot see under READ COMMITTED, so both PUTs pass the check.

This is the exact create-race the codebase already documents on `store.SecretMutationLockClass`: FOR UPDATE "locks nothing at all when the set is empty".

## Fix

1. Take a `pg_advisory_xact_lock` (`store.SettingsMutationLockKey`) as the first statement of the settings write transaction, mirroring the registration and secret-mutation locks. It serializes all settings PUTs regardless of which rows exist, so the second transaction runs its check only after the first commits. This is the real fix.
2. Migration `00178` reconciles the label seed with PRD #764: seed `uzi_label` at its default (behaviour-neutral, the accessor already falls back to the same value) and drop the dead `prd_label` seed row. Hygiene on top of the lock, not the fix.
3. Per-change live-DB regression test (`settings_race_livedb_test.go`). The E2E assertion itself is correct and unchanged; this adds coverage on `test:api-store-it`, which runs per PR, instead of nightly-only.

## Validation

- `gate:api`, `gate:repo` green (go1.26.6 pinned toolchain).
- Handler live-DB package sweep green against a fresh Postgres.
- The regression test loops the race so it is a reliable discriminator: deterministic pass with the lock; removing the lock reproduces `200/200` (verified by mutation).
- Migration verified on a clean DB: `uzi_label=uzi`, `autopilot_label=autopilot`, `prd_label` gone.

Note: `00178` may be renumbered above the live head at merge time per the goose numbering convention.

Closes #831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented concurrent settings updates from creating conflicting labels.
  - Preserved cross-setting label uniqueness during simultaneous changes.
  - Added safeguards for consistent settings writes, ensuring one conflicting update is rejected.

- **Data Updates**
  - Added the default `uzi` label when missing.
  - Retired untouched default `prd` labels while preserving customized values.
  - Added rollback support to restore defaults safely when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->