### PR TITLE
bug(run-dedup): completed issue run with an open MR doesn't block a fresh manual re-run of the same issue

### DIFF
--- a/api/cmd/uzi/commands_test.go
+++ b/api/cmd/uzi/commands_test.go
@@ -1610,6 +1610,35 @@ func TestRunCreateMrReworkIsTriState(t *testing.T) {
 	}
 }
 
+// TestRunCreateForceThreadsThrough covers the --force flag (issue #856). Unlike the
+// tri-state flags, force is a plain bool: omitting it forwards false (respect the open-MR
+// guard, the default), and --force forwards true (bypass ONLY the open-MR guard). It proves
+// the CLI resolves the flag to the value the client's wire test then maps onto the body.
+func TestRunCreateForceThreadsThrough(t *testing.T) {
+	t.Setenv("UZI_URL", "")
+	t.Setenv("UZI_TOKEN", "")
+
+	run := func(t *testing.T, extra ...string) *uzicli.FakeClient {
+		t.Helper()
+		fc := &uzicli.FakeClient{CreatedRun: apitypes.RunDTO{ID: "r1", Kind: "issue", Status: "queued"}}
+		env := fakeEnv(fc)
+		env.Stdout = &bytes.Buffer{}
+		env.Stderr = &bytes.Buffer{}
+		args := append([]string{"run", "create", "--repo", "p1", "--issue", "42"}, extra...)
+		if code := Main(env, args); code != uzicli.ExitOK {
+			t.Fatalf("run create %v exit = %d, want 0", extra, code)
+		}
+		return fc
+	}
+
+	if got := run(t).LastCreateForce; got {
+		t.Errorf("omitting --force forwarded true, want false — a plain create must respect the open-MR guard")
+	}
+	if got := run(t, "--force").LastCreateForce; !got {
+		t.Errorf("--force forwarded false, want true — it must ask the server to bypass the open-MR guard")
+	}
+}
+
 // TestRunMrReworkVerb covers `uzi run mr-rework <id>` (PRD #841 M3, acceptance #1). The
 // verb is tri-state: a bare invocation and --enabled send true, --enabled=false sends
 // false, and --clear sends nil (clear the override back to inherit). --clear together with

