### PR TITLE
fix(web): version build-info popover spills past the expanded sidebar's right edge

### DIFF
--- a/web/src/components/BuildInfoPopover.test.tsx
+++ b/web/src/components/BuildInfoPopover.test.tsx
@@ -575,6 +575,11 @@ describe("BuildInfoPopover — panel width is state-dependent so it fits the exp
     const cls = popover().className;
     expect(cls).toContain("w-[222px]");
     expect(cls).not.toContain("w-[226px]");
+    // Fitting the rail took BOTH levers: 222px alone at the old `left-2` inset (left
+    // 20) still reaches right 242, a 2px spill. Pin the inset too, so a revert to
+    // `left-2` that keeps the width reintroduces the overflow and this test catches it.
+    expect(cls).toContain("left-1");
+    expect(cls).not.toContain("left-2");
   });
 
   it("collapsed: keeps the wider 226px width (its overhang is deliberate)", () => {

--- a/web/src/components/BuildInfoPopover.test.tsx
+++ b/web/src/components/BuildInfoPopover.test.tsx
@@ -561,3 +561,26 @@ describe("BuildInfoPopover — Changelog button + focus-within (PRD #415 M2)", (
     expect(bridge.className).not.toContain("pointer-events");
   });
 });
+
+describe("BuildInfoPopover — panel width is state-dependent so it fits the expanded rail", () => {
+  // jsdom does no layout, so getBoundingClientRect returns zeros and a test cannot
+  // measure real pixel overflow — the same reason the hover-bridge tests assert the
+  // mechanism. Here the mechanism is the width utility class: expanded the panel must
+  // carry the rail-bounded width (222px), collapsed it keeps the wider 226px whose
+  // overhang past the 56px rail is deliberate. Guarding that the two states differ is
+  // what locks out a regression back to a single fixed width spilling past the 240px
+  // expanded rail (see AppShell.tsx `w-60`).
+  it("expanded: carries the bounded width, not the wider collapsed width", () => {
+    render(<BuildInfoPopover info={mockBuildInfo} now={NOW} />);
+    const cls = popover().className;
+    expect(cls).toContain("w-[222px]");
+    expect(cls).not.toContain("w-[226px]");
+  });
+
+  it("collapsed: keeps the wider 226px width (its overhang is deliberate)", () => {
+    render(<BuildInfoPopover info={mockBuildInfo} now={NOW} collapsed />);
+    const cls = popover().className;
+    expect(cls).toContain("w-[226px]");
+    expect(cls).not.toContain("w-[222px]");
+  });
+});

--- a/web/src/components/BuildInfoPopover.tsx
+++ b/web/src/components/BuildInfoPopover.tsx
@@ -378,14 +378,28 @@ export function BuildInfoPopover({
           // siblings. Raising it to compete with the mobile overlay would be
           // wrong — in the drawer it rides ABOVE that overlay already, and on
           // desktop the overlay is lg:hidden and cannot coexist.
-          "absolute bottom-full z-10 mb-2 w-[226px] rounded-lg border border-edge bg-raised p-3 shadow-2xl",
+          "absolute bottom-full z-10 mb-2 rounded-lg border border-edge bg-raised p-3 shadow-2xl",
           // Left-anchored in BOTH states, inset from the rail edge. Collapsed, the
           // rail is 56px (`w-14`, AppShell.tsx) against this panel's 226px, so it
           // overhangs the content by ~170px — deliberately, since there is nowhere
           // else for a 226px panel to go, and it is why the no-clipping note above
-          // matters. The 4px difference between the two insets is cosmetic and
-          // changes nothing about that overhang.
-          collapsed ? "left-1" : "left-2",
+          // matters.
+          //
+          // WIDTH and inset are BOTH state-dependent, and they trade against each
+          // other on the expanded rail. Expanded the rail is 240px (`w-60`,
+          // AppShell.tsx); the panel's left edge is host `px-3` (12px) + this inset,
+          // so a fixed 226px panel at `left-2` reached x=246 and spilled 6px past the
+          // rail onto <main>. Fitting it needs BOTH the wider room `left-1` buys and a
+          // bounded width: at `left-1` the left edge is 12 + 4 = 16, so width 222 →
+          // right 238, i.e. a 2px gap inside the 240 rail. 222 (not less) because the
+          // widest row — Built, a 21-glyph `29 Aug 2026 20:57 UTC` in mono — needs a
+          // ~132px value column, and the value column is width − 88 (p-3 24 + border 2
+          // + label-col 50 + gap-x-3 12); 222 − 88 = 134 clears it, 218 (130) wrapped
+          // `UTC` to a second line on Linux mono stacks (measured in a real browser;
+          // jsdom does no layout so the unit test can only assert the width is
+          // state-dependent). Collapsed keeps `left-1 w-[226px]` — a 56px rail cannot
+          // contain any reasonable width, so its overhang stays as documented above.
+          collapsed ? "left-1 w-[226px]" : "left-1 w-[222px]",
           "transition-opacity duration-150 motion-reduce:transition-none",
           open ? "opacity-100" : "pointer-events-none opacity-0",
         )}


### PR DESCRIPTION
Implements issue #849.

Closes #849

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-849`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the build information popover sizing and positioning for expanded and collapsed states.
  * Expanded panels now use a slightly narrower width and consistent inset, while collapsed panels retain their existing dimensions.
* **Tests**
  * Added coverage to verify the popover’s state-dependent sizing and positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->