### PR TITLE
docs(uzi-watcher): document mr_rework firing lag + add wait-mrrework poller

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -292,6 +292,25 @@ by anything on the PR itself.
    The trigger needs a green pipeline + settled review, so the run may not have spawned yet
    even though it will; if the findings are uzi-fixable (below) and the owner is opted in,
    give it a beat and re-check rather than racing in.
+
+   **How long is "a beat"? Longer than the trigger wording implies — mr_rework firing LAGS
+   the settled review badly, and the measured lag is what to plan around.** The trigger
+   reads as "the next poll tick after the review settles," but on a busy instance the run
+   has been observed firing **30-40+ minutes** after CodeRabbit's review landed and CI went
+   green (measured 2026-08-30: findings on PRs #847/#848 settled ~14:10, the `mr_rework`
+   runs were created ~14:52-14:55, roughly 40 min later), while on a quiet instance it fired
+   in ~4 min (#843, same day). So a 20-minute "it hasn't fired, I'll just fix it myself"
+   conclusion is **premature**: you do the whole local fix and mr_rework then fires on top of
+   it, duplicating the work (not a data-loss collision if your pre-push re-check is clean,
+   but wasted effort and a confusing double set of fix commits). **Budget at least ~40 min
+   of polling for the run to APPEAR before falling back to a local fix, and poll for it
+   rather than eyeballing** — `scripts/wait-mrrework.sh OWNER/REPO PR` waits through the
+   fire→terminal lifecycle and exits when the run lands (or the budget elapses). Fall back to
+   a local fix only when that budget is genuinely spent, or when mr_rework structurally
+   cannot help (owner opted out, the admin kill-switch is on, or a `.github/workflows`
+   finding — the "when this session still fixes locally" list below). **Either way**, the
+   pre-push guard (re-list `kind=mr_rework` for this MR AND re-fetch the branch head, step 1)
+   stays mandatory right before any local push, because the run can fire during your edit.
 3. **Let it finish, then decide from whether the head ACTUALLY moved — and read the ref
    authoritatively at BOTH ends.** With `BR` the PR's `agent/issue-*` branch, **`git fetch
    origin "$BR"` before recording** the pre-rework head (`before=$(git rev-parse
@@ -683,7 +702,9 @@ die with its session. When you close, hand any still-in-flight run ids on the sa
 This skill and its `scripts/` (`watch-run.sh` for uzi runs, `watch-ci.sh` for post-merge
 GitHub Actions, `watch-pr.sh` for a PR's merge-readiness — CI + CodeRabbit-on-head +
 mr_rework coordination in one poll — `pr-findings.sh` to gather CodeRabbit findings across
-PRs, `backup-runs.sh` / `backup-loop.sh` to snapshot in-flight run work from worker PVCs)
+PRs, `wait-mrrework.sh OWNER/REPO PR` to DEFER to uzi's laggy mr_rework by polling its
+fire→terminal lifecycle before falling back to a local fix, `backup-runs.sh` /
+`backup-loop.sh` to snapshot in-flight run work from worker PVCs)
 are living documents — **update them in the same session you find them wanting.**
 When a run surprises you with a new failure mode, a plan trap this list does not name,
 changed merge/ruleset behaviour, a CLI verb that moved, or a poller needs a new

--- a/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
+++ b/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Wait for uzi's mr_rework run on a PR through its fire->terminal lifecycle.
+#
+# mr_rework firing LAGS a settled CodeRabbit review by 30-40+ min on a busy instance
+# (see SKILL.md "uzi may fix the CodeRabbit findings ITSELF"). This poller lets a driver
+# DEFER to it deterministically instead of eyeballing a too-short wait and then doing a
+# redundant local fix. Poll for the run to APPEAR, then to reach terminal.
+#
+# Usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]
+#   default budget: 45 ticks x 60s = 45 min (covers the observed ~40 min fire lag).
+#
+# Exit codes:
+#   0  an mr_rework run reached terminal; prints MRREWORK_ID / MRREWORK_STATUS
+#   2  budget elapsed with NO mr_rework run ever seen (fall back to a local fix)
+#   3  budget elapsed while a run was still non-terminal (still reworking; re-run me)
+#   4  the OWNER/REPO could not be resolved to a uzi repo id
+set -uo pipefail
+
+REPO_SLUG=${1:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]}
+PR=${2:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]}
+MAX=${3:-45}
+INT=${4:-60}
+
+REPO_ID=$(uzi repo list --json 2>/dev/null \
+  | jq -r --arg s "$REPO_SLUG" 'first(.[]|select(.path_with_namespace==$s)|.id) // empty')
+if [ -z "$REPO_ID" ]; then
+  echo "could not resolve repo id for $REPO_SLUG from 'uzi repo list --json'" >&2
+  exit 4
+fi
+
+seen_id=""
+last_status=""
+for i in $(seq 1 "$MAX"); do
+  row=$(uzi run list --json 2>/dev/null | jq -r \
+    --arg repo "$REPO_ID" --argjson pr "$PR" \
+    'first(.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)) // {} | "\(.id // "")\t\(.status // "")"')
+  id=$(printf '%s' "$row" | cut -f1)
+  st=$(printf '%s' "$row" | cut -f2)
+  if [ -z "$id" ]; then
+    echo "$(date +%H:%M:%S) tick $i/$MAX: no mr_rework run yet (waiting to fire)"
+  else
+    seen_id="$id"; last_status="$st"
+    echo "$(date +%H:%M:%S) tick $i/$MAX: mr_rework $id status=$st"
+    case "$st" in
+      completed|failed|cancelled)
+        echo "MRREWORK_ID=$id"
+        echo "MRREWORK_STATUS=$st"
+        exit 0 ;;
+    esac
+  fi
+  sleep "$INT"
+done
+
+if [ -n "$seen_id" ]; then
+  echo "BUDGET_ELAPSED: mr_rework $seen_id still $last_status (re-run to keep waiting)"
+  exit 3
+fi
+echo "BUDGET_ELAPSED: no mr_rework run appeared for $REPO_SLUG#$PR — fall back to a local fix"
+exit 2