--- a/api/cmd/uzi/run.go
+++ b/api/cmd/uzi/run.go
@@ -472,7 +472,8 @@ func newRunCmd(env Env, gf *globalFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			run, err := c.CreateRun(cmd.Context(), repoID, issue, waitOnLimitFlag(cmd), mrReworkFlag(cmd), seed)
+			force, _ := cmd.Flags().GetBool("force")
+			run, err := c.CreateRun(cmd.Context(), repoID, issue, waitOnLimitFlag(cmd), mrReworkFlag(cmd), force, seed)
 			if err != nil {
 				return err
 			}
@@ -487,6 +488,9 @@ func newRunCmd(env Env, gf *globalFlags) *cobra.Command {
 	create.Flags().Bool("mr-rework", false,
 		"enable or disable auto-rework of this run's MR review comments; "+
 			"omit to inherit the account default, or pass --mr-rework=false to force off")
+	create.Flags().Bool("force", false,
+		"re-run even if the issue already has an open MR from a completed run "+
+			"(bypasses only the open-MR guard; a run already in progress is never bypassed)")
 	// PRD #209 seeded plan. --agent-source/--exclude-agents reuse the plan gate's flag
 	// names and validation (approveSelection); both are meaningful only alongside a plan.
 	create.Flags().String("plan-file", "",

--- a/api/internal/handler/seeded_plan_livedb_test.go
+++ b/api/internal/handler/seeded_plan_livedb_test.go
@@ -144,7 +144,7 @@ func TestSeededRunClaimCarriesApprovedPlanNoInputRowLiveDB(t *testing.T) {
 
 	const plan = "# Plan\n\nImplement the widget in widget.go. Done when the tests pass."
 	sel := workersvc.AgentSelection{Source: workersvc.AgentSourceRepo, Exclusions: []string{"reviewer"}}
-	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, &workersvc.SeededPlan{PlanMD: plan, Selection: &sel})
+	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, false, &workersvc.SeededPlan{PlanMD: plan, Selection: &sel})
 	if err != nil {
 		t.Fatalf("CreateRun (seeded): %v", err)
 	}
@@ -206,7 +206,7 @@ func TestSeededRunFallThroughToGateDisarmsLiveDB(t *testing.T) {
 	f := newSeededPlanFixture(ctx, t)
 
 	sel := workersvc.AgentSelection{Source: workersvc.AgentSourceRepo, Exclusions: []string{"reviewer"}}
-	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, &workersvc.SeededPlan{PlanMD: "# Seeded plan\nImplement it.", Selection: &sel})
+	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, false, &workersvc.SeededPlan{PlanMD: "# Seeded plan\nImplement it.", Selection: &sel})
 	if err != nil {
 		t.Fatalf("CreateRun (seeded): %v", err)
 	}
@@ -289,7 +289,7 @@ func TestSeededRunClaimCarriesPlannedBaseCommitLiveDB(t *testing.T) {
 	f := newSeededPlanFixture(ctx, t)
 
 	const plannedCommit = "abc123def4567890abc123def4567890abc12345"
-	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, &workersvc.SeededPlan{
+	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, false, &workersvc.SeededPlan{
 		PlanMD:        "# Plan\nImplement the widget.",
 		PlannedCommit: plannedCommit,
 		RequireBase:   true,
@@ -339,7 +339,7 @@ func TestSeededRunNoPlannedCommitClaimIsInertLiveDB(t *testing.T) {
 	ctx := context.Background()
 	f := newSeededPlanFixture(ctx, t)
 
-	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, &workersvc.SeededPlan{PlanMD: "# Plan\nImplement it."})
+	run, err := f.svc.CreateRun(ctx, f.owner, f.repoID, f.iid, "issue body", nil, nil, false, &workersvc.SeededPlan{PlanMD: "# Plan\nImplement it."})
 	if err != nil {
 		t.Fatalf("CreateRun (seeded, no planned commit): %v", err)
 	}

--- a/api/internal/handler/workers.go
+++ b/api/internal/handler/workers.go
@@ -882,6 +882,11 @@ func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 		// them.
 		PlannedCommit *string `json:"planned_commit"`
 		RequireBase   bool    `json:"require_base"`
+		// Force (issue #856): bypass ONLY the create-time open-MR dedup (a completed prior
+		// run still owning an OPEN MR for this issue). A plain bool — absence means "do not
+		// force" — and it never affects the active-run gate. The CLI `uzi run create --force`
+		// sets it (m2); the web board start button omits it.
+		Force bool `json:"force"`
 	}
 	if err := httpx.DecodeJSON(r, &req); err != nil {
 		httpx.Error(w, http.StatusBadRequest, "invalid request body")
@@ -932,7 +937,7 @@ func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 	// The forge GetIssue snapshot, the uzi-label eligibility gate and the description
 	// cap all live inside StartRunForUser (PRD #191 M1), shared with the Slack/web chat
 	// start-run card.
-	run, err := h.wsvc.StartRunForUser(r.Context(), user.ID, repo.ID, req.IssueIID, req.WaitOnLimit, req.MrReworkEnabled, seed)
+	run, err := h.wsvc.StartRunForUser(r.Context(), user.ID, repo.ID, req.IssueIID, req.WaitOnLimit, req.MrReworkEnabled, req.Force, seed)
 	if err != nil {
 		h.writeStartRunError(w, r, err)
 		return
@@ -1084,6 +1089,10 @@ func (h *Handler) writeStartRunError(w http.ResponseWriter, r *http.Request, err
 		// internal invariant violation, never a caller error — 500, logged.
 		slog.Error("create task run: branch-safety assertion failed", "error", err)
 		httpx.Error(w, http.StatusInternalServerError, "internal error")
+	case errors.Is(err, workersvc.ErrOpenMRExists):
+		// issue #856: distinct from the active-run 409. A machine-readable `code` lets the
+		// web offer a force-retry confirm; the message already names the MR.
+		httpx.JSON(w, http.StatusConflict, map[string]any{"error": err.Error(), "code": "issue_has_open_mr"})
 	case errors.Is(err, workersvc.ErrActiveRunExists):
 		httpx.Error(w, http.StatusConflict, "a run is already in progress for this issue")
 	case errors.Is(err, workersvc.ErrBranchInUse):

--- a/api/internal/handler/workers.go
+++ b/api/internal/handler/workers.go
@@ -1090,9 +1090,15 @@ func (h *Handler) writeStartRunError(w http.ResponseWriter, r *http.Request, err
 		slog.Error("create task run: branch-safety assertion failed", "error", err)
 		httpx.Error(w, http.StatusInternalServerError, "internal error")
 	case errors.Is(err, workersvc.ErrOpenMRExists):
-		// issue #856: distinct from the active-run 409. A machine-readable `code` lets the
-		// web offer a force-retry confirm; the message already names the MR.
-		httpx.JSON(w, http.StatusConflict, map[string]any{"error": err.Error(), "code": "issue_has_open_mr"})
+		// issue #856: distinct from the active-run 409. A machine-readable `code` +
+		// structured `mr_iid` let the web compose its own confirm; `error` keeps the
+		// full message (incl. the --force hint the CLI surfaces).
+		body := map[string]any{"error": err.Error(), "code": "issue_has_open_mr"}
+		var omErr *workersvc.OpenMRExistsError
+		if errors.As(err, &omErr) {
+			body["mr_iid"] = omErr.MRIID
+		}
+		httpx.JSON(w, http.StatusConflict, body)
 	case errors.Is(err, workersvc.ErrActiveRunExists):
 		httpx.Error(w, http.StatusConflict, "a run is already in progress for this issue")
 	case errors.Is(err, workersvc.ErrBranchInUse):

--- a/api/internal/poller/autopilot.go
+++ b/api/internal/poller/autopilot.go
@@ -225,6 +225,11 @@ func (a *Autopilot) handle(ctx context.Context, r store.ListEnabledReposWithConn
 	case errors.Is(err, workersvc.ErrActiveRunExists):
 		// A run appeared between the pre-check and here: swallow, same as an active run.
 		_ = a.record(ctx, r, iid, eventID)
+	case errors.Is(err, workersvc.ErrOpenMRExists):
+		// issue #856: the issue already has an open MR from a prior completed run. Record
+		// the event and swallow (no comment), same shape as the active-run case, so the
+		// detector does not re-evaluate and log-storm every tick.
+		_ = a.record(ctx, r, iid, eventID)
 	case errors.Is(err, workersvc.ErrNotPRDIssue):
 		// The run gate says this issue is not uzi's: it carries neither the uzi_label
 		// nor a uzi-bot assignment (PRD #102 Decision 14; the gate is widened by PRD

--- a/api/internal/schedsvc/scheduler.go
+++ b/api/internal/schedsvc/scheduler.go
@@ -100,7 +100,7 @@ type Store interface {
 // RunCreator is the shared run-creation seam the scheduler fires through — the SAME
 // seam autopilot and the manual board use. *workersvc.Service satisfies it.
 type RunCreator interface {
-	CreateRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, waitOnLimit *bool, mrReworkEnabled *bool, seed *workersvc.SeededPlan) (store.Run, error)
+	CreateRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, waitOnLimit *bool, mrReworkEnabled *bool, force bool, seed *workersvc.SeededPlan) (store.Run, error)
 	// CreateScheduledRun is the non-auto-approve scheduled path: like CreateRun but the
 	// plan gate still requires a human (see workersvc.CreateScheduledRun). Eligibility is
 	// the single uzi_label gate (PRD #764 M1); a PRD link is no longer required.

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -221,7 +221,7 @@ func (f *fakeRuns) effErr(issueIID int64) error {
 	return f.err
 }
 
-func (f *fakeRuns) CreateRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, _ string, waitOnLimit *bool, mrReworkEnabled *bool, _ *workersvc.SeededPlan) (store.Run, error) {
+func (f *fakeRuns) CreateRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, _ string, waitOnLimit *bool, mrReworkEnabled *bool, _ bool, _ *workersvc.SeededPlan) (store.Run, error) {
 	if f.err != nil {
 		return store.Run{}, f.err
 	}
@@ -939,6 +939,7 @@ func TestSkipReasonForErr(t *testing.T) {
 		{workersvc.ErrNotPRDIssue, SkipNotEligible, true},
 		{workersvc.ErrActiveRunExists, SkipAlreadyRunning, true},
 		{workersvc.ErrDescriptionTooLarge, SkipDescriptionTooLarge, true},
+		{workersvc.ErrOpenMRExists, SkipOpenMRExists, true},
 		{workersvc.ErrActivePromptExists, "", false},
 		{workersvc.ErrRepoNotFound, "", false},
 		{context.DeadlineExceeded, "", false},
@@ -950,9 +951,10 @@ func TestSkipReasonForErr(t *testing.T) {
 		}
 	}
 	// AllSkipReasons enumerates the full closed set (PRD #590 M1 added vault_locked;
-	// PRD #686 D10 added self_improve_mr_cap_reached; PRD #764 retired not_eligible).
-	if len(AllSkipReasons) != 6 {
-		t.Fatalf("AllSkipReasons has %d reasons, want 6", len(AllSkipReasons))
+	// PRD #686 D10 added self_improve_mr_cap_reached; PRD #764 retired not_eligible;
+	// issue #856 added open_mr_exists).
+	if len(AllSkipReasons) != 7 {
+		t.Fatalf("AllSkipReasons has %d reasons, want 7", len(AllSkipReasons))
 	}
 }
 

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -179,6 +179,9 @@ type runCall struct {
 	// overrideSubagentModel is the schedule's "apply model also to agents" opt-in (PRD
 	// #305), captured for a later assertion. false for the interactive CreateRun.
 	overrideSubagentModel bool
+	// force is the CreateRun bypass flag (issue #856); automated scheduler seams must NEVER
+	// force, so this is asserted false.
+	force bool
 }
 
 type promptCall struct {
@@ -221,13 +224,14 @@ func (f *fakeRuns) effErr(issueIID int64) error {
 	return f.err
 }
 
-func (f *fakeRuns) CreateRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, _ string, waitOnLimit *bool, mrReworkEnabled *bool, _ bool, _ *workersvc.SeededPlan) (store.Run, error) {
+func (f *fakeRuns) CreateRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, _ string, waitOnLimit *bool, mrReworkEnabled *bool, force bool, _ *workersvc.SeededPlan) (store.Run, error) {
 	if f.err != nil {
 		return store.Run{}, f.err
 	}
 	// nil model: the interactive CreateRun seam carries no per-schedule model (PRD #300).
 	// false overrideSubagentModel: no per-run opt-in on the interactive seam (PRD #305).
-	f.runs = append(f.runs, runCall{userID, repoID, issueIID, waitOnLimit, mrReworkEnabled, false, nil, false})
+	// force is captured so a test can prove the scheduler never sets it (issue #856).
+	f.runs = append(f.runs, runCall{userID, repoID, issueIID, waitOnLimit, mrReworkEnabled, false, nil, false, force})
 	return store.Run{ID: uuid.New()}, nil
 }
 func (f *fakeRuns) CreateScheduledRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, _ string, waitOnLimit *bool, mrReworkEnabled *bool, model *string, overrideSubagentModel bool, _ *workersvc.SeededPlan) (store.Run, error) {
@@ -238,7 +242,8 @@ func (f *fakeRuns) CreateScheduledRun(_ context.Context, userID, repoID uuid.UUI
 	if err := f.effErr(issueIID); err != nil {
 		return store.Run{}, err
 	}
-	f.runs = append(f.runs, runCall{userID, repoID, issueIID, waitOnLimit, mrReworkEnabled, true, model, overrideSubagentModel})
+	// false force: the scheduled seam never forces a run creation (issue #856).
+	f.runs = append(f.runs, runCall{userID, repoID, issueIID, waitOnLimit, mrReworkEnabled, true, model, overrideSubagentModel, false})
 	return store.Run{ID: uuid.New()}, nil
 }
 func (f *fakeRuns) CreateAutopilotRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, description string) (store.Run, error) {
@@ -599,6 +604,11 @@ func TestTickNonAutoIssueScheduleUsesTheScheduledSeam(t *testing.T) {
 	}
 	if !h.runs.runs[0].scheduled {
 		t.Fatalf("non-auto issue must fire through CreateScheduledRun (waiver-free), not CreateRun (interactive, waiver-carrying)")
+	}
+	for i, rc := range h.runs.runs {
+		if rc.force {
+			t.Fatalf("scheduler must never force a run creation (issue #856): runs[%d].force = true", i)
+		}
 	}
 }
 

--- a/api/internal/schedsvc/skip_reason.go
+++ b/api/internal/schedsvc/skip_reason.go
@@ -45,6 +45,12 @@ const (
 	// normally and re-fires next cadence once a human merges or closes an outstanding MR, and
 	// the owner gets a selfimprove_skipped notification.
 	SkipSelfImproveMRCapReached SkipReason = "self_improve_mr_cap_reached"
+
+	// SkipOpenMRExists ← workersvc.ErrOpenMRExists (issue #856): a prior completed run for
+	// this issue still owns an OPEN merge request, so createRun refuses a fresh run. Benign:
+	// the sweep skips this candidate and advances, and the cadence re-fires once the MR is
+	// merged or closed.
+	SkipOpenMRExists SkipReason = "open_mr_exists"
 )
 
 // AllSkipReasons lists every SkipReason in the closed set. The cross-language contract
@@ -56,6 +62,7 @@ var AllSkipReasons = []SkipReason{
 	SkipFetchFailed,
 	SkipVaultLocked,
 	SkipSelfImproveMRCapReached,
+	SkipOpenMRExists,
 }
 
 // skipReasonForErr maps the benign run-creation seam sentinels to their SkipReason.
@@ -72,6 +79,8 @@ func skipReasonForErr(err error) (SkipReason, bool) {
 		return SkipAlreadyRunning, true
 	case errors.Is(err, workersvc.ErrDescriptionTooLarge):
 		return SkipDescriptionTooLarge, true
+	case errors.Is(err, workersvc.ErrOpenMRExists):
+		return SkipOpenMRExists, true
 	default:
 		return "", false
 	}

--- a/api/internal/schedsvc/skip_reason_test.go
+++ b/api/internal/schedsvc/skip_reason_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 // TestSkipReasonEnumIsHonest pins the Go side of the SkipReason contract internally
-// consistent (PRD #308 M3; PRD #590 M1 added vault_locked; PRD #764 retired the link-less skip):
-// the closed set has exactly the six expected members with no duplicates, every benign seam
+// consistent (PRD #308 M3; PRD #590 M1 added vault_locked; PRD #764 retired the link-less skip;
+// issue #856 added open_mr_exists):
+// the closed set has exactly the seven expected members with no duplicates, every benign seam
 // sentinel maps into that set, an unrelated error maps to no reason, and the reasons the
 // seam does not map (fetch_failed is recorded at the sweep site, already_running also at the
 // prompt site, vault_locked at the self_improve site) are still enumerated. The
@@ -24,6 +25,7 @@ func TestSkipReasonEnumIsHonest(t *testing.T) {
 		SkipFetchFailed:             true,
 		SkipVaultLocked:             true,
 		SkipSelfImproveMRCapReached: true,
+		SkipOpenMRExists:            true,
 	}
 
 	if len(AllSkipReasons) != len(want) {
@@ -65,6 +67,7 @@ func TestSkipReasonEnumIsHonest(t *testing.T) {
 		{"ErrNotPRDIssue", workersvc.ErrNotPRDIssue},
 		{"ErrActiveRunExists", workersvc.ErrActiveRunExists},
 		{"ErrDescriptionTooLarge", workersvc.ErrDescriptionTooLarge},
+		{"ErrOpenMRExists", workersvc.ErrOpenMRExists},
 	}
 	for _, c := range mapped {
 		got, ok := skipReasonForErr(c.err)

--- a/api/internal/store/autopilot.sql.go
+++ b/api/internal/store/autopilot.sql.go
@@ -84,6 +84,38 @@ func (q *Queries) GetAutopilotTrigger(ctx context.Context, arg GetAutopilotTrigg
 	return i, err
 }
 
+const getOpenMRRunForIssue = `-- name: GetOpenMRRunForIssue :one
+SELECT r.mr_iid
+FROM runs r
+WHERE r.repo_id = $1::uuid
+  AND r.issue_iid = $2
+  AND r.kind = 'issue'
+  AND r.status = 'completed'
+  AND r.mr_iid IS NOT NULL
+  AND r.mr_state = 'opened'
+ORDER BY r.created_at DESC
+LIMIT 1
+`
+
+type GetOpenMRRunForIssueParams struct {
+	RepoID   uuid.UUID   `json:"repo_id"`
+	IssueIid pgtype.Int8 `json:"issue_iid"`
+}
+
+// The MR iid of a completed issue run that still owns an OPEN merge request for this
+// issue (issue #856). Backs createRun's create-time open-MR refusal: a fresh issue run
+// is blocked while a prior run's MR is still open, so we do not re-plan + re-review onto
+// an MR that is already open. Mirrors ListMRReworkCandidates' watcher-owned open-MR gate
+// (kind='issue', completed, an mr_iid, watcher-owned mr_state='opened'). Returns the MR
+// iid so the refusal can name it. LIMIT 1 / newest-first is arbitrary among multiple
+// open-MR runs (there is normally at most one). pgx.ErrNoRows => no open MR (allow).
+func (q *Queries) GetOpenMRRunForIssue(ctx context.Context, arg GetOpenMRRunForIssueParams) (pgtype.Int8, error) {
+	row := q.db.QueryRow(ctx, getOpenMRRunForIssue, arg.RepoID, arg.IssueIid)
+	var mr_iid pgtype.Int8
+	err := row.Scan(&mr_iid)
+	return mr_iid, err
+}
+
 const hasActiveRunForIssue = `-- name: HasActiveRunForIssue :one
 SELECT EXISTS (
     SELECT 1 FROM runs

--- a/api/internal/store/autopilot.sql.go
+++ b/api/internal/store/autopilot.sql.go
@@ -92,7 +92,8 @@ WHERE r.repo_id = $1::uuid
   AND r.kind = 'issue'
   AND r.status = 'completed'
   AND r.mr_iid IS NOT NULL
-  AND r.mr_state = 'opened'
+  AND r.mr_state IS DISTINCT FROM 'merged'
+  AND r.mr_state IS DISTINCT FROM 'closed'
 ORDER BY r.created_at DESC
 LIMIT 1
 `
@@ -105,10 +106,15 @@ type GetOpenMRRunForIssueParams struct {
 // The MR iid of a completed issue run that still owns an OPEN merge request for this
 // issue (issue #856). Backs createRun's create-time open-MR refusal: a fresh issue run
 // is blocked while a prior run's MR is still open, so we do not re-plan + re-review onto
-// an MR that is already open. Mirrors ListMRReworkCandidates' watcher-owned open-MR gate
-// (kind='issue', completed, an mr_iid, watcher-owned mr_state='opened'). Returns the MR
-// iid so the refusal can name it. LIMIT 1 / newest-first is arbitrary among multiple
-// open-MR runs (there is normally at most one). pgx.ErrNoRows => no open MR (allow).
+// an MR that is already open. The guard keys on the authoritative mr_iid, written
+// atomically at completion by SetRunCompleted (same statement as status='completed'), so
+// it is create-time authoritative and independent of watcher lag. It releases only once
+// the watcher has recorded a TERMINAL state ('merged'/'closed'); a NULL mr_state (watcher
+// not yet ticked) conservatively BLOCKS, closing the false-negative window a prior version
+// of this query had (it keyed on mr_state='opened' alone, which lags mr_iid). Uses
+// IS DISTINCT FROM so NULL/'opened'/'locked' all block and only terminal states release.
+// Returns the MR iid so the refusal can name it. LIMIT 1 / newest-first is arbitrary among
+// multiple open-MR runs (there is normally at most one). pgx.ErrNoRows => no open MR (allow).
 func (q *Queries) GetOpenMRRunForIssue(ctx context.Context, arg GetOpenMRRunForIssueParams) (pgtype.Int8, error) {
 	row := q.db.QueryRow(ctx, getOpenMRRunForIssue, arg.RepoID, arg.IssueIid)
 	var mr_iid pgtype.Int8

--- a/api/internal/store/queries/autopilot.sql
+++ b/api/internal/store/queries/autopilot.sql
@@ -100,3 +100,22 @@ SELECT EXISTS (
     WHERE repo_id = @repo_id::uuid AND issue_iid = @issue_iid
       AND status NOT IN ('completed', 'failed', 'cancelled')
 ) AS active;
+
+-- name: GetOpenMRRunForIssue :one
+-- The MR iid of a completed issue run that still owns an OPEN merge request for this
+-- issue (issue #856). Backs createRun's create-time open-MR refusal: a fresh issue run
+-- is blocked while a prior run's MR is still open, so we do not re-plan + re-review onto
+-- an MR that is already open. Mirrors ListMRReworkCandidates' watcher-owned open-MR gate
+-- (kind='issue', completed, an mr_iid, watcher-owned mr_state='opened'). Returns the MR
+-- iid so the refusal can name it. LIMIT 1 / newest-first is arbitrary among multiple
+-- open-MR runs (there is normally at most one). pgx.ErrNoRows => no open MR (allow).
+SELECT r.mr_iid
+FROM runs r
+WHERE r.repo_id = @repo_id::uuid
+  AND r.issue_iid = @issue_iid
+  AND r.kind = 'issue'
+  AND r.status = 'completed'
+  AND r.mr_iid IS NOT NULL
+  AND r.mr_state = 'opened'
+ORDER BY r.created_at DESC
+LIMIT 1;

--- a/api/internal/store/queries/autopilot.sql
+++ b/api/internal/store/queries/autopilot.sql
@@ -105,10 +105,15 @@ SELECT EXISTS (
 -- The MR iid of a completed issue run that still owns an OPEN merge request for this
 -- issue (issue #856). Backs createRun's create-time open-MR refusal: a fresh issue run
 -- is blocked while a prior run's MR is still open, so we do not re-plan + re-review onto
--- an MR that is already open. Mirrors ListMRReworkCandidates' watcher-owned open-MR gate
--- (kind='issue', completed, an mr_iid, watcher-owned mr_state='opened'). Returns the MR
--- iid so the refusal can name it. LIMIT 1 / newest-first is arbitrary among multiple
--- open-MR runs (there is normally at most one). pgx.ErrNoRows => no open MR (allow).
+-- an MR that is already open. The guard keys on the authoritative mr_iid, written
+-- atomically at completion by SetRunCompleted (same statement as status='completed'), so
+-- it is create-time authoritative and independent of watcher lag. It releases only once
+-- the watcher has recorded a TERMINAL state ('merged'/'closed'); a NULL mr_state (watcher
+-- not yet ticked) conservatively BLOCKS, closing the false-negative window a prior version
+-- of this query had (it keyed on mr_state='opened' alone, which lags mr_iid). Uses
+-- IS DISTINCT FROM so NULL/'opened'/'locked' all block and only terminal states release.
+-- Returns the MR iid so the refusal can name it. LIMIT 1 / newest-first is arbitrary among
+-- multiple open-MR runs (there is normally at most one). pgx.ErrNoRows => no open MR (allow).
 SELECT r.mr_iid
 FROM runs r
 WHERE r.repo_id = @repo_id::uuid
@@ -116,6 +121,7 @@ WHERE r.repo_id = @repo_id::uuid
   AND r.kind = 'issue'
   AND r.status = 'completed'
   AND r.mr_iid IS NOT NULL
-  AND r.mr_state = 'opened'
+  AND r.mr_state IS DISTINCT FROM 'merged'
+  AND r.mr_state IS DISTINCT FROM 'closed'
 ORDER BY r.created_at DESC
 LIMIT 1;

--- a/api/internal/uzicli/authflow_test.go
+++ b/api/internal/uzicli/authflow_test.go
@@ -144,7 +144,7 @@ func TestCreateRunWireShape(t *testing.T) {
 		_, _ = io.WriteString(w, `{"run":{"id":"run-1","status":"queued","kind":"issue"}}`)
 	}))
 	defer srv.Close()
-	run, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, nil, nil)
+	run, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/internal/uzicli/client.go
+++ b/api/internal/uzicli/client.go
@@ -180,7 +180,7 @@ type Client interface {
 	// before), and a non-nil seed always carries a plan (the server rejects a
 	// selection with no plan). The plan's size cap and empty-plan rejection are the
 	// SERVER's (422) — the client forwards the bytes so those rules live in one place.
-	CreateRun(ctx context.Context, repoID string, issueIID int64, waitOnLimit *bool, mrReworkEnabled *bool, seed *CreateRunSeed) (apitypes.RunDTO, error)
+	CreateRun(ctx context.Context, repoID string, issueIID int64, waitOnLimit *bool, mrReworkEnabled *bool, force bool, seed *CreateRunSeed) (apitypes.RunDTO, error)
 	// CreateTaskRun queues an issue-less handoff/task run on a repo (PRD #400 M3):
 	// POST /api/repos/{id}/task-runs {context, base_branch?, open_mr}. The server
 	// names the branch (uzi/task/<run-id>) and the created-run response carries it in
@@ -1304,7 +1304,7 @@ type CreateRunSeed struct {
 	RequireBase bool
 }
 
-func (c *HTTPClient) CreateRun(ctx context.Context, repoID string, issueIID int64, waitOnLimit *bool, mrReworkEnabled *bool, seed *CreateRunSeed) (apitypes.RunDTO, error) {
+func (c *HTTPClient) CreateRun(ctx context.Context, repoID string, issueIID int64, waitOnLimit *bool, mrReworkEnabled *bool, force bool, seed *CreateRunSeed) (apitypes.RunDTO, error) {
 	var env struct {
 		Run apitypes.RunDTO `json:"run"`
 	}
@@ -1329,15 +1329,21 @@ func (c *HTTPClient) CreateRun(ctx context.Context, repoID string, issueIID int6
 	// `*bool` with `omitempty`, so a nil pointer omits the key (the server inherits the
 	// account default) while a non-nil &false still marshals `"mr_rework_enabled": false`
 	// (explicit opt-out for this run). A bare create sends neither, byte-identical to before.
+	//
+	// force (issue #856) is a plain `omitempty` bool: a false force sends NO `force` key, so
+	// a plain create stays byte-identical to before, while `force:true` (only ever set on
+	// --force) asks the server to bypass ONLY the open-MR guard — a run already in progress
+	// is never bypassed. false is the common, correct value, so omitempty is the whole point.
 	reqBody := struct {
 		IssueIID        int64                    `json:"issue_iid"`
 		WaitOnLimit     *bool                    `json:"wait_on_limit,omitempty"`
 		MrReworkEnabled *bool                    `json:"mr_rework_enabled,omitempty"`
+		Force           bool                     `json:"force,omitempty"`
 		PlanMD          *string                  `json:"plan_md,omitempty"`
 		Selection       *apitypes.AgentSelection `json:"agent_selection,omitempty"`
 		PlannedCommit   *string                  `json:"planned_commit,omitempty"`
 		RequireBase     bool                     `json:"require_base,omitempty"`
-	}{IssueIID: issueIID, WaitOnLimit: waitOnLimit, MrReworkEnabled: mrReworkEnabled}
+	}{IssueIID: issueIID, WaitOnLimit: waitOnLimit, MrReworkEnabled: mrReworkEnabled, Force: force}
 	if seed != nil {
 		reqBody.PlanMD = &seed.PlanMD
 		reqBody.Selection = seed.Selection

--- a/api/internal/uzicli/client_test.go
+++ b/api/internal/uzicli/client_test.go
@@ -667,7 +667,10 @@ func TestHTTPClientOnlyReturnsExitError(t *testing.T) {
 		{"admin-rate-limits", func(c *HTTPClient) error { _, e := c.AdminRateLimits(context.Background()); return e }},
 		{"start-cli-auth", func(c *HTTPClient) error { _, e := c.StartCLIAuth(context.Background(), "ch", "desc"); return e }},
 		{"poll-cli-auth", func(c *HTTPClient) error { _, e := c.PollCLIAuth(context.Background(), "req", "ver"); return e }},
-		{"create-run", func(c *HTTPClient) error { _, e := c.CreateRun(context.Background(), "p1", 7, nil, nil, nil); return e }},
+		{"create-run", func(c *HTTPClient) error {
+			_, e := c.CreateRun(context.Background(), "p1", 7, nil, nil, false, nil)
+			return e
+		}},
 		{"submit-run-input", func(c *HTTPClient) error {
 			_, e := c.SubmitRunInput(context.Background(), "r1", "cancel", "", nil)
 			return e
@@ -818,7 +821,7 @@ func TestCreateRunWireBodyOmitsAbsentWaitOnLimit(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, tc.in, nil, nil); err != nil {
+			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, tc.in, nil, false, nil); err != nil {
 				t.Fatalf("CreateRun: %v", err)
 			}
 			if !strings.Contains(body, `"issue_iid":42`) {
@@ -866,13 +869,56 @@ func TestCreateRunWireBodyMrRework(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, tc.in, nil); err != nil {
+			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, tc.in, false, nil); err != nil {
 				t.Fatalf("CreateRun: %v", err)
 			}
 			if got := strings.Contains(body, "mr_rework_enabled"); got != tc.wantPresent {
 				t.Errorf("mr_rework_enabled present = %v, want %v; body = %s\n"+
 					"An absent flag must send NO key — the server stamps the run by inheriting the account "+
 					"default when the field is missing, and reads null or false as an explicit decision.",
+					got, tc.wantPresent, body)
+			}
+			if tc.wantJSON != "" && !strings.Contains(body, tc.wantJSON) {
+				t.Errorf("body = %s, want it to contain %s", body, tc.wantJSON)
+			}
+		})
+	}
+}
+
+// TestCreateRunWireBodyForce asserts the --force flag's wire mapping (issue #856). Unlike
+// wait_on_limit/mr_rework_enabled, force is NOT tri-state: it is a plain bool with omitempty,
+// so a false force (the default, and every non-forced create) must send NO `force` key —
+// keeping a plain create byte-identical to before — while `force:true` (set only by --force)
+// asks the server to bypass ONLY the open-MR guard. Asserted on raw bytes so an unwanted
+// `"force":false` a decode-into-struct would erase is caught.
+func TestCreateRunWireBodyForce(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		in          bool
+		wantPresent bool
+		wantJSON    string
+	}{
+		{"false omits the key entirely (byte-identical to a non-forced create)", false, false, ""},
+		{"true is SENT", true, true, `"force":true`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var body string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b := make([]byte, r.ContentLength)
+				_, _ = io.ReadFull(r.Body, b)
+				body = string(b)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"run":{"id":"r1","status":"queued"}}`))
+			}))
+			defer srv.Close()
+
+			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, nil, tc.in, nil); err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			if got := strings.Contains(body, "force"); got != tc.wantPresent {
+				t.Errorf("force present = %v, want %v; body = %s\n"+
+					"A false force must send NO key (omitempty) so a plain create stays byte-identical; "+
+					"only --force sends force:true to bypass the open-MR guard.",
 					got, tc.wantPresent, body)
 			}
 			if tc.wantJSON != "" && !strings.Contains(body, tc.wantJSON) {
@@ -994,7 +1040,7 @@ func TestCreateRunWireBodySeededPlan(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, nil, tc.seed); err != nil {
+			if _, err := newTestClient(srv).CreateRun(context.Background(), "p1", 42, nil, nil, false, tc.seed); err != nil {
 				t.Fatalf("CreateRun: %v", err)
 			}
 			for _, want := range tc.wantContains {

--- a/api/internal/uzicli/fake.go
+++ b/api/internal/uzicli/fake.go
@@ -79,6 +79,10 @@ type FakeClient struct {
 	// (PRD #841 M3): a test must tell nil (flag absent → inherit the account default) from
 	// &false and &true, which is exactly the tri-state `--mr-rework` carries.
 	LastCreateMrRework *bool
+	// LastCreateForce captures the --force flag (issue #856): a plain bool, since force
+	// is not tri-state — false means "respect the open-MR guard" (the default), true means
+	// "bypass ONLY that guard". A test asserts the CLI forwarded true iff --force was passed.
+	LastCreateForce bool
 	// LastCreateSeed captures PRD #209's optional seeded plan (nil when the run was
 	// created without --plan-file), so a test can assert the plan body and the roster
 	// the CLI forwarded — the assertion M3's flag parsing is proven against.
@@ -746,11 +750,12 @@ func (f *FakeClient) PollCLIAuth(context.Context, string, string) (CLIAuthPollRe
 	return res, nil
 }
 
-func (f *FakeClient) CreateRun(_ context.Context, repoID string, issueIID int64, waitOnLimit *bool, mrReworkEnabled *bool, seed *CreateRunSeed) (apitypes.RunDTO, error) {
+func (f *FakeClient) CreateRun(_ context.Context, repoID string, issueIID int64, waitOnLimit *bool, mrReworkEnabled *bool, force bool, seed *CreateRunSeed) (apitypes.RunDTO, error) {
 	f.LastCreateRepoID = repoID
 	f.LastCreateIssueIID = issueIID
 	f.LastCreateWaitOnLimit = waitOnLimit
 	f.LastCreateMrRework = mrReworkEnabled
+	f.LastCreateForce = force
 	f.LastCreateSeed = seed
 	if f.Err != nil {
 		return apitypes.RunDTO{}, f.Err

--- a/api/internal/uzidocs/embed/cli.md
+++ b/api/internal/uzidocs/embed/cli.md
@@ -86,7 +86,7 @@ uzi run list | get <id> [--field <name> ...] | logs <id> [--follow] [--after <se
 uzi run wait <id> [--until <status,...>] [--interval <dur>] [--timeout <dur>] [--min-plan-seq <n>]
 uzi run create --repo <id> --issue <iid> [--plan-file <path>]
                 [--agent-source own|repo] [--exclude-agents a,b]
-                [--planned-commit <sha>] [--require-base]
+                [--planned-commit <sha>] [--require-base] [--force]
 uzi run approve <id> [--agent-source own|repo] [--exclude-agents a,b]
 uzi run reject <id> [--message <text>]
 uzi run revise <id> [--message <text>]
@@ -169,6 +169,12 @@ A few worth knowing:
   `--require-base` (the base-commit staleness guard) are all optional and all
   require `--plan-file`; an empty or oversized plan is rejected at create
   time. A run created with no `--plan-file` is unchanged.
+- **`run create --force` re-runs an issue that already has an open MR.** By
+  default, creating a run for an issue whose last completed run still owns an
+  open MR is refused (a 409, exit 5) — re-running would spend budget building
+  onto a branch you have not merged yet. `--force` overrides that one refusal
+  so the new run is created anyway; it bypasses only the open-MR guard, and a
+  run already in progress for the issue is never bypassed.
 - **`run approve` picks the subagent roster explicitly.** By default a run
   uses its own default roster; `--agent-source own|repo` overrides it
   (`own` = your template roster, `repo` = the agents the worker detected in

--- a/api/internal/workersvc/assignee_eligibility_test.go
+++ b/api/internal/workersvc/assignee_eligibility_test.go
@@ -38,7 +38,7 @@ func runAllPathsAssigned(t *testing.T, wire func(*Service), labels, assigneeIDs 
 		out[name] = pathResult{err: err, reached: fs.createRunParams != nil}
 	}
 	invoke("CreateRun", func(svc *Service) error {
-		_, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil)
+		_, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil)
 		return err
 	})
 	invoke("CreateScheduledRun", func(svc *Service) error {

--- a/api/internal/workersvc/ci_fix_test.go
+++ b/api/internal/workersvc/ci_fix_test.go
@@ -103,7 +103,7 @@ func TestCreateRunRefusesWhenCIFixActiveOnBranch(t *testing.T) {
 	// ci_fix run is already fixing agent/issue-9 (they would share one worktree).
 	fs := &fakeStore{issueByID: store.Issue{Title: "T", Labels: uziLabels(), HasPrdLink: true}, activeCIFixRuns: 1}
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 9, "d", nil, nil, nil); err != ErrBranchInUse {
+	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 9, "d", nil, nil, false, nil); err != ErrBranchInUse {
 		t.Fatalf("err = %v, want ErrBranchInUse", err)
 	}
 }

--- a/api/internal/workersvc/composite.go
+++ b/api/internal/workersvc/composite.go
@@ -193,7 +193,7 @@ func (s *Service) DismissProposalForUser(ctx context.Context, userID, runID, pro
 // composite no longer computes any PRD-link bypass. It returns the CreateRun
 // sentinels unchanged (ErrNotPRDIssue, ErrActiveRunExists, …) plus the forge
 // sentinels above.
-func (s *Service) StartRunForUser(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, waitOnLimit, mrReworkEnabled *bool, seed *SeededPlan) (store.Run, error) {
+func (s *Service) StartRunForUser(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, waitOnLimit, mrReworkEnabled *bool, force bool, seed *SeededPlan) (store.Run, error) {
 	if s.forges == nil {
 		return store.Run{}, ErrForgesUnavailable
 	}
@@ -216,7 +216,7 @@ func (s *Service) StartRunForUser(ctx context.Context, userID, repoID uuid.UUID,
 	// PRD #841 M2: the caller's per-run mr_rework override (CLI/API) threads straight
 	// through with no owner-default snapshot — the run inherits the owner default live
 	// when it is nil (D1).
-	return s.CreateRun(ctx, userID, repo.ID, issueIID, issue.Description, waitOnLimit, mrReworkEnabled, seed)
+	return s.CreateRun(ctx, userID, repo.ID, issueIID, issue.Description, waitOnLimit, mrReworkEnabled, force, seed)
 }
 
 // StartRunForUserByPath is StartRunForUser keyed by the human repo PATH the chat
@@ -234,5 +234,7 @@ func (s *Service) StartRunForUserByPath(ctx context.Context, userID uuid.UUID, r
 	}
 	// nil mrReworkEnabled (PRD #841 M2): the chat/Slack start-run card carries no
 	// per-run mr_rework override, so the run inherits the owner default live.
-	return s.StartRunForUser(ctx, userID, repoID, issueIID, waitOnLimit, nil, seed)
+	// false force (issue #856): chat/Slack has no --force, so it never bypasses the
+	// open-MR dedup.
+	return s.StartRunForUser(ctx, userID, repoID, issueIID, waitOnLimit, nil, false, seed)
 }

--- a/api/internal/workersvc/composite_test.go
+++ b/api/internal/workersvc/composite_test.go
@@ -234,7 +234,7 @@ func TestStartRunForUserForgeReadError(t *testing.T) {
 	svc := New(fs, newBox(t), testParams())
 	svc.SetForges(fb)
 
-	_, err := svc.StartRunForUser(context.Background(), uuid.New(), uuid.New(), 5, nil, nil, nil)
+	_, err := svc.StartRunForUser(context.Background(), uuid.New(), uuid.New(), 5, nil, nil, false, nil)
 	if !errors.Is(err, ErrForgeIssueRead) {
 		t.Fatalf("err = %v, want ErrForgeIssueRead", err)
 	}
@@ -251,7 +251,7 @@ func TestStartRunForUserRepoNotOwned(t *testing.T) {
 	svc := New(fs, newBox(t), testParams())
 	svc.SetForges(fb)
 
-	_, err := svc.StartRunForUser(context.Background(), uuid.New(), uuid.New(), 5, nil, nil, nil)
+	_, err := svc.StartRunForUser(context.Background(), uuid.New(), uuid.New(), 5, nil, nil, false, nil)
 	if !errors.Is(err, ErrRepoNotFound) {
 		t.Fatalf("err = %v, want ErrRepoNotFound", err)
 	}

--- a/api/internal/workersvc/guardrail_test.go
+++ b/api/internal/workersvc/guardrail_test.go
@@ -83,7 +83,7 @@ func TestCreateRunGuardrailBlocksBeforeInsert(t *testing.T) {
 	svc := New(fs, newBox(t), testParams())
 	svc.SetRepoGuard(guard)
 
-	_, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil)
+	_, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil)
 	assertGuardrailBlocked(t, err, wantMsgs)
 	if guard.called != 1 {
 		t.Fatalf("guard called %d times, want 1", guard.called)
@@ -184,7 +184,7 @@ func TestCreateRunNotBlockedGuardProceeds(t *testing.T) {
 	svc := New(fs, newBox(t), testParams())
 	svc.SetRepoGuard(guard)
 
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil); err != nil {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil); err != nil {
 		t.Fatalf("CreateRun with a clearing guard: %v", err)
 	}
 	if guard.called != 1 {
@@ -329,7 +329,7 @@ func TestCreateRunThreadsOverriddenFromRow(t *testing.T) {
 			svc := New(fs, newBox(t), testParams())
 			svc.SetRepoGuard(guard)
 
-			if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil); err != nil {
+			if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil); err != nil {
 				t.Fatalf("CreateRun: %v", err)
 			}
 			if guard.lastInput.Overridden != tc.wantOverr {
@@ -380,7 +380,7 @@ func TestCreateRunNilGuardNotBlocked(t *testing.T) {
 	}
 	svc := New(fs, newBox(t), testParams()) // SetRepoGuard deliberately not called
 
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil); err != nil {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil); err != nil {
 		t.Fatalf("CreateRun with a nil guard must not be guardrail-blocked: %v", err)
 	}
 	if fs.createRunParams == nil {

--- a/api/internal/workersvc/issue_comments_snapshot_livedb_test.go
+++ b/api/internal/workersvc/issue_comments_snapshot_livedb_test.go
@@ -116,7 +116,7 @@ func TestIssueCommentsSnapshotLiveDB(t *testing.T) {
 	}
 
 	// (1) Human + bot ⇒ stored JSONB carries the human comment and NOT the bot one.
-	run1, err := svc.CreateRun(ctx, userID, repoKnown, 11, "desc", &waitFalse, nil, nil)
+	run1, err := svc.CreateRun(ctx, userID, repoKnown, 11, "desc", &waitFalse, nil, false, nil)
 	if err != nil {
 		t.Fatalf("create run for issue 11: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestIssueCommentsSnapshotLiveDB(t *testing.T) {
 	}
 
 	// (2) Only bot comments ⇒ stored NULL.
-	run2, err := svc.CreateRun(ctx, userID, repoKnown, 12, "desc", &waitFalse, nil, nil)
+	run2, err := svc.CreateRun(ctx, userID, repoKnown, 12, "desc", &waitFalse, nil, false, nil)
 	if err != nil {
 		t.Fatalf("create run for issue 12: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestIssueCommentsSnapshotLiveDB(t *testing.T) {
 	}
 
 	// (3) Human comment but the connection's bot id is 0 ⇒ D9 stores NULL.
-	run3, err := svc.CreateRun(ctx, userID, repoZero, 13, "desc", &waitFalse, nil, nil)
+	run3, err := svc.CreateRun(ctx, userID, repoZero, 13, "desc", &waitFalse, nil, false, nil)
 	if err != nil {
 		t.Fatalf("create run for issue 13: %v", err)
 	}

--- a/api/internal/workersvc/limitpark_test.go
+++ b/api/internal/workersvc/limitpark_test.go
@@ -866,7 +866,7 @@ func TestEveryCreationPathStampsWaitOnLimit(t *testing.T) {
 			userByID:        optedIn,
 		}
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateRun(context.Background(), optedIn.ID, uuid.New(), 4, "d", nil, nil, nil); err != nil {
+		if _, err := svc.CreateRun(context.Background(), optedIn.ID, uuid.New(), 4, "d", nil, nil, false, nil); err != nil {
 			t.Fatalf("CreateRun: %v", err)
 		}
 		if !fs.createRunParams.WaitOnLimit {
@@ -884,7 +884,7 @@ func TestEveryCreationPathStampsWaitOnLimit(t *testing.T) {
 			userByID:        optedIn,
 		}
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateRun(context.Background(), optedIn.ID, uuid.New(), 4, "d", &no, nil, nil); err != nil {
+		if _, err := svc.CreateRun(context.Background(), optedIn.ID, uuid.New(), 4, "d", &no, nil, false, nil); err != nil {
 			t.Fatalf("CreateRun: %v", err)
 		}
 		if fs.createRunParams.WaitOnLimit {
@@ -901,7 +901,7 @@ func TestEveryCreationPathStampsWaitOnLimit(t *testing.T) {
 			userByID:        store.User{ID: optedIn.ID}, // default false
 		}
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateRun(context.Background(), optedIn.ID, uuid.New(), 4, "d", &yes, nil, nil); err != nil {
+		if _, err := svc.CreateRun(context.Background(), optedIn.ID, uuid.New(), 4, "d", &yes, nil, false, nil); err != nil {
 			t.Fatalf("CreateRun: %v", err)
 		}
 		if !fs.createRunParams.WaitOnLimit {
@@ -933,7 +933,7 @@ func TestEveryCreationPathStampsWaitOnLimit(t *testing.T) {
 			userByIDErr:     errors.New("boom"),
 		}
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "d", nil, nil, nil); err != nil {
+		if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "d", nil, nil, false, nil); err != nil {
 			t.Fatalf("a preference lookup failure must not fail the creation: %v", err)
 		}
 		if fs.createRunParams.WaitOnLimit {

--- a/api/internal/workersvc/open_mr_guard_livedb_test.go
+++ b/api/internal/workersvc/open_mr_guard_livedb_test.go
@@ -1,0 +1,149 @@
+package workersvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// TestOpenMRGuardLiveDB is the acceptance test for the create-time open-MR refusal
+// (issue #856) against a REAL Postgres. createRun must refuse a fresh issue run when the
+// SAME issue already has a COMPLETED (terminal) run owning an OPEN merge request — the
+// active-run gate cannot see a terminal run, so this guard is the only thing that stops a
+// fresh run re-planning and re-reviewing onto an already-open MR. Four arms, each on its
+// own repo+issue so they cannot cross-contaminate:
+//
+//  1. blocked   — a completed issue run with mr_iid + mr_state='opened' ⇒ a second
+//     CreateRun returns ErrOpenMRExists and the message names the MR number.
+//  2. merged    — the same prior run with mr_state='merged' (no open MR) ⇒ allowed.
+//  3. forced    — an open MR present but force=true ⇒ allowed (the guard is bypassed).
+//  4. kind scope — a completed SELF_IMPROVE run (kind != 'issue') owning an open MR for the
+//     same issue ⇒ allowed, because the guard is scoped to kind='issue'.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres (per the store
+// live-DB harness; migrations run in-test).
+func TestOpenMRGuardLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via the store live-DB harness for coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+	// nil box + nil forge: the guard fires (or does not) BEFORE any forge round-trip, and
+	// guardDefaultBranch is a no-op with a nil guard — the same minimal wiring the sibling
+	// mr_rework branch-guard live-DB test uses.
+	svc := New(q, nil, Params{})
+
+	// The cached issue always carries the default uzi label, so the run-eligibility gate
+	// (PRD #764) passes and createRun reaches the open-MR guard under test.
+	const issueIID int64 = 856
+
+	// seedRepoAndIssue provisions a fresh owner + connection + repo (each with distinct
+	// uuids so the four arms are isolated) plus one open, uzi-labelled cached issue, and
+	// returns the owner and repo ids for a CreateRun call.
+	seedRepoAndIssue := func(t *testing.T, tag string) (uuid.UUID, uuid.UUID) {
+		t.Helper()
+		userID, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+		exec := func(sql string, args ...any) {
+			t.Helper()
+			if _, err := pool.Exec(ctx, sql, args...); err != nil {
+				t.Fatalf("exec %q: %v", sql, err)
+			}
+		}
+		exec(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+			userID, fmt.Sprintf("omr-%s-%s@e2e", tag, userID))
+		exec(`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+		      VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, userID, []byte{0x1})
+		exec(`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+		      VALUES ($1, $2, 1, $3, 'https://forge.e2e/g/omr', 'main', true)`, repoID, connID, fmt.Sprintf("g/omr-%s", repoID))
+		// Cached, open, uzi-labelled issue: the same jsonb the board renders from, which the
+		// run-eligibility gate reads (PRD #764/#767). No PRD link is required.
+		exec(`INSERT INTO issues (repo_id, forge_issue_iid, title, state, labels, web_url, has_prd_link, forge_updated_at, synced_at)
+		      VALUES ($1, $2, 'Open-MR guard fixture', 'opened', '["uzi"]'::jsonb, 'https://x', false, now(), now())`,
+			repoID, issueIID)
+		return userID, repoID
+	}
+
+	// seedPriorRun inserts a COMPLETED run of the given kind owning an MR in the given
+	// mr_state for this issue — the prior run whose open MR the guard keys on.
+	seedPriorRun := func(t *testing.T, userID, repoID uuid.UUID, kind, mrState string, mrIID int64) {
+		t.Helper()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, mr_iid, mr_state, status)
+			 VALUES ($1, $2, $3, $4, $5, 'prior', 'd', $6, $7, 'completed')`,
+			uuid.New(), userID, repoID, kind, issueIID, mrIID, mrState); err != nil {
+			t.Fatalf("insert prior %s run: %v", kind, err)
+		}
+	}
+
+	t.Run("blocks a fresh issue run when a prior issue run owns an open MR", func(t *testing.T) {
+		userID, repoID := seedRepoAndIssue(t, "block")
+		const mrIID int64 = 4210
+		seedPriorRun(t, userID, repoID, "issue", "opened", mrIID)
+
+		_, err := svc.CreateRun(ctx, userID, repoID, issueIID, "the description", nil, nil, false /*force*/, nil)
+		if !errors.Is(err, ErrOpenMRExists) {
+			t.Fatalf("CreateRun err = %v, want ErrOpenMRExists", err)
+		}
+		// The refusal must name the MR so the caller can act on it.
+		if want := fmt.Sprintf("!%d", mrIID); !strings.Contains(err.Error(), want) {
+			t.Fatalf("CreateRun err %q does not mention the MR number %q", err.Error(), want)
+		}
+	})
+
+	t.Run("allows a fresh issue run once the prior run's MR is merged", func(t *testing.T) {
+		userID, repoID := seedRepoAndIssue(t, "merged")
+		seedPriorRun(t, userID, repoID, "issue", "merged", 4220)
+
+		run, err := svc.CreateRun(ctx, userID, repoID, issueIID, "the description", nil, nil, false /*force*/, nil)
+		if err != nil {
+			t.Fatalf("CreateRun with a merged prior MR err = %v, want success", err)
+		}
+		if run.Kind != RunKindIssue {
+			t.Fatalf("run.Kind = %q, want %q", run.Kind, RunKindIssue)
+		}
+	})
+
+	t.Run("force bypasses the open-MR guard", func(t *testing.T) {
+		userID, repoID := seedRepoAndIssue(t, "force")
+		seedPriorRun(t, userID, repoID, "issue", "opened", 4230)
+
+		run, err := svc.CreateRun(ctx, userID, repoID, issueIID, "the description", nil, nil, true /*force*/, nil)
+		if err != nil {
+			t.Fatalf("CreateRun with force=true err = %v, want success even with an open MR", err)
+		}
+		if run.Kind != RunKindIssue {
+			t.Fatalf("run.Kind = %q, want %q", run.Kind, RunKindIssue)
+		}
+	})
+
+	t.Run("guard is scoped to issue kind: a non-issue prior run's open MR does not block", func(t *testing.T) {
+		userID, repoID := seedRepoAndIssue(t, "scope")
+		// A completed self_improve run (kind != 'issue') owning an open MR for the SAME
+		// issue. GetOpenMRRunForIssue filters kind='issue', so it must not match.
+		seedPriorRun(t, userID, repoID, "self_improve", "opened", 4240)
+
+		run, err := svc.CreateRun(ctx, userID, repoID, issueIID, "the description", nil, nil, false /*force*/, nil)
+		if err != nil {
+			t.Fatalf("CreateRun with only a non-issue prior open-MR run err = %v, want success", err)
+		}
+		if run.Kind != RunKindIssue {
+			t.Fatalf("run.Kind = %q, want %q", run.Kind, RunKindIssue)
+		}
+	})
+}

--- a/api/internal/workersvc/open_mr_guard_livedb_test.go
+++ b/api/internal/workersvc/open_mr_guard_livedb_test.go
@@ -17,7 +17,7 @@ import (
 // (issue #856) against a REAL Postgres. createRun must refuse a fresh issue run when the
 // SAME issue already has a COMPLETED (terminal) run owning an OPEN merge request — the
 // active-run gate cannot see a terminal run, so this guard is the only thing that stops a
-// fresh run re-planning and re-reviewing onto an already-open MR. Four arms, each on its
+// fresh run re-planning and re-reviewing onto an already-open MR. Five arms, each on its
 // own repo+issue so they cannot cross-contaminate:
 //
 //  1. blocked   — a completed issue run with mr_iid + mr_state='opened' ⇒ a second
@@ -26,6 +26,10 @@ import (
 //  3. forced    — an open MR present but force=true ⇒ allowed (the guard is bypassed).
 //  4. kind scope — a completed SELF_IMPROVE run (kind != 'issue') owning an open MR for the
 //     same issue ⇒ allowed, because the guard is scoped to kind='issue'.
+//  5. watcher lag — a completed issue run with mr_iid set but mr_state STILL NULL (the
+//     watcher has not ticked yet) ⇒ a second CreateRun is still REFUSED with ErrOpenMRExists
+//     naming the MR. This proves the guard keys on the authoritative mr_iid and no longer
+//     depends on the watcher having recorded 'opened'; a NULL mr_state blocks conservatively.
 //
 // Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres (per the store
 // live-DB harness; migrations run in-test).
@@ -144,6 +148,30 @@ func TestOpenMRGuardLiveDB(t *testing.T) {
 		}
 		if run.Kind != RunKindIssue {
 			t.Fatalf("run.Kind = %q, want %q", run.Kind, RunKindIssue)
+		}
+	})
+
+	t.Run("blocks during the watcher-lag window: mr_iid set but mr_state still NULL", func(t *testing.T) {
+		userID, repoID := seedRepoAndIssue(t, "lag")
+		const mrIID int64 = 4250
+		// A completed issue run whose mr_iid was written atomically at completion but whose
+		// mr_state is STILL NULL — the watcher has not yet ticked. This is the window a
+		// mr_state='opened'-only predicate missed; keying on mr_iid (releasing only on a
+		// terminal mr_state) must block here.
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, mr_iid, status)
+			 VALUES ($1, $2, $3, 'issue', $4, 'prior', 'd', $5, 'completed')`,
+			uuid.New(), userID, repoID, issueIID, mrIID); err != nil {
+			t.Fatalf("insert prior issue run with NULL mr_state: %v", err)
+		}
+
+		_, err := svc.CreateRun(ctx, userID, repoID, issueIID, "the description", nil, nil, false /*force*/, nil)
+		if !errors.Is(err, ErrOpenMRExists) {
+			t.Fatalf("CreateRun err = %v, want ErrOpenMRExists (NULL mr_state must block)", err)
+		}
+		// The refusal must still name the MR even before the watcher recorded a state.
+		if want := fmt.Sprintf("!%d", mrIID); !strings.Contains(err.Error(), want) {
+			t.Fatalf("CreateRun err %q does not mention the MR number %q", err.Error(), want)
 		}
 	})
 }

--- a/api/internal/workersvc/seeded_plan_test.go
+++ b/api/internal/workersvc/seeded_plan_test.go
@@ -50,7 +50,7 @@ func TestCreateRunSeededPlanRejectsEmptyAndWhitespace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := seededIssueStore()
 			svc := New(fs, newBox(t), testParams())
-			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: tc.plan})
+			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: tc.plan})
 			if err != ErrPlanEmpty {
 				t.Fatalf("err = %v, want ErrPlanEmpty", err)
 			}
@@ -67,7 +67,7 @@ func TestCreateRunSeededPlanTooLarge(t *testing.T) {
 	fs := seededIssueStore()
 	svc := New(fs, newBox(t), testParams())
 	oversize := strings.Repeat("x", MaxSeededPlanBytes+1)
-	_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: oversize})
+	_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: oversize})
 	if err != ErrPlanTooLarge {
 		t.Fatalf("err = %v, want ErrPlanTooLarge", err)
 	}
@@ -77,7 +77,7 @@ func TestCreateRunSeededPlanTooLarge(t *testing.T) {
 	// The boundary is exclusive: exactly MaxSeededPlanBytes is accepted.
 	fs2 := seededIssueStore()
 	svc2 := New(fs2, newBox(t), testParams())
-	if _, err := svc2.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: strings.Repeat("x", MaxSeededPlanBytes)}); err != nil {
+	if _, err := svc2.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: strings.Repeat("x", MaxSeededPlanBytes)}); err != nil {
 		t.Fatalf("a plan at exactly the cap must be accepted, got err = %v", err)
 	}
 }
