### PR TITLE
Verify SetRunAwaitingFollowup watermark monotonicity (unconditional SET may lower open_followup_id on an out-of-order park)

### DIFF
--- a/api/internal/store/interactive_task_runs_recovery_livedb_test.go
+++ b/api/internal/store/interactive_task_runs_recovery_livedb_test.go
@@ -712,6 +712,54 @@ func TestSetRunRunningAwaitingFollowupWatermarkDiscriminatesLiveDB(t *testing.T)
 	if got := f.status(ctx, t, run); got != "running" {
 		t.Fatalf("status = %q after new follow_up wake, want running", got)
 	}
+
+	// (6) Issue #817: the PRESENT-0 re-park (a fresh re-claiming worker). A worker that
+	//     just re-claimed a requeued run inits lastDeliveredFollowUpId to 0 and reports
+	//     that PRESENT 0 (Valid:true) at park — unlike an old worker that OMITS the param
+	//     (NULL) and falls back to the server max. The monotone floor must hold the
+	//     watermark at id2 rather than let the present 0 drop it.
+	park()
+	if w := watermark(); w != id2 {
+		t.Fatalf("watermark after normal re-park = %d, want id2=%d", w, id2)
+	}
+	prows, err := f.q.SetRunAwaitingFollowup(ctx, store.SetRunAwaitingFollowupParams{
+		ID: run, WorkerID: pgU(wkr), OpenFollowupID: pgtype.Int8{Int64: 0, Valid: true},
+	})
+	if err != nil || prows != 1 {
+		t.Fatalf("present-0 SetRunAwaitingFollowup: rows=%d err=%v", prows, err)
+	}
+	if w := watermark(); w != id2 {
+		// On the UNPATCHED SQL (pure GREATEST(0, LEAST(...)) with no current-value floor)
+		// the present 0 would have dropped the watermark to 0 here — this assertion is the teeth.
+		t.Fatalf("watermark after present-0 re-park = %d, want id2=%d — the monotone floor did not hold", w, id2)
+	}
+
+	// (7) With id2 still the newest consumed follow_up, a stale/duplicate pre-park `running`
+	//     report must be REFUSED (the park holds). On unpatched SQL the watermark is 0 here
+	//     and this resume would return 1.
+	if rows := resume(); rows != 0 {
+		t.Fatalf("a stale pre-park report un-parked the run after a present-0 re-park (%d rows) — the "+
+			"open_followup_id floor did not survive the fresh-worker present 0", rows)
+	}
+	if got := f.status(ctx, t, run); got != "awaiting_followup" {
+		t.Fatalf("status = %q after the refused report, want awaiting_followup (the park must hold)", got)
+	}
+
+	// (8) A genuinely NEW follow_up (#3, id3 > id2) still wakes the floored park — proving the
+	//     floor at id2 is not too strict.
+	id3 := createFollowup()
+	if id3 <= id2 {
+		t.Fatalf("follow_up #3 id=%d not > #2 id=%d — run_user_inputs.id is not monotone as assumed", id3, id2)
+	}
+	if _, err := f.q.ConsumeRunInputs(ctx, run); err != nil {
+		t.Fatalf("ConsumeRunInputs #3: %v", err)
+	}
+	if rows := resume(); rows != 1 {
+		t.Fatalf("a genuinely new follow_up (#3) did not wake the floored park (%d rows) — the floor is too strict", rows)
+	}
+	if got := f.status(ctx, t, run); got != "running" {
+		t.Fatalf("status = %q after new follow_up wake, want running", got)
+	}
 }
 
 // The park WRITER itself (SetRunAwaitingFollowup): status write, the load-bearing health

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -1508,10 +1508,13 @@ UPDATE runs SET
     --
     -- CONSUMED-only (consumed_at IS NOT NULL) remains load-bearing on the server ceiling:
     -- the follow_up that wakes a park is UNCONSUMED until it wakes, so a consumed-only MAX