--- a/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
+++ b/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
@@ -52,8 +52,12 @@ for i in $(seq 1 "$MAX"); do
     sleep "$INT"; continue
   fi
   ok_polls=$((ok_polls + 1)); last_poll_ok=1
+  # Anchor on the NEWEST mr_rework run for this MR, not an arbitrary first match: an MR can
+  # be reworked over several cycles (each a distinct run, up to the per-MR cap), so `first`
+  # could latch onto a stale TERMINAL earlier cycle and exit 0 while the current cycle is
+  # still running. `max_by(.created_at)` always tracks the latest cycle.
   row=$(printf '%s' "$raw" | jq -r --arg repo "$REPO_ID" --argjson pr "$PR" \
-    'first(.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)) // {} | "\(.id // "")\t\(.status // "")"')
+    '([.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)] | max_by(.created_at)) // {} | "\(.id // "")\t\(.status // "")"')
   id=$(printf '%s' "$row" | cut -f1)
   st=$(printf '%s' "$row" | cut -f2)
   if [ -z "$id" ]; then

--- a/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
+++ b/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
@@ -11,9 +11,18 @@
 #
 # Exit codes:
 #   0  an mr_rework run reached terminal; prints MRREWORK_ID / MRREWORK_STATUS
-#   2  budget elapsed with NO mr_rework run ever seen (fall back to a local fix)
+#   2  budget elapsed with NO mr_rework run seen AND the poll that ended the budget
+#      SUCCEEDED (a confirmed empty result) — safe to fall back to a local fix
 #   3  budget elapsed while a run was still non-terminal (still reworking; re-run me)
 #   4  the OWNER/REPO could not be resolved to a uzi repo id
+#   5  budget elapsed but the polls were UNRELIABLE (every poll, or the final one,
+#      failed — `uzi run list` errored or returned non-JSON), so "never fired" is NOT
+#      established: do NOT fall back to a local fix on this; re-run or investigate.
+#
+# The exit-2-vs-5 split is load-bearing: a failed listing must never masquerade as a
+# confirmed-empty "no run", or a transient `uzi`/network blip would greenlight a local
+# fix while mr_rework is in fact mid-flight — recreating the double-push collision this
+# poller exists to prevent.
 set -uo pipefail
 
 REPO_SLUG=${1:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]}