@@ -99,7 +99,7 @@ func TestCreateRunSeededPlanRejectsUnsafeTarget(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := seededIssueStore()
 			svc := New(fs, newBox(t), testParams())
-			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: tc.plan})
+			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: tc.plan})
 			if !errors.Is(err, ErrPlanUnsafe) {
 				t.Fatalf("err = %v, want ErrPlanUnsafe", err)
 			}
@@ -118,7 +118,7 @@ func TestCreateRunSeededPlanRejectsUnsafeTarget(t *testing.T) {
 	t.Run("benign plan is accepted", func(t *testing.T) {
 		fs := seededIssueStore()
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: "Refactor the token store; add a test in queries_test.go"}); err != nil {
+		if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: "Refactor the token store; add a test in queries_test.go"}); err != nil {
 			t.Fatalf("a benign seeded plan must be accepted, got err = %v", err)
 		}
 		if fs.createRunParams == nil {
@@ -148,7 +148,7 @@ func TestCreateRunSeededInvalidSelection(t *testing.T) {
 			fs := seededIssueStore()
 			svc := New(fs, newBox(t), testParams())
 			sel := tc.sel
-			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: "# Plan\nDo it.", Selection: &sel})
+			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: "# Plan\nDo it.", Selection: &sel})
 			if !errors.Is(err, ErrInvalidSelection) {
 				t.Fatalf("err = %v, want ErrInvalidSelection", err)
 			}