-    -- never advances past it. The watermark stays monotone across re-parks with NO claim
-    -- re-delivery and NO clear-on-wake — it simply names the last follow_up already spent
-    -- (or the worker's last-delivered id, whichever is lower), and anything newer is a
-    -- genuine new steer.
+    -- never advances past it. Monotonicity across re-parks is now ENFORCED by the
+    -- GREATEST(COALESCE(open_followup_id, 0), ...) current-value floor below — no longer
+    -- merely asserted from the protocol. Issue #817: the old "(or the worker's
+    -- last-delivered id, whichever is lower)" clause was exactly what broke it, because a
+    -- fresh re-claiming worker reports a present 0 (min of a monotone value and a value
+    -- that resets to 0 is not monotone). The watermark simply names the last follow_up
+    -- already spent, and anything newer is a genuine new steer.
     -- The GREATEST(0, ...) floor is the LOWER bound the LEAST ceiling does not give:
     -- LEAST only bounds a huge value from above, so a nonsensical NEGATIVE worker value
     -- (e.g. -1) would otherwise pass through and fail-open THIS run's own wake guard
@@ -1520,7 +1523,18 @@ UPDATE runs SET
     -- Flooring to 0 maps it to "nothing applied" (the first-park value), matching the
     -- stated "neutralize a buggy value" intent. GREATEST(0, ...) never affects a correct
     -- worker: its last-delivered id is always ≥ 0.
