### PR TITLE
bug(mr_rework): in-flight rework isn't aborted when its MR is merged/closed mid-run

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -488,6 +488,10 @@ func run() error {
 	// the owner. Nil-safe; wired here so the sync's reset-on-green path can reach it.
 	svc.SetNotifier(notifier)
 
+	// Wire the mid-flight mr_rework abort (#853): when the MR-close watcher observes a
+	// merge/close, cancel any in-flight rework for that MR through workersvc's cancel path.
+	svc.SetReworkCanceller(wsvc)
+
 	failNotifier := notifysvc.NewRunFailureNotifier(q, notifier, slog.Default())
 	wsvc.SetBroadcaster(workersvc.MultiBroadcaster{liveHub, slackNotifier, failNotifier})
 

--- a/api/internal/forgesvc/mr_rework_cancel_livedb_test.go
+++ b/api/internal/forgesvc/mr_rework_cancel_livedb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/vtmocanu/uzi/api/internal/board"
 	"github.com/vtmocanu/uzi/api/internal/forge"
 	"github.com/vtmocanu/uzi/api/internal/store"
 	"github.com/vtmocanu/uzi/api/internal/workersvc"
@@ -25,17 +26,22 @@ import (
 // re-assert the wiring the unit tests already pin (mr_watch_test.go); the point here is
 // that the two services agree over the SAME rows through the SAME SQL the server runs.
 //
-// The four subtests each seed their OWN repo + issue + mr_iid so they are independent, and
+// The five subtests each seed their OWN repo + issue + mr_iid so they are independent, and
 // assert on the LIVE DB (runs.status / runs.stop_kind / a run_user_inputs cancel row):
 //
-//  1. Merged, NO live poller  -> the rework run flips to status='cancelled' (CancelRunServerSide).
+//  1. Merged, NO live poller  -> the rework run flips to status='cancelled' (CancelRunServerSide);
+//     no cancel verdict is enqueued (countCancelInputs==0).
 //  2. Merged, LIVE poller     -> stop_kind='cancelled' stamped AND a kind='cancel' run_user_inputs
 //     row is enqueued (CreateStopVerdictInput); the run stays non-terminal because no real worker
 //     acks — the enqueue+stamp IS the observable, not a terminal status.
 //  3. Locked (no-op)          -> the rework run is untouched: status unchanged, stop_kind NULL, no
 //     cancel input. Locked is transient mid-merge and must NOT trigger a cancel.
 //  4. Closed, cancels too     -> the CLOSED arm reaches the cancel (guardedMRMove returns moveSkipped
-//     on a closed issue, not moveDeferred), so the rework run flips to status='cancelled'.
+//     on a closed issue, not moveDeferred), so the rework run flips to status='cancelled'; no
+//     cancel verdict is enqueued (countCancelInputs==0).
+//  5. Closed + move DEFERRED  -> an OPEN issue with seeded board columns whose move fails (updateErr)
+//     makes guardedMRMove return moveDeferred; the cancel is DECOUPLED from the move and still fires
+//     (status='cancelled'), while mr_state is left 'opened' so the move retries next tick.
 //
 // Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres; e2e/run-store-it.sh
 // (and task gate:api in CI) provide one. `go test ./...` without it SKIPs.
@@ -245,14 +251,21 @@ func TestMRReworkCancelOnMRCloseLiveDB(t *testing.T) {
 	})
 
 	t.Run("closed, forge move deferred -> cancels anyway (decoupled from board move)", func(t *testing.T) {
-		// Regression guard for #853 review finding: an OPEN issue whose card sits in
-		// Human Review is a Lane-A candidate, so guardedMRMove ATTEMPTS the move — but
-		// updateErr makes AutoMove fail, returning moveDeferred (not moveSkipped). The
-		// cancel must still fire: it is keyed on the MR, not gated behind the move, so a
-		// confirmed close cancels the in-flight rework even when the board move can't
-		// complete. mr_state is left unadvanced (the move retries next tick), which we do
-		// not assert here — the point is that the rework is cancelled regardless.
+		// Regression guard for #853 review finding: the close-edge cancel must fire even
+		// when the board move genuinely DEFERS (a forge-side move error). To reach that
+		// path the guarded move must ATTEMPT AutoMove rather than short-circuit, so this
+		// subtest — unlike #4, whose closed ISSUE skips the move — uses an OPEN issue AND
+		// seeds board_columns so ResolveColumn(["Human Review"]) == wantSource. Then
+		// updateErr makes AutoMove's UpdateIssueLabels fail → guardedMRMove returns
+		// moveDeferred. Pre-fix, that early-returned before the cancel; post-fix, the
+		// cancel is decoupled and still runs. mr_state is left unadvanced so the move
+		// retries next tick — asserted below.
 		s := seed(t, 8535, 85350, "opened", false /* live */)
+		// A card only resolves to a column when that label is a real board column; with
+		// no board_columns row ResolveColumn returns "" and the source guard yields
+		// moveSkipped, never reaching AutoMove. Seed the two columns the move spans.
+		exec(t, `INSERT INTO board_columns (repo_id, label_name, position) VALUES ($1, $2, 0), ($1, $3, 1)`,
+			s.repoID, board.ColumnInProgress, board.ColumnHumanReview)
 		f := &fakeForge{
 			mrByIID:   map[int64]forge.MergeRequest{s.mrIID: forgeMR(s.mrIID, "closed")},
 			updateErr: fmt.Errorf("forge unreachable"),
@@ -268,6 +281,17 @@ func TestMRReworkCancelOnMRCloseLiveDB(t *testing.T) {
 		}
 		if !stopKind.Valid || stopKind.String != "cancelled" {
 			t.Fatalf("rework run stop_kind = %+v, want 'cancelled'", stopKind)
+		}
+		// A deferred move must NOT consume the edge: the issue run's mr_state stays
+		// 'opened' so the next poller tick re-observes the close and retries the move.
+		var mrState pgtype.Text
+		if err := pool.QueryRow(ctx,
+			`SELECT mr_state FROM runs WHERE repo_id = $1 AND kind = 'issue'`, s.repoID).
+			Scan(&mrState); err != nil {
+			t.Fatalf("read issue-run mr_state: %v", err)
+		}
+		if !mrState.Valid || mrState.String != "opened" {
+			t.Fatalf("issue-run mr_state = %+v, want 'opened' — a deferred move must leave the edge unadvanced for retry", mrState)
 		}
 	})
 }

--- a/api/internal/forgesvc/mr_rework_cancel_livedb_test.go
+++ b/api/internal/forgesvc/mr_rework_cancel_livedb_test.go
@@ -100,9 +100,14 @@ func TestMRReworkCancelOnMRCloseLiveDB(t *testing.T) {
 	seed := func(t *testing.T, issueIID, mrIID int64, issueState string, live bool) seeded {
 		t.Helper()
 		repoID := uuid.New()
+		// forge_project_id must be UNIQUE per repo under repos_connection_id_forge_project_id_key
+		// (one connection can't own two repos for the same forge project); mrIID is distinct per
+		// subtest so it serves. This is only the STORED row — SyncMRStates is still called with the
+		// const forgeProjectID below, which the fakeForge ignores, so the value here is inert beyond
+		// satisfying the constraint.
 		exec(t, `INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
 		         VALUES ($1, $2, $3, $4, 'https://forge.e2e/g/r', 'main', true)`,
-			repoID, connID, forgeProjectID, fmt.Sprintf("g/r-%s", repoID))
+			repoID, connID, mrIID, fmt.Sprintf("g/r-%s", repoID))
 
 		exec(t, `INSERT INTO issues (repo_id, forge_issue_iid, title, state, labels, web_url, forge_updated_at, synced_at)
 		         VALUES ($1, $2, 'seeded', $3, '["Human Review"]'::jsonb, 'https://x', now(), now())`,
@@ -167,6 +172,9 @@ func TestMRReworkCancelOnMRCloseLiveDB(t *testing.T) {
 		if !stopKind.Valid || stopKind.String != "cancelled" {
 			t.Fatalf("rework run stop_kind = %+v, want 'cancelled'", stopKind)
 		}
+		if n := countCancelInputs(t, s.reworkRunID); n != 0 {
+			t.Fatalf("kind='cancel' run_user_inputs rows = %d, want 0 for a non-live worker (server-side cancel enqueues no verdict)", n)
+		}
 	})
 
 	t.Run("merged, live poller -> cancel verdict enqueued + stop_kind stamped", func(t *testing.T) {
@@ -227,6 +235,36 @@ func TestMRReworkCancelOnMRCloseLiveDB(t *testing.T) {
 		status, stopKind := readRun(t, s.reworkRunID)
 		if status != "cancelled" {
 			t.Fatalf("rework run status = %q, want 'cancelled' — a closed MR must cancel the rework via the CLOSED arm", status)
+		}
+		if !stopKind.Valid || stopKind.String != "cancelled" {
+			t.Fatalf("rework run stop_kind = %+v, want 'cancelled'", stopKind)
+		}
+		if n := countCancelInputs(t, s.reworkRunID); n != 0 {
+			t.Fatalf("kind='cancel' run_user_inputs rows = %d, want 0 for a non-live worker (server-side cancel enqueues no verdict)", n)
+		}
+	})
+
+	t.Run("closed, forge move deferred -> cancels anyway (decoupled from board move)", func(t *testing.T) {
+		// Regression guard for #853 review finding: an OPEN issue whose card sits in
+		// Human Review is a Lane-A candidate, so guardedMRMove ATTEMPTS the move — but
+		// updateErr makes AutoMove fail, returning moveDeferred (not moveSkipped). The
+		// cancel must still fire: it is keyed on the MR, not gated behind the move, so a
+		// confirmed close cancels the in-flight rework even when the board move can't
+		// complete. mr_state is left unadvanced (the move retries next tick), which we do
+		// not assert here — the point is that the rework is cancelled regardless.
+		s := seed(t, 8535, 85350, "opened", false /* live */)
+		f := &fakeForge{
+			mrByIID:   map[int64]forge.MergeRequest{s.mrIID: forgeMR(s.mrIID, "closed")},
+			updateErr: fmt.Errorf("forge unreachable"),
+		}
+
+		if err := forgeSvc.SyncMRStates(ctx, s.repoID, forgeProjectID, f); err != nil {
+			t.Fatalf("SyncMRStates: %v", err)
+		}
+
+		status, stopKind := readRun(t, s.reworkRunID)
+		if status != "cancelled" {
+			t.Fatalf("rework run status = %q, want 'cancelled' — a confirmed-closed MR must cancel the rework even when the board move defers", status)
 		}
 		if !stopKind.Valid || stopKind.String != "cancelled" {
 			t.Fatalf("rework run stop_kind = %+v, want 'cancelled'", stopKind)

--- a/api/internal/forgesvc/mr_rework_cancel_livedb_test.go
+++ b/api/internal/forgesvc/mr_rework_cancel_livedb_test.go
@@ -1,0 +1,235 @@
+package forgesvc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/vtmocanu/uzi/api/internal/forge"
+	"github.com/vtmocanu/uzi/api/internal/store"
+	"github.com/vtmocanu/uzi/api/internal/workersvc"
+)
+
+// TestMRReworkCancelOnMRCloseLiveDB is the milestone-M3 acceptance test for issue #853:
+// the MR-close watcher (forgesvc.SyncMRStates) aborts an in-flight mr_rework run once its
+// MR leaves the opened state (merged/closed), and leaves it untouched on a locked
+// transition. It wires the REAL collaborators end to end against a live Postgres —
+// forgesvc.Service --SetReworkCanceller--> *workersvc.Service (whose CancelReworkForMR
+// resolves the active mr_rework via GetActiveMRReworkRunForMR and either enqueues a cancel
+// verdict for a live worker or flips the run server-side). A fake canceller would only
+// re-assert the wiring the unit tests already pin (mr_watch_test.go); the point here is
+// that the two services agree over the SAME rows through the SAME SQL the server runs.
+//
+// The four subtests each seed their OWN repo + issue + mr_iid so they are independent, and
+// assert on the LIVE DB (runs.status / runs.stop_kind / a run_user_inputs cancel row):
+//
+//  1. Merged, NO live poller  -> the rework run flips to status='cancelled' (CancelRunServerSide).
+//  2. Merged, LIVE poller     -> stop_kind='cancelled' stamped AND a kind='cancel' run_user_inputs
+//     row is enqueued (CreateStopVerdictInput); the run stays non-terminal because no real worker
+//     acks — the enqueue+stamp IS the observable, not a terminal status.
+//  3. Locked (no-op)          -> the rework run is untouched: status unchanged, stop_kind NULL, no
+//     cancel input. Locked is transient mid-merge and must NOT trigger a cancel.
+//  4. Closed, cancels too     -> the CLOSED arm reaches the cancel (guardedMRMove returns moveSkipped
+//     on a closed issue, not moveDeferred), so the rework run flips to status='cancelled'.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres; e2e/run-store-it.sh
+// (and task gate:api in CI) provide one. `go test ./...` without it SKIPs.
+func TestMRReworkCancelOnMRCloseLiveDB(t *testing.T) {
+	ctx := context.Background()
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	q := store.New(pool)
+
+	// The REAL canceller wired into the REAL forge sync. WorkerHeartbeatStale is set
+	// large so a worker whose last_heartbeat_at = now() reads as a LIVE poller in
+	// hasLivePoller (now() - heartbeat < stale). now defaults to time.Now via New.
+	workerSvc := workersvc.New(q, nil, workersvc.Params{WorkerHeartbeatStale: time.Hour})
+	forgeSvc := New(q, nil, time.Second, nil)
+	forgeSvc.SetReworkCanceller(workerSvc)
+
+	exec := func(t *testing.T, sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	// One owner is enough; each subtest gets a FRESH repo so scenarios never collide on
+	// the (repo_id, mr_iid) partial unique index or the candidate scan.
+	userID, connID := uuid.New(), uuid.New()
+	exec(t, `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+		userID, fmt.Sprintf("rework-cancel-%s@e2e", userID))
+	exec(t, `INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+	         VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`,
+		connID, userID, []byte{0x1})
+
+	const forgeProjectID = 4242 // fakeForge ignores it; SyncMRStates only forwards it.
+
+	// scenario seeds a fresh repo with:
+	//   - an issue cache row (state issueState, labelled Human Review so it is a Lane-A
+	//     candidate when open; a closed issue is admitted by Lane B while mr_state='opened');
+	//   - the completed ISSUE run (kind='issue', status='completed', mr_iid, mr_state='opened')
+	//     — the sole/latest run for its issue_iid, so it IS the watch candidate;
+	//   - the active MR_REWORK run (kind='mr_rework', mr_iid=N, status='running', pipeline_ref
+	//     set, target_run_id = the issue run, issue_iid NULL so it is never itself a candidate).
+	// When live is true it also seeds a worker with a fresh heartbeat and points the rework
+	// run's worker_id at it, so hasLivePoller returns true.
+	//
+	// issueIID and mrIID differ on purpose (an issue number is not its MR number); the watch
+	// is keyed on mr_iid, which is what links the issue run and the rework run to one MR.
+	type seeded struct {
+		repoID      uuid.UUID
+		reworkRunID uuid.UUID
+		mrIID       int64
+	}
+	seed := func(t *testing.T, issueIID, mrIID int64, issueState string, live bool) seeded {
+		t.Helper()
+		repoID := uuid.New()
+		exec(t, `INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+		         VALUES ($1, $2, $3, $4, 'https://forge.e2e/g/r', 'main', true)`,
+			repoID, connID, forgeProjectID, fmt.Sprintf("g/r-%s", repoID))
+
+		exec(t, `INSERT INTO issues (repo_id, forge_issue_iid, title, state, labels, web_url, forge_updated_at, synced_at)
+		         VALUES ($1, $2, 'seeded', $3, '["Human Review"]'::jsonb, 'https://x', now(), now())`,
+			repoID, issueIID, issueState)
+
+		branch := fmt.Sprintf("agent/issue-%d", issueIID)
+		issueRunID := uuid.New()
+		exec(t, `INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status)
+		         VALUES ($1, $2, $3, 'issue', $4, 't', 'd', $5, $6, 'opened', 'completed')`,
+			issueRunID, userID, repoID, issueIID, branch, mrIID)
+
+		var workerID any // NULL unless a live worker is seeded
+		if live {
+			wID := uuid.New()
+			exec(t, `INSERT INTO workers (id, user_id, name, token_hash, status, last_heartbeat_at)
+			         VALUES ($1, $2, 'w', $3, 'online', now())`,
+				wID, userID, []byte(fmt.Sprintf("tok-%s", wID)))
+			workerID = wID
+		}
+
+		reworkRunID := uuid.New()
+		exec(t, `INSERT INTO runs (id, user_id, repo_id, kind, issue_title, issue_description,
+		             pipeline_ref, mr_iid, target_run_id, worker_id, status)
+		         VALUES ($1, $2, $3, 'mr_rework', 't', 'd', $4, $5, $6, $7, 'running')`,
+			reworkRunID, userID, repoID, branch, mrIID, issueRunID, workerID)
+
+		return seeded{repoID: repoID, reworkRunID: reworkRunID, mrIID: mrIID}
+	}
+
+	// readRun reads the live rework-run row back through raw SQL (this is a live-DB test).
+	readRun := func(t *testing.T, runID uuid.UUID) (status string, stopKind pgtype.Text) {
+		t.Helper()
+		if err := pool.QueryRow(ctx, `SELECT status, stop_kind FROM runs WHERE id = $1`, runID).
+			Scan(&status, &stopKind); err != nil {
+			t.Fatalf("read rework run %s: %v", runID, err)
+		}
+		return status, stopKind
+	}
+	countCancelInputs := func(t *testing.T, runID uuid.UUID) int {
+		t.Helper()
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM run_user_inputs WHERE run_id = $1 AND kind = 'cancel'`, runID).
+			Scan(&n); err != nil {
+			t.Fatalf("count cancel inputs %s: %v", runID, err)
+		}
+		return n
+	}
+
+	t.Run("merged, no live poller -> server-side cancel", func(t *testing.T) {
+		s := seed(t, 8531, 85310, "opened", false /* live */)
+		f := &fakeForge{mrByIID: map[int64]forge.MergeRequest{s.mrIID: forgeMR(s.mrIID, "merged")}}
+
+		if err := forgeSvc.SyncMRStates(ctx, s.repoID, forgeProjectID, f); err != nil {
+			t.Fatalf("SyncMRStates: %v", err)
+		}
+
+		status, stopKind := readRun(t, s.reworkRunID)
+		if status != "cancelled" {
+			t.Fatalf("rework run status = %q, want %q — a merged MR with no live poller must be cancelled server-side", status, "cancelled")
+		}
+		if !stopKind.Valid || stopKind.String != "cancelled" {
+			t.Fatalf("rework run stop_kind = %+v, want 'cancelled'", stopKind)
+		}
+	})
+
+	t.Run("merged, live poller -> cancel verdict enqueued + stop_kind stamped", func(t *testing.T) {
+		s := seed(t, 8532, 85320, "opened", true /* live */)
+		f := &fakeForge{mrByIID: map[int64]forge.MergeRequest{s.mrIID: forgeMR(s.mrIID, "merged")}}
+
+		if err := forgeSvc.SyncMRStates(ctx, s.repoID, forgeProjectID, f); err != nil {
+			t.Fatalf("SyncMRStates: %v", err)
+		}
+
+		status, stopKind := readRun(t, s.reworkRunID)
+		// The live-worker path stamps stop_kind + enqueues a cancel; it does NOT itself
+		// finalize the run (a real worker would ack the verdict and report). So the run
+		// stays non-terminal here — assert the ENQUEUE + STAMP, not a terminal status.
+		if !stopKind.Valid || stopKind.String != "cancelled" {
+			t.Fatalf("rework run stop_kind = %+v, want 'cancelled' (stamped by CreateStopVerdictInput)", stopKind)
+		}
+		if n := countCancelInputs(t, s.reworkRunID); n != 1 {
+			t.Fatalf("kind='cancel' run_user_inputs rows = %d, want 1 (a live worker must be sent a cancel verdict)", n)
+		}
+		if status == "cancelled" || status == "completed" || status == "failed" {
+			t.Fatalf("rework run status = %q, want a NON-terminal status (no real worker acked the verdict)", status)
+		}
+	})
+
+	t.Run("locked -> no-op, rework untouched", func(t *testing.T) {
+		s := seed(t, 8533, 85330, "opened", false /* live */)
+		f := &fakeForge{mrByIID: map[int64]forge.MergeRequest{s.mrIID: forgeMR(s.mrIID, "locked")}}
+
+		if err := forgeSvc.SyncMRStates(ctx, s.repoID, forgeProjectID, f); err != nil {
+			t.Fatalf("SyncMRStates: %v", err)
+		}
+
+		status, stopKind := readRun(t, s.reworkRunID)
+		if status != "running" {
+			t.Fatalf("rework run status = %q, want 'running' — a locked transition must NOT cancel the rework", status)
+		}
+		if stopKind.Valid {
+			t.Fatalf("rework run stop_kind = %+v, want NULL — locked must leave the run untouched", stopKind)
+		}
+		if n := countCancelInputs(t, s.reworkRunID); n != 0 {
+			t.Fatalf("kind='cancel' run_user_inputs rows = %d, want 0 — locked must enqueue nothing", n)
+		}
+	})
+
+	t.Run("closed, no live poller -> server-side cancel via the CLOSED arm", func(t *testing.T) {
+		// Closed issue: guardedMRMove short-circuits to moveSkipped (a closed issue is a
+		// terminal placement, not a workflow column), so the CLOSED arm PROCEEDS to the
+		// cancel instead of deferring. Lane B admits the closed-issue candidate while
+		// mr_state='opened'.
+		s := seed(t, 8534, 85340, "closed", false /* live */)
+		f := &fakeForge{mrByIID: map[int64]forge.MergeRequest{s.mrIID: forgeMR(s.mrIID, "closed")}}
+
+		if err := forgeSvc.SyncMRStates(ctx, s.repoID, forgeProjectID, f); err != nil {
+			t.Fatalf("SyncMRStates: %v", err)
+		}
+
+		status, stopKind := readRun(t, s.reworkRunID)
+		if status != "cancelled" {
+			t.Fatalf("rework run status = %q, want 'cancelled' — a closed MR must cancel the rework via the CLOSED arm", status)
+		}
+		if !stopKind.Valid || stopKind.String != "cancelled" {
+			t.Fatalf("rework run stop_kind = %+v, want 'cancelled'", stopKind)
+		}
+	})
+}

--- a/api/internal/forgesvc/mr_watch.go
+++ b/api/internal/forgesvc/mr_watch.go
@@ -97,11 +97,15 @@ func (s *Service) syncOneMRState(ctx context.Context, repoID uuid.UUID, forgePro
 		//
 		// A confirmed close means any in-flight rework can never land — abort it
 		// INDEPENDENTLY of the board move (#853 review finding). Cancellation is
-		// idempotent (no active rework / no canceller → no-op nil) and keyed on the
-		// MR, not the card, so it must NOT be gated behind a move that can defer:
-		// a forge move error, or an evicted card that stops being a candidate next
-		// tick, would otherwise leave the rework spending forever. Attempt it every
-		// tick, ahead of the move.
+		// keyed on the MR, not the card, so it must NOT be gated behind a move that
+		// can defer: a forge move error, or an evicted card that stops being a
+		// candidate next tick, would otherwise leave the rework spending forever.
+		// Attempt it every tick, ahead of the move. Re-attempts converge: once the
+		// run is terminal (server-side path) GetActiveMRReworkRunForMR returns no
+		// rows → no-op nil; while a live worker's run is still non-terminal a
+		// re-entry re-stamps stop_kind and re-enqueues a cancel verdict, which is
+		// harmless (the worker cancels on the first it consumes) and only occurs in
+		// the narrow window where the move keeps deferring before the worker acks.
 		cancelErr := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64)
 		if cancelErr != nil {
 			slog.Warn("forgesvc: cancel rework on MR close failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "error", cancelErr)

--- a/api/internal/forgesvc/mr_watch.go
+++ b/api/internal/forgesvc/mr_watch.go
@@ -94,12 +94,23 @@ func (s *Service) syncOneMRState(ctx context.Context, repoID uuid.UUID, forgePro
 	case stored == forge.MRStateOpened && observed == forge.MRStateClosed:
 		// close-edge: reviewer rejected the MR → rework needed → In Progress,
 		// guarded from Human Review (where the completed run parked the card).
-		if s.guardedMRMove(ctx, repoID, forgeProjectID, c.IssueIid.Int64, f, board.ColumnHumanReview, board.ColumnInProgress) == moveDeferred {
-			return // forge failure / vanished card: leave the edge for next-tick retry
+		//
+		// A confirmed close means any in-flight rework can never land — abort it
+		// INDEPENDENTLY of the board move (#853 review finding). Cancellation is
+		// idempotent (no active rework / no canceller → no-op nil) and keyed on the
+		// MR, not the card, so it must NOT be gated behind a move that can defer:
+		// a forge move error, or an evicted card that stops being a candidate next
+		// tick, would otherwise leave the rework spending forever. Attempt it every
+		// tick, ahead of the move.
+		cancelErr := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64)
+		if cancelErr != nil {
+			slog.Warn("forgesvc: cancel rework on MR close failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "error", cancelErr)
 		}
-		if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
-			slog.Warn("forgesvc: cancel rework on MR close failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "error", err)
-			return // leave mr_state unadvanced so the next tick retries; don't consume the edge
+		moved := s.guardedMRMove(ctx, repoID, forgeProjectID, c.IssueIid.Int64, f, board.ColumnHumanReview, board.ColumnInProgress)
+		if moved == moveDeferred || cancelErr != nil {
+			// forge failure / vanished card, or a cancel that must be retried: leave
+			// mr_state unadvanced so the next tick re-observes the edge and retries.
+			return
 		}
 		s.recordMRState(ctx, c.ID, observed)
 	case stored == forge.MRStateClosed && observed == forge.MRStateOpened:

--- a/api/internal/forgesvc/mr_watch.go
+++ b/api/internal/forgesvc/mr_watch.go
@@ -97,6 +97,10 @@ func (s *Service) syncOneMRState(ctx context.Context, repoID uuid.UUID, forgePro
 		if s.guardedMRMove(ctx, repoID, forgeProjectID, c.IssueIid.Int64, f, board.ColumnHumanReview, board.ColumnInProgress) == moveDeferred {
 			return // forge failure / vanished card: leave the edge for next-tick retry
 		}
+		if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
+			slog.Warn("forgesvc: cancel rework on MR close failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "error", err)
+			return // leave mr_state unadvanced so the next tick retries; don't consume the edge
+		}
 		s.recordMRState(ctx, c.ID, observed)
 	case stored == forge.MRStateClosed && observed == forge.MRStateOpened:
 		// reopen-edge (Decision 6): restore the card Human Review-ward,
@@ -110,8 +114,29 @@ func (s *Service) syncOneMRState(ctx context.Context, repoID uuid.UUID, forgePro
 		// Unknown states never reach here — they are ignored before the bootstrap
 		// check above. A merge closes the issue via `Closes #N`, which the existing
 		// issue-close sync owns; locked is transient during merge processing.
+		//
+		// A merge additionally means the branch is gone and any in-flight rework can
+		// never land — abort it (#853). Locked is transient during merge processing
+		// and must NOT trigger a cancel.
+		if observed == forge.MRStateMerged {
+			if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
+				slog.Warn("forgesvc: cancel rework on MR merge failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "error", err)
+				return // leave mr_state unadvanced so the next tick retries
+			}
+		}
 		s.recordMRState(ctx, c.ID, observed)
 	}
+}
+
+// cancelReworkOnClosedMR aborts an in-flight mr_rework when its MR has merged/closed
+// (issue #853). Returns nil when no canceller is wired or no active rework exists.
+// A non-nil error means the caller must LEAVE mr_state unadvanced (don't consume the
+// edge) so the next poller tick retries — same contract as a forge-side failure.
+func (s *Service) cancelReworkOnClosedMR(ctx context.Context, repoID uuid.UUID, mrIID int64) error {
+	if s.reworkCanceller == nil {
+		return nil
+	}
+	return s.reworkCanceller.CancelReworkForMR(ctx, repoID, mrIID, "MR merged/closed during rework")
 }
 
 // moveOutcome is the result of a guarded MR-state move, distinguishing the two

--- a/api/internal/forgesvc/service.go
+++ b/api/internal/forgesvc/service.go
@@ -156,6 +156,18 @@ type Service struct {
 	// (PRD #71 M6). Optional (nil-safe): set via SetNotifier, unset means the landed
 	// notification is skipped — every other pipeline-sync behaviour is unaffected.
 	notifier LandedNotifier
+
+	// reworkCanceller aborts an in-flight mr_rework run when its MR leaves the opened
+	// state (issue #853). Optional (nil-safe): set via SetReworkCanceller, unset means
+	// the mid-flight abort is skipped — every other MR-sync behaviour is unaffected.
+	reworkCanceller ReworkCanceller
+}
+
+// ReworkCanceller aborts an active mr_rework run when its MR leaves the opened
+// state (issue #853). *workersvc.Service satisfies it. Optional (nil-safe): unset
+// means the mid-flight abort is skipped and every other sync behaviour is unchanged.
+type ReworkCanceller interface {
+	CancelReworkForMR(ctx context.Context, repoID uuid.UUID, mrIID int64, reason string) error
 }
 
 // LandedNotifier lands an inbox notification when a ci_fix run's fix pipeline goes
@@ -177,6 +189,11 @@ func New(q IssueStore, box *secretbox.Box, timeout time.Duration, labels LabelCo
 // startup, before the poller runs. A nil notifier (the default) disables the landed
 // inbox row; the rest of the sync is unchanged.
 func (s *Service) SetNotifier(n LandedNotifier) { s.notifier = n }
+
+// SetReworkCanceller wires the mid-flight mr_rework abort collaborator (issue #853).
+// Call once at startup, before the poller runs. A nil canceller (the default) disables
+// the abort; the rest of the sync is unchanged.
+func (s *Service) SetReworkCanceller(c ReworkCanceller) { s.reworkCanceller = c }
 
 // uziLabel resolves the configured uzi run-eligibility label for the sync filters,
 // falling back to the compiled-in default when unconfigured or on a settings read

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -1719,6 +1719,18 @@ UPDATE runs SET status = 'cancelled', status_since = now(), stop_kind = 'cancell
 WHERE id = @id AND user_id = @user_id
   AND status NOT IN ('completed', 'failed', 'cancelled');
 
+-- name: GetActiveMRReworkRunForMR :one
+-- Resolve the single non-terminal mr_rework run for a (repo, MR). Used by the
+-- mid-flight abort (issue #853): when the MR-close watcher sees the MR leave the
+-- opened state, the active rework is cancelled so a live worker stops spending.
+-- The WHERE is byte-identical to the partial unique index uq_runs_one_active_mr_rework
+-- (migration 00167) — that index is the ONLY reason this can be :one; widening it, or
+-- narrowing the status set here, would silently break the single-row guarantee.
+SELECT * FROM runs
+WHERE repo_id = @repo_id::uuid AND mr_iid = @mr_iid
+  AND kind = 'mr_rework'
+  AND status NOT IN ('completed', 'failed', 'cancelled');
+
 -- name: CancelRunByWorker :execrows
 -- Live-worker cancel transition (PRD #503 M1). When a LIVE worker consumes a cancel
 -- verdict it reports `failed`; SetState's failed arm routes HERE off the run's already

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -1775,6 +1775,133 @@ func (q *Queries) FailWorkerRunsOverCap(ctx context.Context, arg FailWorkerRunsO
 	return items, nil
 }
 
+const getActiveMRReworkRunForMR = `-- name: GetActiveMRReworkRunForMR :one
+SELECT id, user_id, repo_id, issue_iid, issue_title, issue_description, status, requeue_count, worker_id, session_id, last_seq, branch, mr_iid, failure_reason, plan_md, iteration_count, claimed_at, started_at, finished_at, created_at, updated_at, origin_column, board_column, move_pending_since, mr_state, auto_approve, autopilot_commented_at, kind, pipeline_id, pipeline_ref, failure_snapshot, fix_verdict, stop_kind, agent_source, agent_exclusions, repo_agents, title, resume_of_run_id, last_activity_at, health, health_reason, health_since, health_notified_at, target_run_id, mr_web_url, prd_done_path, prd_patch_settled_at, anthropic_secret_id, anthropic_secret_label, anthropic_select_reason, anthropic_headroom_pct, wait_on_limit, limit_resets_at, retry_not_before, limit_wait_count, rate_limit_type, open_question_id, revise_count, plan_source, planned_base_commit, require_base_match, milestones_candidate, milestones_frozen, milestones_completed, milestones_in_progress, budget_max_iterations, budget_wall_seconds, schedule_id, limit_dead_secret_id, report_only, report_md, ci_config_paths, model, override_subagent_model, fail_origin, priority, summary_intent, summary_plan, summary_deltas, issue_comments, base_branch, open_mr, dispatched_at, review_target_run_id, review_requested, then_fix_requested, then_fix_of_run_id, preserved_patch, required_capabilities, stop_reason, required_tools, size_class, interactive, open_followup_id, plan_changed_files, scope_ceiling, status_since, review_comments, budget_paused_seconds, lineage_epoch, mr_rework_enabled FROM runs
+WHERE repo_id = $1::uuid AND mr_iid = $2
+  AND kind = 'mr_rework'
+  AND status NOT IN ('completed', 'failed', 'cancelled')
+`
+
+type GetActiveMRReworkRunForMRParams struct {
+	RepoID uuid.UUID   `json:"repo_id"`
+	MrIid  pgtype.Int8 `json:"mr_iid"`
+}
+
+// Resolve the single non-terminal mr_rework run for a (repo, MR). Used by the
+// mid-flight abort (issue #853): when the MR-close watcher sees the MR leave the
+// opened state, the active rework is cancelled so a live worker stops spending.
+// The WHERE is byte-identical to the partial unique index uq_runs_one_active_mr_rework
+// (migration 00167) — that index is the ONLY reason this can be :one; widening it, or
+// narrowing the status set here, would silently break the single-row guarantee.
+func (q *Queries) GetActiveMRReworkRunForMR(ctx context.Context, arg GetActiveMRReworkRunForMRParams) (Run, error) {
+	row := q.db.QueryRow(ctx, getActiveMRReworkRunForMR, arg.RepoID, arg.MrIid)
+	var i Run
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.RepoID,
+		&i.IssueIid,
+		&i.IssueTitle,
+		&i.IssueDescription,
+		&i.Status,
+		&i.RequeueCount,
+		&i.WorkerID,
+		&i.SessionID,
+		&i.LastSeq,
+		&i.Branch,
+		&i.MrIid,
+		&i.FailureReason,
+		&i.PlanMd,
+		&i.IterationCount,
+		&i.ClaimedAt,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.OriginColumn,
+		&i.BoardColumn,
+		&i.MovePendingSince,
+		&i.MrState,
+		&i.AutoApprove,
+		&i.AutopilotCommentedAt,
+		&i.Kind,
+		&i.PipelineID,
+		&i.PipelineRef,
+		&i.FailureSnapshot,
+		&i.FixVerdict,
+		&i.StopKind,
+		&i.AgentSource,
+		&i.AgentExclusions,
+		&i.RepoAgents,
+		&i.Title,
+		&i.ResumeOfRunID,
+		&i.LastActivityAt,
+		&i.Health,
+		&i.HealthReason,
+		&i.HealthSince,
+		&i.HealthNotifiedAt,
+		&i.TargetRunID,
+		&i.MrWebUrl,
+		&i.PrdDonePath,
+		&i.PrdPatchSettledAt,
+		&i.AnthropicSecretID,
+		&i.AnthropicSecretLabel,
+		&i.AnthropicSelectReason,
+		&i.AnthropicHeadroomPct,
+		&i.WaitOnLimit,
+		&i.LimitResetsAt,
+		&i.RetryNotBefore,
+		&i.LimitWaitCount,
+		&i.RateLimitType,
+		&i.OpenQuestionID,
+		&i.ReviseCount,
+		&i.PlanSource,
+		&i.PlannedBaseCommit,
+		&i.RequireBaseMatch,
+		&i.MilestonesCandidate,
+		&i.MilestonesFrozen,
+		&i.MilestonesCompleted,
+		&i.MilestonesInProgress,
+		&i.BudgetMaxIterations,
+		&i.BudgetWallSeconds,
+		&i.ScheduleID,
+		&i.LimitDeadSecretID,
+		&i.ReportOnly,
+		&i.ReportMd,
+		&i.CiConfigPaths,
+		&i.Model,
+		&i.OverrideSubagentModel,
+		&i.FailOrigin,
+		&i.Priority,
+		&i.SummaryIntent,
+		&i.SummaryPlan,
+		&i.SummaryDeltas,
+		&i.IssueComments,
+		&i.BaseBranch,
+		&i.OpenMr,
+		&i.DispatchedAt,
+		&i.ReviewTargetRunID,
+		&i.ReviewRequested,
+		&i.ThenFixRequested,
+		&i.ThenFixOfRunID,
+		&i.PreservedPatch,
+		&i.RequiredCapabilities,
+		&i.StopReason,
+		&i.RequiredTools,
+		&i.SizeClass,
+		&i.Interactive,
+		&i.OpenFollowupID,
+		&i.PlanChangedFiles,
+		&i.ScopeCeiling,
+		&i.StatusSince,
+		&i.ReviewComments,
+		&i.BudgetPausedSeconds,
+		&i.LineageEpoch,
+		&i.MrReworkEnabled,
+	)
+	return i, err
+}
+
 const getForgeTypeForRepo = `-- name: GetForgeTypeForRepo :one
 SELECT c.forge_type
 FROM repos r

--- a/api/internal/workersvc/mr_rework_cancel.go
+++ b/api/internal/workersvc/mr_rework_cancel.go
@@ -1,0 +1,65 @@
+package workersvc
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// CancelReworkForMR aborts the active mr_rework run for (repoID, mrIID), if any,
+// when its MR has left the opened state (merged/closed) — issue #853. It reuses the
+// operator-cancel decision (submitInput's cancel branch, service.go) so a LIVE worker
+// is actually stopped: a raw status flip would enqueue nothing into run_user_inputs and
+// the worker would keep spending. No active rework → no-op (nil).
+//
+// GetActiveMRReworkRunForMR is :one, safe because its WHERE matches the
+// uq_runs_one_active_mr_rework partial unique index (migration 00167): at most one
+// non-terminal mr_rework run exists per (repo, MR).
+func (s *Service) CancelReworkForMR(ctx context.Context, repoID uuid.UUID, mrIID int64, reason string) error {
+	run, err := s.q.GetActiveMRReworkRunForMR(ctx, store.GetActiveMRReworkRunForMRParams{
+		RepoID: repoID,
+		MrIid:  pgtype.Int8{Int64: mrIID, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil // no active rework for this MR — nothing to cancel
+		}
+		return err
+	}
+	live, err := s.hasLivePoller(ctx, run)
+	if err != nil {
+		return err
+	}
+	if live {
+		// Live worker: enqueue a cancel verdict AND stamp stop_kind in one statement.
+		// The worker consumes it, reports failed, and SetState routes off stop_kind
+		// to CancelRunByWorker, finalizing to 'cancelled' (kind-agnostic).
+		_, err = s.q.CreateStopVerdictInput(ctx, store.CreateStopVerdictInputParams{
+			RunID:      run.ID,
+			Kind:       "cancel",
+			Body:       pgText(reason),
+			StopKind:   pgText("cancelled"),
+			StopReason: pgText(reason),
+		})
+		return err
+	}
+	// No live poller: server-side flip (owner-scoped by the run's own user_id).
+	if _, err = s.q.CancelRunServerSide(ctx, store.CancelRunServerSideParams{
+		ID:         run.ID,
+		UserID:     run.UserID,
+		StopReason: pgText(reason),
+	}); err != nil {
+		return err
+	}
+	if s.bcast != nil { // bcast is optional/post-construction — nil-guard required
+		s.bcast.PublishState(run.ID, "cancelled")
+	}
+	s.notify(run.ID, "cancelled")
+	s.maybeEnqueueJudgeByID(ctx, run.ID) // cancel is judge-filtered → no-op, but mirrors the operator path
+	return nil
+}

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -469,6 +469,11 @@ type Store interface {
 	ListPoolWaitRuns(ctx context.Context) ([]store.ListPoolWaitRunsRow, error)
 	PromotePoolWaitRun(ctx context.Context, arg store.PromotePoolWaitRunParams) (int64, error)
 	MarkRunFailedByID(ctx context.Context, arg store.MarkRunFailedByIDParams) (int64, error)
+	// GetActiveMRReworkRunForMR resolves the single non-terminal mr_rework run for a
+	// (repo, MR) — the mid-flight abort (issue #853) uses it to cancel a live rework
+	// when its MR leaves the opened state. :one is safe because the WHERE matches the
+	// uq_runs_one_active_mr_rework partial unique index (migration 00167).
+	GetActiveMRReworkRunForMR(ctx context.Context, arg store.GetActiveMRReworkRunForMRParams) (store.Run, error)
 	CancelRunServerSide(ctx context.Context, arg store.CancelRunServerSideParams) (int64, error)
 	// CancelRunByWorker is the LIVE-worker cancel transition (PRD #503 M1). SetState's
 	// failed arm routes here (instead of SetRunFailed) when the loaded run carries


### PR DESCRIPTION
Implements issue #853.

Closes #853

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-853`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active merge-request rework is now cancelled when a merge request is merged or closed.
  * Cancellation occurs even when the related board move is deferred.
  * Failed cancellations or board moves leave the merge-request state unchanged so the operation can be retried.
  * Locked merge requests are not cancelled.
  * Cancellation supports both live and non-live rework runs, including notifications and follow-up processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->