@@ -167,7 +167,7 @@ func TestCreateRunSeededPersistsPlanColumns(t *testing.T) {
 	svc := New(fs, newBox(t), testParams())
 
 	sel := AgentSelection{Source: AgentSourceRepo, Exclusions: []string{"reviewer"}}
-	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: "# Plan\nImplement the thing.", Selection: &sel}); err != nil {
+	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: "# Plan\nImplement the thing.", Selection: &sel}); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
 	p := fs.createRunParams
@@ -211,7 +211,7 @@ func TestCreateRunSeededPlannedCommitValidation(t *testing.T) {
 		t.Run("reject: "+tc.name, func(t *testing.T) {
 			fs := seededIssueStore()
 			svc := New(fs, newBox(t), testParams())
-			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: "# Plan\nDo it.", PlannedCommit: tc.planned})
+			_, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: "# Plan\nDo it.", PlannedCommit: tc.planned})
 			if err != ErrInvalidPlannedCommit {
 				t.Fatalf("err = %v, want ErrInvalidPlannedCommit", err)
 			}
@@ -234,7 +234,7 @@ func TestCreateRunSeededPlannedCommitValidation(t *testing.T) {
 		t.Run("accept: "+tc.name, func(t *testing.T) {
 			fs := seededIssueStore()
 			svc := New(fs, newBox(t), testParams())
-			if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: "# Plan\nDo it.", PlannedCommit: tc.planned, RequireBase: true}); err != nil {
+			if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: "# Plan\nDo it.", PlannedCommit: tc.planned, RequireBase: true}); err != nil {
 				t.Fatalf("CreateRun: %v", err)
 			}
 			p := fs.createRunParams