-    open_followup_id = GREATEST(0, LEAST(
+    -- Issue #817: floor the SET at the run's currently-stored value so the watermark
+    -- can never REGRESS. The RHS `open_followup_id` reads the PRE-UPDATE (old) row —
+    -- the same self-referential SET-RHS pattern this file already uses for
+    -- milestones_completed (see SetRunRunning and SetRunCompleted). Strand-free: every
+    -- GREATEST operand is ≤ the run's MAX(consumed follow_up id), which is monotone
+    -- non-decreasing, and the unconsumed wake follow_up has id > that max, so
+    -- `id > open_followup_id` always still holds. SAFETY DEPENDS on run_user_inputs
+    -- being append-only and consumed_at set-once: a retention/pruning job that
+    -- hard-deletes consumed follow_up rows would let MAX(consumed) drop below a prior
+    -- stamp, and this floor — unlike the pre-fix pure-LEAST clamp — would then hold the
+    -- watermark too high; such a change must reckon with the wake guard.
+    open_followup_id = GREATEST(0, COALESCE(open_followup_id, 0), LEAST(
         COALESCE(sqlc.narg('open_followup_id')::bigint,
                  (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
                   WHERE run_user_inputs.run_id = @id AND kind = 'follow_up' AND consumed_at IS NOT NULL)),

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -5352,10 +5352,13 @@ UPDATE runs SET
     --
     -- CONSUMED-only (consumed_at IS NOT NULL) remains load-bearing on the server ceiling:
     -- the follow_up that wakes a park is UNCONSUMED until it wakes, so a consumed-only MAX
-    -- never advances past it. The watermark stays monotone across re-parks with NO claim
-    -- re-delivery and NO clear-on-wake — it simply names the last follow_up already spent
-    -- (or the worker's last-delivered id, whichever is lower), and anything newer is a
-    -- genuine new steer.
+    -- never advances past it. Monotonicity across re-parks is now ENFORCED by the
+    -- GREATEST(COALESCE(open_followup_id, 0), ...) current-value floor below — no longer
+    -- merely asserted from the protocol. Issue #817: the old "(or the worker's
+    -- last-delivered id, whichever is lower)" clause was exactly what broke it, because a
+    -- fresh re-claiming worker reports a present 0 (min of a monotone value and a value
+    -- that resets to 0 is not monotone). The watermark simply names the last follow_up
+    -- already spent, and anything newer is a genuine new steer.
     -- The GREATEST(0, ...) floor is the LOWER bound the LEAST ceiling does not give:
     -- LEAST only bounds a huge value from above, so a nonsensical NEGATIVE worker value
     -- (e.g. -1) would otherwise pass through and fail-open THIS run's own wake guard
@@ -5364,7 +5367,18 @@ UPDATE runs SET
     -- Flooring to 0 maps it to "nothing applied" (the first-park value), matching the
     -- stated "neutralize a buggy value" intent. GREATEST(0, ...) never affects a correct
     -- worker: its last-delivered id is always ≥ 0.
-    open_followup_id = GREATEST(0, LEAST(
+    -- Issue #817: floor the SET at the run's currently-stored value so the watermark
+    -- can never REGRESS. The RHS ` + "`" + `open_followup_id` + "`" + ` reads the PRE-UPDATE (old) row —
+    -- the same self-referential SET-RHS pattern this file already uses for
+    -- milestones_completed (see SetRunRunning and SetRunCompleted). Strand-free: every
+    -- GREATEST operand is ≤ the run's MAX(consumed follow_up id), which is monotone
+    -- non-decreasing, and the unconsumed wake follow_up has id > that max, so
+    -- ` + "`" + `id > open_followup_id` + "`" + ` always still holds. SAFETY DEPENDS on run_user_inputs
+    -- being append-only and consumed_at set-once: a retention/pruning job that
+    -- hard-deletes consumed follow_up rows would let MAX(consumed) drop below a prior
+    -- stamp, and this floor — unlike the pre-fix pure-LEAST clamp — would then hold the
+    -- watermark too high; such a change must reckon with the wake guard.
+    open_followup_id = GREATEST(0, COALESCE(open_followup_id, 0), LEAST(
         COALESCE($2::bigint,
                  (SELECT COALESCE(MAX(id), 0) FROM run_user_inputs
                   WHERE run_user_inputs.run_id = $3 AND kind = 'follow_up' AND consumed_at IS NOT NULL)),

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -23139,6 +23139,21 @@ wake-guard watermark (issue #552 M1 / PRD #517). The watermark is `runs.open_fol
   `SetRunRunning` worker_id pin and the next ACK-checked park report remain the backstop.
 - Commits `aace2d0b`/`fc072247` (M1, server clamp+floor), `d8625495` (M2, worker threads the
   last-delivered id through `SteeringChannel`), `ab774e05` (M3, park-skip ownership probe).
+- **Issue #817 follow-up — the watermark could still REGRESS on an out-of-order / re-claim park,
+  reopening #558 for that run.** §586's "still monotone" claim held only for a worker whose
+  last-delivered id is monotone. A FRESH `SteeringChannel` re-claiming a requeued run reports a
+  **present 0** (`lastDeliveredFollowUpIdValue` inits to 0 and is NOT re-seeded from the durable
+  `open_followup_id` column, unlike `stop_pending`), and the pre-fix unconditional SET —
+  `GREATEST(0, LEAST(...))` — LOWERED the watermark to 0, so any already-consumed follow_up then
+  satisfied `id > 0` and woke the park (#558). `min(monotone value, value that resets to 0)` is not
+  monotone, so the ceiling/floor pair was never sufficient. Fixed by flooring the SET at the
+  current stored value: `open_followup_id = GREATEST(0, COALESCE(open_followup_id, 0), LEAST(...))`
+  (the RHS `open_followup_id` reads the pre-UPDATE row, the same self-referential SET-RHS pattern
+  as `milestones_completed`). Provably strand-free while `run_user_inputs` is append-only and
+  `consumed_at` is set-once: every operand is ≤ `MAX(consumed follow_up id)`, and the unconsumed
+  wake follow_up has id > that max, so `id > open_followup_id` always still holds. A future
+  retention/pruning job that hard-deletes consumed follow_up rows would break that premise and must
+  reckon with the wake guard.
 
 ## 587. PRD #767 — assignment to the uzi-bot is a second, equivalent expression of the single run-eligibility gate
 


### PR DESCRIPTION
Implements issue #817.

Closes #817

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-817`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented follow-up progress from regressing when runs are reclaimed out of order.
  * Ensured previously consumed follow-ups remain blocked while newer follow-ups can still resume the run.
  * Added safeguards for recovery scenarios where no follow-up identifier is provided.

* **Documentation**
  * Documented follow-up watermark behavior, recovery safeguards, and retention considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->