@@ -30,9 +39,20 @@ fi
 
 seen_id=""
 last_status=""
+ok_polls=0        # count of polls where `uzi run list` returned valid JSON
+last_poll_ok=0    # was the MOST RECENT poll a successful (valid-JSON) listing?
 for i in $(seq 1 "$MAX"); do
-  row=$(uzi run list --json 2>/dev/null | jq -r \
-    --arg repo "$REPO_ID" --argjson pr "$PR" \
+  # Separate a command/parse FAILURE from a successful-but-empty listing: pipefail alone
+  # can't, because the jq at the tail masks `uzi run list`'s exit status. Capture raw
+  # output + rc, then validate it is JSON before trusting an "empty" result.
+  raw=$(uzi run list --json 2>/dev/null); rc=$?
+  if [ "$rc" -ne 0 ] || ! printf '%s' "$raw" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    last_poll_ok=0
+    echo "$(date +%H:%M:%S) tick $i/$MAX: poll FAILED (uzi run list rc=$rc or non-array JSON) — NOT counted as 'no run'"
+    sleep "$INT"; continue
+  fi
+  ok_polls=$((ok_polls + 1)); last_poll_ok=1
+  row=$(printf '%s' "$raw" | jq -r --arg repo "$REPO_ID" --argjson pr "$PR" \
     'first(.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)) // {} | "\(.id // "")\t\(.status // "")"')
   id=$(printf '%s' "$row" | cut -f1)
   st=$(printf '%s' "$row" | cut -f2)
@@ -55,5 +75,11 @@ if [ -n "$seen_id" ]; then
   echo "BUDGET_ELAPSED: mr_rework $seen_id still $last_status (re-run to keep waiting)"
   exit 3
 fi
-echo "BUDGET_ELAPSED: no mr_rework run appeared for $REPO_SLUG#$PR — fall back to a local fix"
+# No run ever seen. Only call it "never fired" if the LAST poll was a confirmed empty
+# listing; if polls were failing (esp. at the end), "never fired" is not established.
+if [ "$ok_polls" -eq 0 ] || [ "$last_poll_ok" -ne 1 ]; then
+  echo "BUDGET_ELAPSED: polls UNRELIABLE ($ok_polls ok, last_poll_ok=$last_poll_ok) — 'never fired' NOT established; do NOT fall back to a local fix on this"
+  exit 5
+fi
+echo "BUDGET_ELAPSED: no mr_rework run appeared for $REPO_SLUG#$PR across $ok_polls confirmed polls — fall back to a local fix"
 exit 2


### PR DESCRIPTION
## What

The `uzi-watcher` skill told drivers to "defer to mr_rework" but implied it fires within a few minutes of a settled CodeRabbit review. In practice it lags badly: measured 2026-08-30 on PRs #847/#848, the mr_rework runs fired ~40 min after the review settled and CI went green (a quiet instance fired in ~4 min on #843). A driver who waits ~20 min, concludes it will not fire, and fixes locally then does redundant work that mr_rework duplicates on top.

## Changes

- **SKILL.md**: document the real 30-40+ min firing lag, budget at least ~40 min of polling before falling back to a local fix, and point at the new poller. Pre-push mr_rework re-check stays mandatory.
- **scripts/wait-mrrework.sh**: new poller that waits an mr_rework run through its fire-to-terminal lifecycle (resolves repo id from OWNER/REPO, exit 0 terminal / 2 never-fired / 3 still-reworking / 4 repo-unresolved). shellcheck-clean.

Docs + script only; no code, no workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated monitoring for rework requests until they reach a final status.
  * Reports clear outcomes for completed requests, unresolved repositories, timeouts, and unreliable polling.
  * Retries failed status checks and distinguishes them from confirmed empty results.
  * Selects the newest matching rework request for the target merge request.

* **Documentation**
  * Updated coordination guidance for delays of up to approximately 40 minutes.
  * Documented the recommended polling workflow and monitoring script before applying local fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->