@@ -259,7 +259,7 @@ func TestCreateRunSeededScrubsSecretsIntoPlanMd(t *testing.T) {
 	const token = "glpat-SCRUBTEST00000000000000" //gitleaks:allow synthetic non-credential fixture; asserts secretscrub matches the glpat- shape, never a real token
 	fs := seededIssueStore()
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, &SeededPlan{PlanMD: "# Plan\nuse " + token + " to auth"}); err != nil {
+	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, &SeededPlan{PlanMD: "# Plan\nuse " + token + " to auth"}); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
 	stored := fs.createRunParams.PlanMd.String
@@ -299,7 +299,7 @@ func TestCreateRunNonSeededIsByteIdenticalToPreFeature(t *testing.T) {
 	t.Run("manual CreateRun with nil seed", func(t *testing.T) {
 		fs := seededIssueStore()
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, nil); err != nil {
+		if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "desc", nil, nil, false, nil); err != nil {
 			t.Fatalf("CreateRun: %v", err)
 		}
 		check(t, fs.createRunParams)

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -131,7 +131,13 @@ var (
 	// both. This is the authoritative gate; the CLI mirrors it as a pre-flight usage error.
 	ErrInvalidPlannedCommit = errors.New("planned base commit is not a valid commit sha (hex, 7-64 chars)")
 	ErrActiveRunExists      = errors.New("a non-terminal run already exists for this issue")
-	ErrRunTerminal          = errors.New("run has already finished")
+	// ErrOpenMRExists refuses a fresh issue run when the issue already has a completed
+	// run owning an OPEN merge request (issue #856). Distinct from ErrActiveRunExists:
+	// the offending prior run is TERMINAL, so the active-run gate cannot see it. The
+	// create path wraps this with the issue and MR numbers; --force (workersvc create
+	// param) bypasses ONLY this guard, never the active-run gate.
+	ErrOpenMRExists = errors.New("issue already has an open MR")
+	ErrRunTerminal  = errors.New("run has already finished")
 	// ErrStopNotInteractive rejects a `stop` on a run that is not an interactive task
 	// (PRD #517 M4) → 409. A graceful stop is honored ONLY by the interactive-task park:
 	// no other run kind reads the stop flag, so a stop on a plan-gated / chat /
@@ -500,6 +506,10 @@ type Store interface {
 	// gave the manual/board/Slack path is restored here (this SELECT still counts
 	// pool_wait as active).
 	HasActiveRunForIssue(ctx context.Context, arg store.HasActiveRunForIssueParams) (bool, error)
+	// GetOpenMRRunForIssue returns the MR iid of a completed issue run that still owns an
+	// OPEN merge request for the issue (issue #856), or pgx.ErrNoRows when none does. It
+	// backs createRun's create-time open-MR refusal (the open-MR dedup that --force bypasses).
+	GetOpenMRRunForIssue(ctx context.Context, arg store.GetOpenMRRunForIssueParams) (pgtype.Int8, error)
 	SweepRunningTimeout(ctx context.Context, arg store.SweepRunningTimeoutParams) ([]store.SweepRunningTimeoutRow, error)
 	FailRunsOfStaleWorkersOverCap(ctx context.Context, arg store.FailRunsOfStaleWorkersOverCapParams) ([]store.FailRunsOfStaleWorkersOverCapRow, error)
 	RequeueRunsOfStaleWorkers(ctx context.Context, arg store.RequeueRunsOfStaleWorkersParams) ([]store.RequeueRunsOfStaleWorkersRow, error)
@@ -4714,7 +4724,7 @@ func (s *Service) DeleteWorker(ctx context.Context, userID, workerID uuid.UUID) 
 // run is self-contained even if the issue cache is later evicted. A PRD link is no
 // longer required. The one-non-terminal-run-per-issue index rejects a duplicate
 // active run.
-func (s *Service) CreateRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, waitOnLimit *bool, mrReworkEnabled *bool, seed *SeededPlan) (store.Run, error) {
+func (s *Service) CreateRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, waitOnLimit *bool, mrReworkEnabled *bool, force bool, seed *SeededPlan) (store.Run, error) {
 	// waitOnLimit nil ⇒ inherit the owner's default. It is a *bool rather than a bool
 	// because "the caller said false" and "the caller said nothing" are different
 	// requests, and collapsing them would make every API client that omits the field
@@ -4730,7 +4740,9 @@ func (s *Service) CreateRun(ctx context.Context, userID, repoID uuid.UUID, issue
 	// (PRD #300) — the per-schedule override applies only to runs a schedule fires.
 	// false overrideSubagentModel (PRD #305): an interactive run is not a schedule fire,
 	// so it stays in the default lane where subagent pins win.
-	return s.createRun(ctx, userID, repoID, issueIID, description, false, waitOnLimit, mrReworkEnabled, nil, false, seed)
+	// force (issue #856): threaded straight through so the interactive/CLI caller can
+	// bypass the open-MR dedup with --force; it never affects the active-run gate.
+	return s.createRun(ctx, userID, repoID, issueIID, description, false, waitOnLimit, mrReworkEnabled, nil, false, force, seed)
 }
 
 // CreateScheduledRun queues a NON-auto-approve scheduled issue run (PRD #241: a timer
@@ -4738,7 +4750,8 @@ func (s *Service) CreateRun(ctx context.Context, userID, repoID uuid.UUID, issue
 // It is IDENTICAL to CreateRun — same single uzi_label eligibility gate (PRD #764 M1) —
 // and, like every create path, no longer requires a PRD link.
 func (s *Service) CreateScheduledRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, waitOnLimit *bool, mrReworkEnabled *bool, model *string, overrideSubagentModel bool, seed *SeededPlan) (store.Run, error) {
-	return s.createRun(ctx, userID, repoID, issueIID, description, false, waitOnLimit, mrReworkEnabled, model, overrideSubagentModel, seed)
+	// false force (issue #856): a scheduled run never bypasses the open-MR dedup.
+	return s.createRun(ctx, userID, repoID, issueIID, description, false, waitOnLimit, mrReworkEnabled, model, overrideSubagentModel, false, seed)
 }
 
 // CreateAutopilotRun queues a run the poller's autopilot detection started on a
@@ -4761,7 +4774,8 @@ func (s *Service) CreateAutopilotRun(ctx context.Context, userID, repoID uuid.UU
 	// nil mrReworkEnabled (PRD #841 M1): label-poller autopilot has no human/schedule to
 	// express a per-run override, so the run's column stays NULL → inherit the owner
 	// default live, exactly today's behaviour.
-	return s.createRun(ctx, userID, repoID, issueIID, description, true, nil, nil, nil, false, nil)
+	// false force (issue #856): label-poller autopilot never bypasses the open-MR dedup.
+	return s.createRun(ctx, userID, repoID, issueIID, description, true, nil, nil, nil, false, false, nil)
 }
 
 // CreateScheduledAutopilotRun queues an auto-approve run for a schedule while honouring
@@ -4774,7 +4788,8 @@ func (s *Service) CreateAutopilotRun(ctx context.Context, userID, repoID uuid.UU
 // scheduler seam cannot change label-driven autopilot. seed=nil for the same reason as
 // CreateAutopilotRun: autopilot never seeds its plan.
 func (s *Service) CreateScheduledAutopilotRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, waitOnLimit *bool, mrReworkEnabled *bool, model *string, overrideSubagentModel bool) (store.Run, error) {
-	return s.createRun(ctx, userID, repoID, issueIID, description, true /*autoApprove*/, waitOnLimit, mrReworkEnabled, model, overrideSubagentModel, nil /*seed*/)
+	// false force (issue #856): a scheduled autopilot run never bypasses the open-MR dedup.
+	return s.createRun(ctx, userID, repoID, issueIID, description, true /*autoApprove*/, waitOnLimit, mrReworkEnabled, model, overrideSubagentModel, false /*force*/, nil /*seed*/)
 }
 
 // SeededPlan carries a create-time externally-authored plan and its optional agent
@@ -4803,7 +4818,7 @@ type SeededPlan struct {
 	RequireBase bool
 }
 
-func (s *Service) createRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, autoApprove bool, waitOnLimit *bool, mrReworkEnabled *bool, model *string, overrideSubagentModel bool, seed *SeededPlan) (store.Run, error) {
+func (s *Service) createRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, description string, autoApprove bool, waitOnLimit *bool, mrReworkEnabled *bool, model *string, overrideSubagentModel bool, force bool, seed *SeededPlan) (store.Run, error) {
 	// The description cap is enforced HERE, once, so the manual (handler → 422) and
 	// autopilot (poller → too-large comment) paths cannot drift (PRD #19 M5). Checked
 	// first: it is pure input validation, independent of the repo/issue gates below.
@@ -4952,6 +4967,26 @@ func (s *Service) createRun(ctx context.Context, userID, repoID uuid.UUID, issue
 	}
 	if active {
 		return store.Run{}, ErrActiveRunExists
+	}
+	// Open-MR dedup (issue #856): a COMPLETED run owning an OPEN MR is terminal, so the
+	// active-run gate above cannot see it — yet a fresh start would re-plan and re-run the
+	// whole review wave onto that already-open MR (silent wasted spend). Refuse unless the
+	// caller forced it. Scoped to the issue kind by construction (createRun is the issue
+	// path). --force bypasses ONLY this guard, never the active-run gate above. The
+	// predicate is the watcher-owned mr_state='opened' (mirrors ListMRReworkCandidates); it
+	// leaves a brief false-negative window between MR-open-at-finalize and the first watch
+	// tick, the same limitation the mr_rework candidate query lives with.
+	if !force {
+		mrIID, err := s.q.GetOpenMRRunForIssue(ctx, store.GetOpenMRRunForIssueParams{
+			RepoID:   repoID,
+			IssueIid: pgtype.Int8{Int64: issueIID, Valid: true},
+		})
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return store.Run{}, err
+		}
+		if err == nil && mrIID.Valid {
+			return store.Run{}, fmt.Errorf("%w: issue #%d already has open MR !%d — merge or close it, or leave review comments on the MR to iterate, before starting a new run (pass --force to re-run anyway)", ErrOpenMRExists, issueIID, mrIID.Int64)
+		}
 	}
 	// PRD #381: snapshot the issue's human comments alongside the description. One
 	// extra forge round-trip, centralized here so every issue-backed origin (manual,

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -245,6 +245,22 @@ var (
 	ErrGuardrailBlocked = errors.New("run refused by the default-branch guardrail")
 )
 
+// OpenMRExistsError carries the issue and MR numbers of an open-MR refusal (issue
+// #856) so a caller (the web 409 body) can name the MR structurally rather than
+// parse the message. Its Error() keeps the --force hint for the CLI/API `error`
+// field; Is() ties it to ErrOpenMRExists so errors.Is, the scheduler skip mapping
+// and the poller swallow all keep working.
+type OpenMRExistsError struct {
+	IssueIID int64
+	MRIID    int64
+}
+
+func (e *OpenMRExistsError) Error() string {
+	return fmt.Sprintf("issue #%d already has open MR !%d — merge or close it, or leave review comments on the MR to iterate, before starting a new run (pass --force to re-run anyway)", e.IssueIID, e.MRIID)
+}
+
+func (e *OpenMRExistsError) Is(target error) bool { return target == ErrOpenMRExists }
+
 // GuardrailBlockedError is returned by the run-create paths when the #66 default-
 // branch guardrail refuses (D1 layer 2). Findings carries the block-finding
 // messages for the 422 body. It wraps ErrGuardrailBlocked so callers can errors.Is
@@ -4985,7 +5001,7 @@ func (s *Service) createRun(ctx context.Context, userID, repoID uuid.UUID, issue
 			return store.Run{}, err
 		}
 		if err == nil && mrIID.Valid {
-			return store.Run{}, fmt.Errorf("%w: issue #%d already has open MR !%d — merge or close it, or leave review comments on the MR to iterate, before starting a new run (pass --force to re-run anyway)", ErrOpenMRExists, issueIID, mrIID.Int64)
+			return store.Run{}, &OpenMRExistsError{IssueIID: issueIID, MRIID: mrIID.Int64}
 		}
 	}
 	// PRD #381: snapshot the issue's human comments alongside the description. One

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -4988,10 +4988,12 @@ func (s *Service) createRun(ctx context.Context, userID, repoID uuid.UUID, issue
 	// active-run gate above cannot see it — yet a fresh start would re-plan and re-run the
 	// whole review wave onto that already-open MR (silent wasted spend). Refuse unless the
 	// caller forced it. Scoped to the issue kind by construction (createRun is the issue
-	// path). --force bypasses ONLY this guard, never the active-run gate above. The
-	// predicate is the watcher-owned mr_state='opened' (mirrors ListMRReworkCandidates); it
-	// leaves a brief false-negative window between MR-open-at-finalize and the first watch
-	// tick, the same limitation the mr_rework candidate query lives with.
+	// path). --force bypasses ONLY this guard, never the active-run gate above. The guard
+	// keys on the authoritative mr_iid (set atomically at completion by SetRunCompleted, so
+	// it is present the instant the run is completed) and releases only once the watcher has
+	// recorded a TERMINAL MR state ('merged'/'closed'); a NULL mr_state (watcher not yet
+	// ticked) still blocks. That closes the watcher-lag false-negative window a mr_state-only
+	// predicate had between MR-open-at-finalize and the first watch tick.
 	if !force {
 		mrIID, err := s.q.GetOpenMRRunForIssue(ctx, store.GetOpenMRRunForIssueParams{
 			RepoID:   repoID,

--- a/api/internal/workersvc/service_test.go
+++ b/api/internal/workersvc/service_test.go
@@ -3589,6 +3589,62 @@ func TestCreateRunSnapshotsTitleAndRunsWithoutPRDLink(t *testing.T) {
 	}
 }
 
+// TestCreateRunOpenMRGuard exercises the create-time open-MR refusal (issue #856) at the
+// unit level against the fakeStore, complementing the live-DB acceptance test. The
+// fakeStore's GetOpenMRRunForIssue returns a staged open-MR iid, so createRun reaches the
+// guard: force=false must refuse with ErrOpenMRExists (naming the MR), force=true must
+// bypass it.
+func TestCreateRunOpenMRGuard(t *testing.T) {
+	user, repo := uuid.New(), uuid.New()
+	const mrIID int64 = 4260
+
+	// Blocked: an open MR is staged and the caller did not force → ErrOpenMRExists, with the
+	// MR number carried structurally on *OpenMRExistsError.
+	t.Run("blocks when an open MR exists and force is false", func(t *testing.T) {
+		fs := &fakeStore{
+			issueByID:         store.Issue{Title: "T", Labels: uziLabels(), HasPrdLink: false},
+			openMRRunForIssue: pgtype.Int8{Int64: mrIID, Valid: true},
+			createRunResult:   store.Run{ID: uuid.New()},
+		}
+		svc := New(fs, newBox(t), testParams())
+		_, err := svc.CreateRun(context.Background(), user, repo, 4, "the description", nil, nil, false /*force*/, nil)
+		if !errors.Is(err, ErrOpenMRExists) {
+			t.Fatalf("CreateRun err = %v, want ErrOpenMRExists", err)
+		}
+		var omr *OpenMRExistsError
+		if !errors.As(err, &omr) {
+			t.Fatalf("CreateRun err = %v, want *OpenMRExistsError", err)
+		}
+		if omr.MRIID != mrIID {
+			t.Fatalf("OpenMRExistsError.MRIID = %d, want %d", omr.MRIID, mrIID)
+		}
+		if fs.createRunParams != nil {
+			t.Fatal("a blocked run must be refused before CreateRun")
+		}
+	})
+
+	// Forced: the same open MR is staged but force=true bypasses the guard, so the run is
+	// created and no ErrOpenMRExists surfaces.
+	t.Run("force bypasses the open-MR guard", func(t *testing.T) {
+		fs := &fakeStore{
+			issueByID:         store.Issue{Title: "T", Labels: uziLabels(), HasPrdLink: false},
+			openMRRunForIssue: pgtype.Int8{Int64: mrIID, Valid: true},
+			createRunResult:   store.Run{ID: uuid.New()},
+		}
+		svc := New(fs, newBox(t), testParams())
+		_, err := svc.CreateRun(context.Background(), user, repo, 4, "the description", nil, nil, true /*force*/, nil)
+		if errors.Is(err, ErrOpenMRExists) {
+			t.Fatalf("CreateRun with force=true err = %v, must NOT be ErrOpenMRExists (guard bypassed)", err)
+		}
+		if err != nil {
+			t.Fatalf("CreateRun with force=true err = %v, want success", err)
+		}
+		if fs.createRunParams == nil {
+			t.Fatal("a forced run must proceed to CreateRun")
+		}
+	})
+}
+
 func TestCreateAutopilotRunSetsAutoApproveAndSharesGates(t *testing.T) {
 	user, repo := uuid.New(), uuid.New()
 

--- a/api/internal/workersvc/service_test.go
+++ b/api/internal/workersvc/service_test.go
@@ -144,6 +144,14 @@ type fakeStore struct {
 	hasActiveRunForIssue    bool
 	hasActiveRunForIssueErr error
 
+	// openMRRunForIssue / openMRRunForIssueErr drive the issue #856 open-MR guard
+	// (GetOpenMRRunForIssue). Defaults (zero Int8, nil err) leave openMRRunForIssueErr set
+	// to pgx.ErrNoRows in the method below so the guard finds no open MR and allows the run,
+	// matching the real store's "no row" contract; a test can stage a valid mr_iid to force
+	// the refusal.
+	openMRRunForIssue    pgtype.Int8
+	openMRRunForIssueErr error
+
 	// issue #297: the in-flight avoid-set source for a self_improve claim.
 	activeRunsAll    []store.ListActiveRunsAllRow
 	activeRunsAllErr error
@@ -872,6 +880,14 @@ func (f *fakeStore) SetRunPoolWait(_ context.Context, arg store.SetRunPoolWaitPa
 }
 func (f *fakeStore) HasActiveRunForIssue(_ context.Context, _ store.HasActiveRunForIssueParams) (bool, error) {
 	return f.hasActiveRunForIssue, f.hasActiveRunForIssueErr
+}
+func (f *fakeStore) GetOpenMRRunForIssue(_ context.Context, _ store.GetOpenMRRunForIssueParams) (pgtype.Int8, error) {
+	// Default to the real store's no-row contract so the open-MR guard (issue #856) allows
+	// the run unless a test explicitly stages an open MR.
+	if f.openMRRunForIssueErr == nil && !f.openMRRunForIssue.Valid {
+		return pgtype.Int8{}, pgx.ErrNoRows
+	}
+	return f.openMRRunForIssue, f.openMRRunForIssueErr
 }
 func (f *fakeStore) SweepRunningTimeout(_ context.Context, arg store.SweepRunningTimeoutParams) ([]store.SweepRunningTimeoutRow, error) {
 	f.runNow = arg.Now
@@ -3559,7 +3575,7 @@ func TestCreateRunSnapshotsTitleAndRunsWithoutPRDLink(t *testing.T) {
 		createRunResult: store.Run{ID: uuid.New()},
 	}
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "the description", nil, nil, nil); err != nil {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "the description", nil, nil, false, nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
 	if fs.createRunParams == nil {
@@ -3610,7 +3626,7 @@ func TestCreateAutopilotRunSetsAutoApproveAndSharesGates(t *testing.T) {
 		createRunResult: store.Run{ID: uuid.New()},
 	}
 	svc = New(fsManual, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, nil); err != nil {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, false, nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
 	if fsManual.createRunParams.AutoApprove {
@@ -3677,7 +3693,7 @@ func TestCreateRunRejectsOversizeDescription(t *testing.T) {
 
 	// Manual and autopilot both reject at the one shared cap, before any run is made.
 	fs := &fakeStore{issueByID: store.Issue{Title: "T", Labels: uziLabels(), HasPrdLink: true}}
-	if _, err := New(fs, newBox(t), testParams()).CreateRun(context.Background(), user, repo, 4, big, nil, nil, nil); err != ErrDescriptionTooLarge {
+	if _, err := New(fs, newBox(t), testParams()).CreateRun(context.Background(), user, repo, 4, big, nil, nil, false, nil); err != ErrDescriptionTooLarge {
 		t.Fatalf("CreateRun err = %v, want ErrDescriptionTooLarge", err)
 	}
 	if fs.createRunParams != nil {
@@ -3692,7 +3708,7 @@ func TestCreateRunRejectsOversizeDescription(t *testing.T) {
 	// Exactly at the cap is accepted (boundary).
 	ok := strings.Repeat("x", MaxIssueDescriptionBytes)
 	fsOK := &fakeStore{issueByID: store.Issue{Title: "T", Labels: uziLabels(), HasPrdLink: true}, createRunResult: store.Run{ID: uuid.New()}}
-	if _, err := New(fsOK, newBox(t), testParams()).CreateRun(context.Background(), user, repo, 4, ok, nil, nil, nil); err != nil {
+	if _, err := New(fsOK, newBox(t), testParams()).CreateRun(context.Background(), user, repo, 4, ok, nil, nil, false, nil); err != nil {
 		t.Fatalf("a description exactly at the cap must be accepted, got %v", err)
 	}
 }
@@ -3704,7 +3720,7 @@ func TestCreateRunMapsDuplicateToActiveRunExists(t *testing.T) {
 		createRunErr: &pgconn.PgError{Code: "23505"},
 	}
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, nil); err != ErrActiveRunExists {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, false, nil); err != ErrActiveRunExists {
 		t.Fatalf("err = %v, want ErrActiveRunExists", err)
 	}
 }
@@ -3723,7 +3739,7 @@ func TestCreateRunPreCheckBlocksDuplicateOnHeldIssue(t *testing.T) {
 		createRunResult:      store.Run{ID: uuid.New()},
 	}
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, nil); err != ErrActiveRunExists {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, false, nil); err != ErrActiveRunExists {
 		t.Fatalf("err = %v, want ErrActiveRunExists — the pre-check must refuse a second run on a held issue", err)
 	}
 }
@@ -3739,7 +3755,7 @@ func TestCreateRunPreCheckErrorPropagates(t *testing.T) {
 		createRunResult:         store.Run{ID: uuid.New()},
 	}
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, nil); !errors.Is(err, sentinel) {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "d", nil, nil, false, nil); !errors.Is(err, sentinel) {
 		t.Fatalf("err = %v, want the pre-check error to propagate", err)
 	}
 }
@@ -3747,7 +3763,7 @@ func TestCreateRunPreCheckErrorPropagates(t *testing.T) {
 func TestCreateRunRepoNotOwned(t *testing.T) {
 	fs := &fakeStore{repoErr: pgx.ErrNoRows}
 	svc := New(fs, newBox(t), testParams())
-	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "d", nil, nil, nil); err != ErrRepoNotFound {
+	if _, err := svc.CreateRun(context.Background(), uuid.New(), uuid.New(), 4, "d", nil, nil, false, nil); err != ErrRepoNotFound {
 		t.Fatalf("err = %v, want ErrRepoNotFound", err)
 	}
 }
@@ -4044,7 +4060,7 @@ func TestCreateRunNotifiesQueuedWithOriginSnapshot(t *testing.T) {
 	lc := &fakeLifecycle{}
 	svc.SetLifecycle(lc)
 
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil); err != nil {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
 	// origin_column snapshots the issue's current column ("Later"), always a valid
@@ -4071,7 +4087,7 @@ func TestCreateRunOriginNullWhenColumnsUnavailable(t *testing.T) {
 	}
 	svc := New(fs, newBox(t), testParams())
 
-	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil); err != nil {
+	if _, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil); err != nil {
 		t.Fatalf("CreateRun should not be blocked by a column-list error: %v", err)
 	}
 	if fs.createRunParams == nil {

--- a/api/internal/workersvc/uzi_label_gate_test.go
+++ b/api/internal/workersvc/uzi_label_gate_test.go
@@ -54,7 +54,7 @@ func runAllPaths(t *testing.T, wire func(*Service), labels []byte, hasPRDLink bo
 		out[name] = pathResult{err: err, reached: fs.createRunParams != nil}
 	}
 	invoke("CreateRun", func(svc *Service) error {
-		_, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, nil)
+		_, err := svc.CreateRun(context.Background(), user, repo, 4, "desc", nil, nil, false, nil)
 		return err
 	})
 	invoke("CreateScheduledRun", func(svc *Service) error {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,7 +86,7 @@ uzi run list | get <id> [--field <name> ...] | logs <id> [--follow] [--after <se
 uzi run wait <id> [--until <status,...>] [--interval <dur>] [--timeout <dur>] [--min-plan-seq <n>]
 uzi run create --repo <id> --issue <iid> [--plan-file <path>]
                 [--agent-source own|repo] [--exclude-agents a,b]
-                [--planned-commit <sha>] [--require-base]
+                [--planned-commit <sha>] [--require-base] [--force]
 uzi run approve <id> [--agent-source own|repo] [--exclude-agents a,b]
 uzi run reject <id> [--message <text>]
 uzi run revise <id> [--message <text>]
@@ -169,6 +169,12 @@ A few worth knowing:
   `--require-base` (the base-commit staleness guard) are all optional and all
   require `--plan-file`; an empty or oversized plan is rejected at create
   time. A run created with no `--plan-file` is unchanged.
+- **`run create --force` re-runs an issue that already has an open MR.** By
+  default, creating a run for an issue whose last completed run still owns an
+  open MR is refused (a 409, exit 5) — re-running would spend budget building
+  onto a branch you have not merged yet. `--force` overrides that one refusal
+  so the new run is created anyway; it bypasses only the open-MR guard, and a
+  run already in progress for the issue is never bypassed.
 - **`run approve` picks the subagent roster explicitly.** By default a run
   uses its own default roster; `--agent-source own|repo` overrides it
   (`own` = your template roster, `repo` = the agents the worker detected in

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -824,6 +824,23 @@ Serves human: Feature #4 job queue + worker registry + lossless live stream.
   `(repo_id, issue_iid) WHERE status NOT IN (completed,failed,cancelled)` — fixes
   bottega's check-then-insert TOCTOU race with a DB constraint. Terminal runs are
   excluded so an issue can be re-run once its prior run finishes.
+  - **Open-MR run-dedup guard** (issue #856) qualifies that re-run allowance: a
+    create-time pre-check in the shared `createRun` refuses a fresh `kind='issue'`
+    run when a prior **completed** run for the same `(repo_id, issue_iid)` still
+    owns an **open MR** (watcher-owned `runs.mr_state='opened'`, queried via
+    `GetOpenMRRunForIssue`), returning a distinct `ErrOpenMRExists` sentinel. It is
+    deliberately a create-time guard, **not** a partial unique index: an index would
+    be violated by the watcher's own `SetRunMRState` UPDATE once a forced second
+    run's MR opens. Applies to **all** issue create paths (manual/board/Slack,
+    scheduled sweep, autopilot) so the auto-approved sweep — where wasted spend is
+    silent — is covered; the scheduler maps the sentinel to a benign
+    `open_mr_exists` skip (advances, no tick-storm), the autopilot poller
+    records-and-swallows. An explicit `--force` (CLI `uzi run create --force`; the
+    web board/issue Start flow offers a confirm that retries with force) bypasses
+    **only** this open-MR guard, never the active-run gate. Keyed on the
+    watcher-owned `mr_state`, so there is a brief false-negative window between
+    MR-open-at-finalize and the first watch tick (mirrors the mr_rework candidate
+    query; acceptable).
 - **`run_messages`** — `bigserial id, run_id→runs ON DELETE CASCADE, seq int,
   kind, agent, payload jsonb, created_at, agent_instance text, agent_label text`,
   **UNIQUE(run_id, seq)**. The last two are PRD #99's per-instance attribution

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -827,7 +827,9 @@ Serves human: Feature #4 job queue + worker registry + lossless live stream.
   - **Open-MR run-dedup guard** (issue #856) qualifies that re-run allowance: a
     create-time pre-check in the shared `createRun` refuses a fresh `kind='issue'`
     run when a prior **completed** run for the same `(repo_id, issue_iid)` still
-    owns an **open MR** (watcher-owned `runs.mr_state='opened'`, queried via
+    owns an **open MR** (keyed on the authoritative `runs.mr_iid`, written
+    atomically at completion by `SetRunCompleted`, releasing only once
+    `runs.mr_state` reaches a terminal `'merged'`/`'closed'`; queried via
     `GetOpenMRRunForIssue`), returning a distinct `ErrOpenMRExists` sentinel. It is
     deliberately a create-time guard, **not** a partial unique index: an index would
     be violated by the watcher's own `SetRunMRState` UPDATE once a forced second
@@ -837,10 +839,13 @@ Serves human: Feature #4 job queue + worker registry + lossless live stream.
     `open_mr_exists` skip (advances, no tick-storm), the autopilot poller
     records-and-swallows. An explicit `--force` (CLI `uzi run create --force`; the
     web board/issue Start flow offers a confirm that retries with force) bypasses
-    **only** this open-MR guard, never the active-run gate. Keyed on the
-    watcher-owned `mr_state`, so there is a brief false-negative window between
-    MR-open-at-finalize and the first watch tick (mirrors the mr_rework candidate
-    query; acceptable).
+    **only** this open-MR guard, never the active-run gate. Now independent of
+    watcher lag: keyed on the authoritative `mr_iid` (create-time authoritative,
+    written atomically with `status='completed'`) and released only on a terminal
+    `mr_state`, so a completed run whose MR the watcher has not yet observed
+    conservatively **blocks** — closing the false-negative window a prior
+    `mr_state='opened'`-only version had. This deliberately diverges from the
+    mr_rework candidate query, which still lives with that window.
 - **`run_messages`** — `bigserial id, run_id→runs ON DELETE CASCADE, seq int,
   kind, agent, payload jsonb, created_at, agent_instance text, agent_label text`,
   **UNIQUE(run_id, seq)**. The last two are PRD #99's per-instance attribution

--- a/web/src/components/LastRun.tsx
+++ b/web/src/components/LastRun.tsx
@@ -30,6 +30,9 @@ const SKIP_REASON_TONES: Record<ScheduleSkipReason, BadgeTone> = {
   // The concurrent-open-MR cap (self_improve, PRD #686 D10) is benign and self-resolving:
   // the cycle re-fires next cadence once a human merges or closes an outstanding MR.
   self_improve_mr_cap_reached: "neutral",
+  // issue #856: a prior completed run's MR is still open, so a fresh run is refused. Benign
+  // and self-resolving like already_running — the cadence re-fires once the MR merges/closes.
+  open_mr_exists: "neutral",
 };
 
 // LastRunOutcome is the enriched "Last run" cell for a schedule that has a

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1237,7 +1237,8 @@ export type ScheduleSkipReason =
   | "description_too_large"
   | "fetch_failed"
   | "vault_locked"
-  | "self_improve_mr_cap_reached";
+  | "self_improve_mr_cap_reached"
+  | "open_mr_exists";
 
 // One run a persisted fire actually created; issue_iid is null for a prompt schedule.
 export interface LastFireStarted {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2890,6 +2890,17 @@ export function isVaultLocked(err: unknown): boolean {
   );
 }
 
+// isOpenMRConflict reports whether an error is the 409 issue_has_open_mr signal
+// (issue #856): a completed prior run still owns an open MR, so a fresh run was
+// refused. The board/issue Start flow offers a force-retry on this specific code.
+export function isOpenMRConflict(err: unknown): boolean {
+  return (
+    err instanceof ApiError &&
+    err.status === 409 &&
+    (err.body as { code?: string } | null)?.code === "issue_has_open_mr"
+  );
+}
+
 async function request<T>(
   method: string,
   path: string,
@@ -3554,9 +3565,10 @@ const realApi = {
       docker,
     }),
 
-  createRun: (repoId: string, issueIid: number) =>
+  createRun: (repoId: string, issueIid: number, force?: boolean) =>
     request<{ run: Run }>("POST", `/repos/${repoId}/runs`, {
       issue_iid: issueIid,
+      ...(force ? { force: true } : {}),
     }),
   /** Queue a CI-fix run for a failed pipeline on a watched ref (PRD #6). */
   createCIFixRun: (repoId: string, ref: string) =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2901,6 +2901,14 @@ export function isOpenMRConflict(err: unknown): boolean {
   );
 }
 
+// openMRConflictMRIID returns the MR iid carried by a 409 issue_has_open_mr body
+// (issue #856), or null when absent — the web composes its own confirm copy from it.
+export function openMRConflictMRIID(err: unknown): number | null {
+  if (!(err instanceof ApiError)) return null;
+  const n = (err.body as { mr_iid?: unknown } | null)?.mr_iid;
+  return typeof n === "number" ? n : null;
+}
+
 async function request<T>(
   method: string,
   path: string,

--- a/web/src/lib/scheduleSkipReasons.test.ts
+++ b/web/src/lib/scheduleSkipReasons.test.ts
@@ -25,6 +25,7 @@ const ALL_SCHEDULE_SKIP_REASONS: ScheduleSkipReason[] = [
   "fetch_failed",
   "vault_locked",
   "self_improve_mr_cap_reached",
+  "open_mr_exists",
 ];
 
 function reasonsFromGo(): string[] {

--- a/web/src/lib/scheduleSkipReasons.ts
+++ b/web/src/lib/scheduleSkipReasons.ts
@@ -15,6 +15,7 @@ export const SCHEDULE_SKIP_REASON_LABELS: Record<ScheduleSkipReason, string> = {
   fetch_failed: "fetch failed",
   vault_locked: "vault locked",
   self_improve_mr_cap_reached: "self-improve MR cap reached",
+  open_mr_exists: "issue already has an open MR",
 };
 
 export function scheduleSkipReasonLabel(reason: ScheduleSkipReason): string {

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -3614,7 +3614,7 @@ export const mockApi = {
         throw new ApiError(
           409,
           `issue #${issueIid} already has open MR !${openMR.mr_iid} — merge or close it, or leave review comments on the MR to iterate, before starting a new run`,
-          { code: "issue_has_open_mr" },
+          { code: "issue_has_open_mr", mr_iid: openMR.mr_iid },
         );
       }
     }

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -3590,7 +3590,7 @@ export const mockApi = {
   },
 
   // ── Runs ────────────────────────────────────────────────────────────────────
-  createRun: async (repoId: string, issueIid: number) => {
+  createRun: async (repoId: string, issueIid: number, force?: boolean) => {
     const b = state.boards.get(repoId);
     const card = b?.cards.find((c) => c.iid === issueIid);
     if (!b || !card) throw new ApiError(404, "issue not found");
@@ -3598,6 +3598,26 @@ export const mockApi = {
       (r) => r.repo_id === repoId && r.issue_iid === issueIid && !["completed", "failed", "cancelled"].includes(r.status),
     );
     if (active) throw new ApiError(409, "a run is already in progress for this issue");
+    // issue #856: a completed prior run that still owns an open MR refuses a fresh
+    // run (coded issue_has_open_mr), unless the caller passes force to override.
+    if (!force) {
+      const openMR = [...state.runs.values()].find(
+        (r) =>
+          r.repo_id === repoId &&
+          r.issue_iid === issueIid &&
+          r.kind === "issue" &&
+          r.status === "completed" &&
+          r.mr_iid != null &&
+          r.mr_state === "opened",
+      );
+      if (openMR) {
+        throw new ApiError(
+          409,
+          `issue #${issueIid} already has open MR !${openMR.mr_iid} — merge or close it, or leave review comments on the MR to iterate, before starting a new run`,
+          { code: "issue_has_open_mr" },
+        );
+      }
+    }
     const now = new Date().toISOString();
     const run: Run = {
       id: nextRunId(),

--- a/web/src/pages/Board.test.tsx
+++ b/web/src/pages/Board.test.tsx
@@ -1402,8 +1402,8 @@ describe("Board — non-uzi issues (PRD #764)", () => {
   const openMRError = () =>
     new ApiError(
       409,
-      "issue #1 already has open MR !42 — merge or close it, or leave review comments on the MR to iterate, before starting a new run",
-      { code: "issue_has_open_mr" },
+      "issue #1 already has open MR !42 — merge or close it, or leave review comments on the MR to iterate, before starting a new run (pass --force to re-run anyway)",
+      { code: "issue_has_open_mr", mr_iid: 42 },
     );
 
   const renderBoardWithRunRoute = () =>
@@ -1428,9 +1428,13 @@ describe("Board — non-uzi issues (PRD #764)", () => {
     await waitFor(() => expect(start.disabled).toBe(false));
     fireEvent.click(start);
 
-    // The confirm used the server message verbatim (it already names MR !42).
+    // The confirm is web-composed: it names the MR, states the action, and carries
+    // no CLI --force jargon (issue #856).
     await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
-    expect(confirmSpy.mock.calls[0][0]).toContain("open MR !42");
+    const confirmMsg = confirmSpy.mock.calls[0][0] as string;
+    expect(confirmMsg).toContain("!42");
+    expect(confirmMsg).toContain("Start a new run anyway?");
+    expect(confirmMsg).not.toContain("--force");
     // Retried with force === true, and the run page opened.
     await waitFor(() => expect(mockApi.createRun).toHaveBeenCalledTimes(2));
     expect(mockApi.createRun.mock.calls[0]).toEqual(["repo-1", 1, undefined]);
@@ -1453,6 +1457,42 @@ describe("Board — non-uzi issues (PRD #764)", () => {
     // No retry, and the coded-conflict message is NOT shown as an error toast.
     expect(mockApi.createRun).toHaveBeenCalledTimes(1);
     expect(screen.queryByText(/already has open MR/)).toBeNull();
+    // The Start control is re-enabled after decline (starting state cleared): a
+    // stuck-in-"Starting…" regression would leave it disabled and fail here.
+    await waitFor(() => {
+      const start2 = within(cardOf("issue one")).getByRole("button", {
+        name: /Start run/,
+      }) as HTMLButtonElement;
+      expect(start2.disabled).toBe(false);
+    });
+    expect(within(cardOf("issue one")).queryByText("Starting…")).toBeNull();
+    confirmSpy.mockRestore();
+  });
+
+  it("on the open-MR 409, a confirmed forced retry that fails shows the toast and clears starting (#856)", async () => {
+    withWorkerAndToken();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockApi.createRun
+      .mockRejectedValueOnce(openMRError())
+      .mockRejectedValueOnce(new ApiError(500, "boom while forcing"));
+    renderBoard();
+    await screen.findByText("Backlog");
+    const start = within(cardOf("issue one")).getByRole("button", { name: /Start run/ }) as HTMLButtonElement;
+    await waitFor(() => expect(start.disabled).toBe(false));
+    fireEvent.click(start);
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
+    // Retried with force === true, that retry failed, so the toast shows the retry
+    // error and the starting state is cleared (button re-enabled).
+    await waitFor(() => expect(mockApi.createRun).toHaveBeenCalledTimes(2));
+    expect(mockApi.createRun.mock.calls[1]).toEqual(["repo-1", 1, true]);
+    await screen.findByText("boom while forcing");
+    await waitFor(() => {
+      const start2 = within(cardOf("issue one")).getByRole("button", {
+        name: /Start run/,
+      }) as HTMLButtonElement;
+      expect(start2.disabled).toBe(false);
+    });
     confirmSpy.mockRestore();
   });
 

--- a/web/src/pages/Board.test.tsx
+++ b/web/src/pages/Board.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import { Board, IssueCard } from "./Board";
-import { api, type Board as BoardData, type Card, type LatestRun } from "../lib/api";
+import { api, ApiError, type Board as BoardData, type Card, type LatestRun } from "../lib/api";
 import { useAuth } from "../auth/AuthContext";
 
 // The full Board mounts four endpoints and reads the configured label names off the
@@ -19,6 +19,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       listWorkers: vi.fn(),
       listSecrets: vi.fn(),
       listRuns: vi.fn(),
+      createRun: vi.fn(),
       moveIssue: vi.fn(),
       reorderBoard: vi.fn(),
       promoteIssue: vi.fn(),
@@ -1393,6 +1394,66 @@ describe("Board — non-uzi issues (PRD #764)", () => {
     // WITHOUT a PRD link, which is exactly the #764 guarantee this test asserts.
     const start = within(cardOf("issue one")).getByRole("button", { name: /Start run/ }) as HTMLButtonElement;
     await waitFor(() => expect(start.disabled).toBe(false));
+  });
+
+  // Issue #856 M3: a completed prior run that still owns an open MR makes the
+  // server refuse a fresh run with a coded 409 (issue_has_open_mr). Start catches
+  // it, confirms (the message names the MR), and retries with force on confirm.
+  const openMRError = () =>
+    new ApiError(
+      409,
+      "issue #1 already has open MR !42 — merge or close it, or leave review comments on the MR to iterate, before starting a new run",
+      { code: "issue_has_open_mr" },
+    );
+
+  const renderBoardWithRunRoute = () =>
+    render(
+      <MemoryRouter initialEntries={["/repos/repo-1/board"]}>
+        <Routes>
+          <Route path="/repos/:id/board" element={<Board />} />
+          <Route path="/runs/:runId" element={<div>run page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+  it("on the open-MR 409, confirms and retries Start with force, then navigates (#856)", async () => {
+    withWorkerAndToken();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockApi.createRun
+      .mockRejectedValueOnce(openMRError())
+      .mockResolvedValueOnce({ run: { id: "run-9" } as unknown as import("../lib/api").Run });
+    renderBoardWithRunRoute();
+    await screen.findByText("Backlog");
+    const start = within(cardOf("issue one")).getByRole("button", { name: /Start run/ }) as HTMLButtonElement;
+    await waitFor(() => expect(start.disabled).toBe(false));
+    fireEvent.click(start);
+
+    // The confirm used the server message verbatim (it already names MR !42).
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
+    expect(confirmSpy.mock.calls[0][0]).toContain("open MR !42");
+    // Retried with force === true, and the run page opened.
+    await waitFor(() => expect(mockApi.createRun).toHaveBeenCalledTimes(2));
+    expect(mockApi.createRun.mock.calls[0]).toEqual(["repo-1", 1, undefined]);
+    expect(mockApi.createRun.mock.calls[1]).toEqual(["repo-1", 1, true]);
+    await screen.findByText("run page");
+    confirmSpy.mockRestore();
+  });
+
+  it("on the open-MR 409, declining Start does not retry and shows no error (#856)", async () => {
+    withWorkerAndToken();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    mockApi.createRun.mockRejectedValueOnce(openMRError());
+    renderBoard();
+    await screen.findByText("Backlog");
+    const start = within(cardOf("issue one")).getByRole("button", { name: /Start run/ }) as HTMLButtonElement;
+    await waitFor(() => expect(start.disabled).toBe(false));
+    fireEvent.click(start);
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
+    // No retry, and the coded-conflict message is NOT shown as an error toast.
+    expect(mockApi.createRun).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/already has open MR/)).toBeNull();
+    confirmSpy.mockRestore();
   });
 
   it("promotes forge-first and adopts the returned card", async () => {

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -13,6 +13,7 @@ import {
   api,
   ApiError,
   isHttpsUrl,
+  isOpenMRConflict,
   preferForgeUrl,
   type Board as BoardData,
   type Card as CardData,
@@ -584,12 +585,37 @@ export function Board() {
   const startRun = async (card: CardData) => {
     setError("");
     setStarting(card.iid);
-    try {
-      const { run } = await api.createRun(repoId, card.iid);
+    // createAndOpen runs the create then navigates; the force path reuses it so
+    // the retry does not duplicate the navigate.
+    const createAndOpen = async (force?: boolean) => {
+      const { run } = await api.createRun(repoId, card.iid, force);
       // encodeURIComponent the id: per-call-site open-redirect hardening (see
       // safeNextPath in Login.tsx). A no-op for today's UUID ids.
       navigate(`/runs/${encodeURIComponent(run.id)}`);
+    };
+    try {
+      await createAndOpen();
     } catch (err) {
+      // issue_has_open_mr (issue #856): a completed prior run still owns an open
+      // MR. The message already names the MR; confirm, then retry with force.
+      if (isOpenMRConflict(err) && err instanceof ApiError) {
+        if (window.confirm(err.message)) {
+          try {
+            await createAndOpen(true);
+            return;
+          } catch (retryErr) {
+            setError(
+              retryErr instanceof ApiError
+                ? retryErr.message
+                : "Could not start run",
+            );
+          }
+        }
+        // Declined (or forced retry failed): clear starting, no toast on decline.
+        setStarting(null);
+        loadPreconditions();
+        return;
+      }
       setError(err instanceof ApiError ? err.message : "Could not start run");
       setStarting(null);
       loadPreconditions();

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -14,6 +14,7 @@ import {
   ApiError,
   isHttpsUrl,
   isOpenMRConflict,
+  openMRConflictMRIID,
   preferForgeUrl,
   type Board as BoardData,
   type Card as CardData,
@@ -597,9 +598,16 @@ export function Board() {
       await createAndOpen();
     } catch (err) {
       // issue_has_open_mr (issue #856): a completed prior run still owns an open
-      // MR. The message already names the MR; confirm, then retry with force.
+      // MR. Compose a web-specific confirm naming the MR (no --force jargon);
+      // confirm, then retry with force.
       if (isOpenMRConflict(err) && err instanceof ApiError) {
-        if (window.confirm(err.message)) {
+        const mr = openMRConflictMRIID(err);
+        const detail =
+          mr != null ? `an open merge request (!${mr})` : "an open merge request";
+        const proceed = window.confirm(
+          `This issue already has ${detail} from a completed run. Starting a new run will plan and review it again from scratch. Start a new run anyway?`,
+        );
+        if (proceed) {
           try {
             await createAndOpen(true);
             return;

--- a/web/src/pages/IssueView.test.tsx
+++ b/web/src/pages/IssueView.test.tsx
@@ -355,8 +355,8 @@ describe("IssueView Start gate (PRD #764)", () => {
   const openMRError = () =>
     new ApiError(
       409,
-      "issue #7 already has open MR !42 — merge or close it, or leave review comments on the MR to iterate, before starting a new run",
-      { code: "issue_has_open_mr" },
+      "issue #7 already has open MR !42 — merge or close it, or leave review comments on the MR to iterate, before starting a new run (pass --force to re-run anyway)",
+      { code: "issue_has_open_mr", mr_iid: 42 },
     );
 
   const renderWithRunRoute = () =>
@@ -389,8 +389,12 @@ describe("IssueView Start gate (PRD #764)", () => {
     await waitFor(() => expect(startBtn().disabled).toBe(false));
     fireEvent.click(startBtn());
 
+    // The confirm is web-composed: names the MR, states the action, no --force jargon.
     await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
-    expect(confirmSpy.mock.calls[0][0]).toContain("open MR !42");
+    const confirmMsg = confirmSpy.mock.calls[0][0] as string;
+    expect(confirmMsg).toContain("!42");
+    expect(confirmMsg).toContain("Start a new run anyway?");
+    expect(confirmMsg).not.toContain("--force");
     await waitFor(() => expect(mockApi.createRun).toHaveBeenCalledTimes(2));
     expect(mockApi.createRun.mock.calls[0]).toEqual(["repo-1", 7, undefined]);
     expect(mockApi.createRun.mock.calls[1]).toEqual(["repo-1", 7, true]);
@@ -414,6 +418,37 @@ describe("IssueView Start gate (PRD #764)", () => {
     expect(mockApi.createRun).toHaveBeenCalledTimes(1);
     // The coded-conflict message is not shown as an error alert on decline.
     expect(screen.queryByText(/already has open MR/)).toBeNull();
+    // The Start control is re-enabled after decline (starting state cleared): a
+    // stuck-in-"Starting…" regression would leave it disabled and fail here.
+    await waitFor(() => expect(startBtn().disabled).toBe(false));
+    expect(screen.queryByText("Starting…")).toBeNull();
+    confirmSpy.mockRestore();
+  });
+
+  it("on the open-MR 409, a confirmed forced retry that fails clears starting (#856)", async () => {
+    setAuth();
+    runnable();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockApi.createRun
+      .mockRejectedValueOnce(openMRError())
+      .mockRejectedValueOnce(new ApiError(500, "boom while forcing"));
+    renderIssueView();
+
+    const startBtn = () => screen.getByRole("button", { name: /start run/i }) as HTMLButtonElement;
+    await screen.findByText("A small typo fix");
+    await waitFor(() => expect(startBtn().disabled).toBe(false));
+    fireEvent.click(startBtn());
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
+    // Retried with force === true; that retry failed, and the starting state is
+    // cleared (button re-enabled). NOTE: unlike Board, IssueView's forced-retry
+    // failure toast does NOT persist — startRun's catch calls load(), whose first
+    // line is setError(""), which wipes the just-set message. This is existing
+    // control flow (the spec said keep it as-is), so this test asserts the real
+    // behavior; the Board/IssueView divergence is flagged back to the lead.
+    await waitFor(() => expect(mockApi.createRun).toHaveBeenCalledTimes(2));
+    expect(mockApi.createRun.mock.calls[1]).toEqual(["repo-1", 7, true]);
+    await waitFor(() => expect(startBtn().disabled).toBe(false));
     confirmSpy.mockRestore();
   });
 });

--- a/web/src/pages/IssueView.test.tsx
+++ b/web/src/pages/IssueView.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { IssueView } from "./IssueView";
-import { api, type Card, type IssueDetail, type SecretMeta, type Worker } from "../lib/api";
+import { api, ApiError, type Card, type IssueDetail, type Run, type SecretMeta, type Worker } from "../lib/api";
 import { useAuth } from "../auth/AuthContext";
 
 // IssueView loads four endpoints and, for Promote (PRD #764), calls promoteIssue.
@@ -18,6 +18,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       listWorkers: vi.fn(),
       listSecrets: vi.fn(),
       promoteIssue: vi.fn(),
+      createRun: vi.fn(),
     },
   };
 });
@@ -346,6 +347,74 @@ describe("IssueView Start gate (PRD #764)", () => {
     const startBtn = () => screen.getByRole("button", { name: /start run/i }) as HTMLButtonElement;
     await screen.findByText("A small typo fix");
     await waitFor(() => expect(startBtn().disabled).toBe(false));
+  });
+
+  // Issue #856 M3: a completed prior run that still owns an open MR makes the
+  // server refuse a fresh run with a coded 409 (issue_has_open_mr). Start catches
+  // it, confirms (the message names the MR), and retries with force on confirm.
+  const openMRError = () =>
+    new ApiError(
+      409,
+      "issue #7 already has open MR !42 — merge or close it, or leave review comments on the MR to iterate, before starting a new run",
+      { code: "issue_has_open_mr" },
+    );
+
+  const renderWithRunRoute = () =>
+    render(
+      <MemoryRouter initialEntries={["/repos/repo-1/issues/7"]}>
+        <Routes>
+          <Route path="/repos/:repoId/issues/:iid" element={<IssueView />} />
+          <Route path="/runs/:runId" element={<div>run page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+  const runnable = () => {
+    mockApi.listWorkers.mockResolvedValue({ workers: [aWorker()] });
+    mockApi.listSecrets.mockResolvedValue({ secrets: [aToken()] });
+    mockApi.getIssue.mockResolvedValue({ issue: anIssue({ labels: ["uzi"], has_prd_link: false }) });
+  };
+
+  it("on the open-MR 409, confirms and retries Start with force, then navigates (#856)", async () => {
+    setAuth();
+    runnable();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockApi.createRun
+      .mockRejectedValueOnce(openMRError())
+      .mockResolvedValueOnce({ run: { id: "run-9" } as unknown as Run });
+    renderWithRunRoute();
+
+    const startBtn = () => screen.getByRole("button", { name: /start run/i }) as HTMLButtonElement;
+    await screen.findByText("A small typo fix");
+    await waitFor(() => expect(startBtn().disabled).toBe(false));
+    fireEvent.click(startBtn());
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
+    expect(confirmSpy.mock.calls[0][0]).toContain("open MR !42");
+    await waitFor(() => expect(mockApi.createRun).toHaveBeenCalledTimes(2));
+    expect(mockApi.createRun.mock.calls[0]).toEqual(["repo-1", 7, undefined]);
+    expect(mockApi.createRun.mock.calls[1]).toEqual(["repo-1", 7, true]);
+    await screen.findByText("run page");
+    confirmSpy.mockRestore();
+  });
+
+  it("on the open-MR 409, declining Start does not retry and shows no error (#856)", async () => {
+    setAuth();
+    runnable();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    mockApi.createRun.mockRejectedValueOnce(openMRError());
+    renderIssueView();
+
+    const startBtn = () => screen.getByRole("button", { name: /start run/i }) as HTMLButtonElement;
+    await screen.findByText("A small typo fix");
+    await waitFor(() => expect(startBtn().disabled).toBe(false));
+    fireEvent.click(startBtn());
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledTimes(1));
+    expect(mockApi.createRun).toHaveBeenCalledTimes(1);
+    // The coded-conflict message is not shown as an error alert on decline.
+    expect(screen.queryByText(/already has open MR/)).toBeNull();
+    confirmSpy.mockRestore();
   });
 });
 

--- a/web/src/pages/IssueView.tsx
+++ b/web/src/pages/IssueView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { api, ApiError, isHttpsUrl, isOpenMRConflict, preferForgeUrl, type IssueDetail, type RunListItem } from "../lib/api";
+import { api, ApiError, isHttpsUrl, isOpenMRConflict, openMRConflictMRIID, preferForgeUrl, type IssueDetail, type RunListItem } from "../lib/api";
 import { hasAnthropicToken } from "../lib/hasToken";
 import { startRunGate } from "../lib/runStream";
 import { activeRunInHistory, effectiveRunStatus, isStoppedRun, mrChipState, runStatusTone } from "../lib/runBadge";
@@ -91,9 +91,16 @@ export function IssueView() {
       await createAndOpen();
     } catch (err) {
       // issue_has_open_mr (issue #856): a completed prior run still owns an open
-      // MR. The message already names the MR; confirm, then retry with force.
+      // MR. Compose a web-specific confirm naming the MR (no --force jargon);
+      // confirm, then retry with force.
       if (isOpenMRConflict(err) && err instanceof ApiError) {
-        if (window.confirm(err.message)) {
+        const mr = openMRConflictMRIID(err);
+        const detail =
+          mr != null ? `an open merge request (!${mr})` : "an open merge request";
+        const proceed = window.confirm(
+          `This issue already has ${detail} from a completed run. Starting a new run will plan and review it again from scratch. Start a new run anyway?`,
+        );
+        if (proceed) {
           try {
             await createAndOpen(true);
             return;

--- a/web/src/pages/IssueView.tsx
+++ b/web/src/pages/IssueView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { api, ApiError, isHttpsUrl, preferForgeUrl, type IssueDetail, type RunListItem } from "../lib/api";
+import { api, ApiError, isHttpsUrl, isOpenMRConflict, preferForgeUrl, type IssueDetail, type RunListItem } from "../lib/api";
 import { hasAnthropicToken } from "../lib/hasToken";
 import { startRunGate } from "../lib/runStream";
 import { activeRunInHistory, effectiveRunStatus, isStoppedRun, mrChipState, runStatusTone } from "../lib/runBadge";
@@ -79,12 +79,33 @@ export function IssueView() {
     if (!issue) return;
     setError("");
     setStarting(true);
-    try {
-      const { run } = await api.createRun(repoId, issue.iid);
+    // createAndOpen runs the create then navigates; the force path reuses it so
+    // the retry does not duplicate the navigate.
+    const createAndOpen = async (force?: boolean) => {
+      const { run } = await api.createRun(repoId, issue.iid, force);
       // encodeURIComponent the id: per-call-site open-redirect hardening (see
       // safeNextPath in Login.tsx). A no-op for today's UUID ids.
       navigate(`/runs/${encodeURIComponent(run.id)}`);
+    };
+    try {
+      await createAndOpen();
     } catch (err) {
+      // issue_has_open_mr (issue #856): a completed prior run still owns an open
+      // MR. The message already names the MR; confirm, then retry with force.
+      if (isOpenMRConflict(err) && err instanceof ApiError) {
+        if (window.confirm(err.message)) {
+          try {
+            await createAndOpen(true);
+            return;
+          } catch (retryErr) {
+            setError(retryErr instanceof ApiError ? retryErr.message : "Could not start run");
+          }
+        }
+        // Declined (or forced retry failed): clear starting, no toast on decline.
+        setStarting(false);
+        load();
+        return;
+      }
       setError(err instanceof ApiError ? err.message : "Could not start run");
       setStarting(false);
       load();


### PR DESCRIPTION
Implements issue #856.

Closes #856

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-856`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protection against starting duplicate runs when a completed run already has an open merge request.
  * Added an optional `--force` option for manually starting a new run despite this protection; active runs remain protected.
  * The web interface now explains conflicts, identifies the existing merge request, and offers a confirmation to retry.
  * Run details now display how each run was triggered.
* **Bug Fixes**
  * Scheduled and automated runs now skip open-merge-request conflicts cleanly.
  * Added clearer conflict details and skip labels for affected runs.
* **Documentation**
  * Updated CLI and automation guidance for the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->