### PR TITLE
docs(uzi-watcher): correct the defer-to-rework wait (reset budget, cycle-anchor, exit-2 gate)

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -304,8 +304,14 @@ by anything on the PR itself.
    it, duplicating the work (not a data-loss collision if your pre-push re-check is clean,
    but wasted effort and a confusing double set of fix commits). **Budget at least ~40 min
    of polling for the run to APPEAR before falling back to a local fix, and poll for it
-   rather than eyeballing** — `scripts/wait-mrrework.sh OWNER/REPO PR` waits through the
-   fire→terminal lifecycle and exits when the run lands (or the budget elapses).
+   rather than eyeballing** — `scripts/wait-mrrework.sh OWNER/REPO PR [max] [int] [since_utc]`
+   waits through the fire→terminal lifecycle and exits when the run lands (or the budget
+   elapses). **Capture `since_utc` BEFORE the wait and pass it**, so the poller anchors to the
+   CURRENT rework cycle and cannot report a PRIOR cycle's already-terminal run as "done" (the
+   exact failure it exists to prevent, one cycle down): `SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)`
+   the moment you first see the findings, then `wait-mrrework.sh OWNER/REPO PR 45 60 "$SINCE"`.
+   Reuse the SAME `$SINCE` on every re-run — a run for any later comment is still created after
+   it, so one baseline catches every cycle for these findings.
 
    **That ~40-min budget is measured from the NEWEST review comment, so it RESETS every time
    a new one lands — it is not a fixed timer off the first finding.** mr_rework's quietPeriod
@@ -317,10 +323,14 @@ by anything on the PR itself.
    full quiet period has elapsed with NO new review comment AND no run has appeared (re-running
    `wait-mrrework.sh` after any new comment does exactly this).
 
-   Fall back to a local fix only when that budget is genuinely spent, or when mr_rework
-   structurally cannot help (owner opted out, the admin kill-switch is on, or a
-   `.github/workflows` finding — the "when this session still fixes locally" list below).
-   **Either way**, the
+   Fall back to a local fix **only on `wait-mrrework.sh` exit 2** — a CONFIRMED empty result
+   (no current-cycle run appeared across reliable polls) — or when mr_rework structurally
+   cannot help (owner opted out, the admin kill-switch is on, or a `.github/workflows` finding
+   — the "when this session still fixes locally" list below). **Its other exits do NOT
+   authorize a local fix:** exit 3 means a run is STILL reworking (re-run to keep waiting),
+   exit 5 means the polls were unreliable so "never fired" is unproven, and exit 4 means the
+   repo did not resolve — treating any of these as "budget spent, fix locally" re-opens the
+   double-push collision. **Either way**, the
    pre-push guard (re-list `kind=mr_rework` for this MR AND re-fetch the branch head, step 1)
    stays mandatory right before any local push, because the run can fire during your edit.
 3. **Let it finish, then decide from whether the head ACTUALLY moved — and read the ref

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -305,10 +305,22 @@ by anything on the PR itself.
    but wasted effort and a confusing double set of fix commits). **Budget at least ~40 min
    of polling for the run to APPEAR before falling back to a local fix, and poll for it
    rather than eyeballing** — `scripts/wait-mrrework.sh OWNER/REPO PR` waits through the
-   fire→terminal lifecycle and exits when the run lands (or the budget elapses). Fall back to
-   a local fix only when that budget is genuinely spent, or when mr_rework structurally
-   cannot help (owner opted out, the admin kill-switch is on, or a `.github/workflows`
-   finding — the "when this session still fixes locally" list below). **Either way**, the
+   fire→terminal lifecycle and exits when the run lands (or the budget elapses).
+
+   **That ~40-min budget is measured from the NEWEST review comment, so it RESETS every time
+   a new one lands — it is not a fixed timer off the first finding.** mr_rework's quietPeriod
+   debounce runs from the latest review comment on the MR, so a later CodeRabbit incremental,
+   a human note, or another bot posting mid-wait pushes the fire window forward by another
+   full debounce. A fixed "~40 min from when I first saw findings" countdown can therefore
+   expire while the run is still legitimately pending against a newer comment. So restart the
+   budget whenever a new review comment arrives, and conclude "it will not fire" only once a
+   full quiet period has elapsed with NO new review comment AND no run has appeared (re-running
+   `wait-mrrework.sh` after any new comment does exactly this).
+
+   Fall back to a local fix only when that budget is genuinely spent, or when mr_rework
+   structurally cannot help (owner opted out, the admin kill-switch is on, or a
+   `.github/workflows` finding — the "when this session still fixes locally" list below).
+   **Either way**, the
    pre-push guard (re-list `kind=mr_rework` for this MR AND re-fetch the branch head, step 1)
    stays mandatory right before any local push, because the run can fire during your edit.
 3. **Let it finish, then decide from whether the head ACTUALLY moved — and read the ref

--- a/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
+++ b/.claude/skills/uzi-watcher/scripts/wait-mrrework.sh
@@ -6,13 +6,17 @@
 # DEFER to it deterministically instead of eyeballing a too-short wait and then doing a
 # redundant local fix. Poll for the run to APPEAR, then to reach terminal.
 #
-# Usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]
+# Usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s] [since_utc]
 #   default budget: 45 ticks x 60s = 45 min (covers the observed ~40 min fire lag).
+#   since_utc: an RFC3339-UTC instant (`date -u +%Y-%m-%dT%H:%M:%SZ`) captured BEFORE this
+#     wait began. When set, only mr_rework runs created AFTER it count as "the current
+#     cycle" — see the cycle-anchoring note below. Omit it and the wait is legacy (newest
+#     run of ANY cycle), which can report a STALE prior cycle's terminal run as done.
 #
 # Exit codes:
-#   0  an mr_rework run reached terminal; prints MRREWORK_ID / MRREWORK_STATUS
-#   2  budget elapsed with NO mr_rework run seen AND the poll that ended the budget
-#      SUCCEEDED (a confirmed empty result) — safe to fall back to a local fix
+#   0  a CURRENT-cycle mr_rework run reached terminal; prints MRREWORK_ID / MRREWORK_STATUS
+#   2  budget elapsed with NO current-cycle mr_rework run seen AND the poll that ended the
+#      budget SUCCEEDED (a confirmed empty result) — the ONLY exit that authorizes a local fix
 #   3  budget elapsed while a run was still non-terminal (still reworking; re-run me)
 #   4  the OWNER/REPO could not be resolved to a uzi repo id
 #   5  budget elapsed but the polls were UNRELIABLE (every poll, or the final one,
@@ -22,13 +26,15 @@
 # The exit-2-vs-5 split is load-bearing: a failed listing must never masquerade as a
 # confirmed-empty "no run", or a transient `uzi`/network blip would greenlight a local
 # fix while mr_rework is in fact mid-flight — recreating the double-push collision this
-# poller exists to prevent.
+# poller exists to prevent. Callers must treat ONLY exit 2 as "no rework, fix locally";
+# 3/4/5 all mean "do NOT fix locally yet".
 set -uo pipefail
 
-REPO_SLUG=${1:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]}
-PR=${2:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s]}
+REPO_SLUG=${1:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s] [since_utc]}
+PR=${2:?usage: wait-mrrework.sh OWNER/REPO PR [max_ticks] [interval_s] [since_utc]}
 MAX=${3:-45}
 INT=${4:-60}
+SINCE=${5:-}   # RFC3339-UTC baseline; empty = legacy (no cycle anchoring)
 
 REPO_ID=$(uzi repo list --json 2>/dev/null \
   | jq -r --arg s "$REPO_SLUG" 'first(.[]|select(.path_with_namespace==$s)|.id) // empty')
@@ -55,9 +61,17 @@ for i in $(seq 1 "$MAX"); do
   # Anchor on the NEWEST mr_rework run for this MR, not an arbitrary first match: an MR can
   # be reworked over several cycles (each a distinct run, up to the per-MR cap), so `first`
   # could latch onto a stale TERMINAL earlier cycle and exit 0 while the current cycle is
-  # still running. `max_by(.created_at)` always tracks the latest cycle.
-  row=$(printf '%s' "$raw" | jq -r --arg repo "$REPO_ID" --argjson pr "$PR" \
-    '([.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr)] | max_by(.created_at)) // {} | "\(.id // "")\t\(.status // "")"')
+  # still running. `max_by(.created_at)` tracks the latest cycle — but "latest that EXISTS
+  # right now" is still a PRIOR cycle's terminal run until the current one is queued, so a
+  # bare max_by can report an old completed run as done before this cycle fires. SINCE fixes
+  # that: when set, only runs created after it are considered, so a prior cycle's run is
+  # excluded and the wait holds for the run this review actually triggers. Fractional seconds
+  # are stripped so a plain `YYYY-MM-DDTHH:MM:SSZ` baseline compares lexicographically (same
+  # format + UTC 'Z' => string order == time order).
+  row=$(printf '%s' "$raw" | jq -r --arg repo "$REPO_ID" --argjson pr "$PR" --arg since "$SINCE" \
+    '([.[]|select(.kind=="mr_rework" and .repo_id==$repo and .mr_iid==$pr
+        and ($since=="" or ((.created_at|sub("\\.[0-9]+";"")) > $since)))]
+      | max_by(.created_at)) // {} | "\(.id // "")\t\(.status // "")"')
   id=$(printf '%s' "$row" | cut -f1)
   st=$(printf '%s' "$row" | cut -f2)
   if [ -z "$id" ]; then


### PR DESCRIPTION
Refines the mr_rework defer-to-rework mechanism #850 shipped. Three points:

1. **Budget resets on each new review comment** — mr_rework's quietPeriod is measured from the *newest* comment, so a fixed timer off the first finding under-waits.
2. **Cycle-anchor `wait-mrrework.sh`** (CR finding) — `max_by(.created_at)` returns the newest run that exists *now*, which is a PRIOR cycle's terminal run until the new cycle is queued, so the poller could report an old completed run as 'done'. Added an optional `since_utc` baseline (5th arg): only runs created after it count as the current cycle. The skill captures `SINCE` before waiting and reuses it across re-runs.
3. **Gate local fallback on exit 2 only** (CR finding) — exit 3 (still reworking) / 5 (unreliable) / 4 (repo unresolved) must NOT authorize a local fix, or the double-push collision re-opens.

(2) and (3) are the two valid CodeRabbit findings on this PR, fixed here rather than deferred. shellcheck + agnix clean.