### PR TITLE
feat(agent): bake semgrep into the worker toolchain (PRD #862 M0)

### DIFF
--- a/agent/devbox-global/devbox.json
+++ b/agent/devbox-global/devbox.json
@@ -373,7 +373,7 @@
   // (contrast openssl.bin/file.out/shellcheck.bin, whose CLI-bearing output is not `out`). No
   // meta.mainProgram is set, but bin/semgrep lands regardless. This rev carries semgrep 1.164.0;
   // its out-output narinfo (4dhfl2628wgqj25rm9m0mn28cp5x3lhq) is HTTP 200 on cache.nixos.org for
-  // x86_64-linux, so CI's amd64-only kaniko build SUBSTITUTES it rather than compiling
+  // x86_64-linux, so CI's amd64-only image build SUBSTITUTES it rather than compiling
   // semgrep-core from source — the non-negotiable condition for baking a tool in. Guard row is
   // `semgrep  semgrep  semgrep --version`. Added by hand-editing this file + the sibling
   // devbox.lock entry (never `devbox add`); locks as `source: "nixpkg"` at 20535e48….

--- a/agent/devbox-global/devbox.json
+++ b/agent/devbox-global/devbox.json
@@ -357,6 +357,26 @@
   // `file` regression. Written BARE of any version/`@latest` suffix and added by hand-editing this
   // file + the sibling devbox.lock entry (never `devbox add`, which pins its own rev and writes a
   // fat `systems:` block); locks as `source: "nixpkg"` at 20535e48….
+  //
+  // `semgrep` (2026-08-30, PRD #862 M0) bakes the SAST engine the security gate needs so a
+  // uzi worker can run and validate `task gate`'s semgrep step (invariant rules). Same "every
+  // worker should have it, restores fidelity of uzi's OWN gate" class as `yamllint`/`shellcheck`
+  // above, NOT a repo-specific tier-2 extra: without it a worker's `command -v semgrep` fails and
+  // `scripts/semgrep-gate.sh` (M2, modelled on `lint:yaml`) FAILS OPEN / prints SKIPPED — a
+  // skipped and a passing gate must never look alike, the same trap yamllint/shellcheck resolve.
+  // semgrep is Python/OCaml with no static binary, so BYO-on-PATH via this baked toolchain is the
+  // delivery (devs install locally, CI installs it) rather than a pinned-download wrapper.
+  //
+  // Multi-output at this rev — MEASURED not assumed (outputs [out dist], meta.outputsToInstall
+  // [out]) — but the CLI is in the DEFAULT `out` output (store ls of out/bin → `semgrep` present),
+  // so a BARE `semgrep` carries the CLI and NO `.bin`/`.out` selector is needed or correct
+  // (contrast openssl.bin/file.out/shellcheck.bin, whose CLI-bearing output is not `out`). No
+  // meta.mainProgram is set, but bin/semgrep lands regardless. This rev carries semgrep 1.164.0;
+  // its out-output narinfo (4dhfl2628wgqj25rm9m0mn28cp5x3lhq) is HTTP 200 on cache.nixos.org for
+  // x86_64-linux, so CI's amd64-only kaniko build SUBSTITUTES it rather than compiling
+  // semgrep-core from source — the non-negotiable condition for baking a tool in. Guard row is
+  // `semgrep  semgrep  semgrep --version`. Added by hand-editing this file + the sibling
+  // devbox.lock entry (never `devbox add`); locks as `source: "nixpkg"` at 20535e48….
   "packages": [
     "go",
     "gcc",
@@ -379,6 +399,7 @@
     "gnumake",
     "ripgrep",
     "opentofu",
-    "yamllint"
+    "yamllint",
+    "semgrep"
   ]
 }

--- a/agent/devbox-global/devbox.lock
+++ b/agent/devbox-global/devbox.lock
@@ -26,6 +26,7 @@
     "gnumake": { "resolved": "github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957#gnumake", "source": "nixpkg" },
     "ripgrep": { "resolved": "github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957#ripgrep", "source": "nixpkg" },
     "opentofu": { "resolved": "github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957#opentofu", "source": "nixpkg" },
-    "yamllint": { "resolved": "github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957#yamllint", "source": "nixpkg" }
+    "yamllint": { "resolved": "github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957#yamllint", "source": "nixpkg" },
+    "semgrep": { "resolved": "github:NixOS/nixpkgs/20535e48e12c86043b577b8518234ff5dbb26957#semgrep", "source": "nixpkg" }
   }
 }

--- a/agent/devbox-global/toolchain-guard.tsv
+++ b/agent/devbox-global/toolchain-guard.tsv
@@ -47,3 +47,4 @@ gnumake	make	make --version
 ripgrep	rg	rg --version
 opentofu	tofu	tofu version
 yamllint	yamllint	yamllint --version
+semgrep	semgrep	semgrep --version

--- a/api/internal/toolseed/devbox.json
+++ b/api/internal/toolseed/devbox.json
@@ -357,6 +357,26 @@
   // `file` regression. Written BARE of any version/`@latest` suffix and added by hand-editing this
   // file + the sibling devbox.lock entry (never `devbox add`, which pins its own rev and writes a
   // fat `systems:` block); locks as `source: "nixpkg"` at 20535e48….
+  //
+  // `semgrep` (2026-08-30, PRD #862 M0) bakes the SAST engine the security gate needs so a
+  // uzi worker can run and validate `task gate`'s semgrep step (invariant rules). Same "every
+  // worker should have it, restores fidelity of uzi's OWN gate" class as `yamllint`/`shellcheck`
+  // above, NOT a repo-specific tier-2 extra: without it a worker's `command -v semgrep` fails and
+  // `scripts/semgrep-gate.sh` (M2, modelled on `lint:yaml`) FAILS OPEN / prints SKIPPED — a
+  // skipped and a passing gate must never look alike, the same trap yamllint/shellcheck resolve.
+  // semgrep is Python/OCaml with no static binary, so BYO-on-PATH via this baked toolchain is the
+  // delivery (devs install locally, CI installs it) rather than a pinned-download wrapper.
+  //
+  // Multi-output at this rev — MEASURED not assumed (outputs [out dist], meta.outputsToInstall
+  // [out]) — but the CLI is in the DEFAULT `out` output (store ls of out/bin → `semgrep` present),
+  // so a BARE `semgrep` carries the CLI and NO `.bin`/`.out` selector is needed or correct
+  // (contrast openssl.bin/file.out/shellcheck.bin, whose CLI-bearing output is not `out`). No
+  // meta.mainProgram is set, but bin/semgrep lands regardless. This rev carries semgrep 1.164.0;
+  // its out-output narinfo (4dhfl2628wgqj25rm9m0mn28cp5x3lhq) is HTTP 200 on cache.nixos.org for
+  // x86_64-linux, so CI's amd64-only image build SUBSTITUTES it rather than compiling
+  // semgrep-core from source — the non-negotiable condition for baking a tool in. Guard row is
+  // `semgrep  semgrep  semgrep --version`. Added by hand-editing this file + the sibling
+  // devbox.lock entry (never `devbox add`); locks as `source: "nixpkg"` at 20535e48….
   "packages": [
     "go",
     "gcc",
@@ -379,6 +399,7 @@
     "gnumake",
     "ripgrep",
     "opentofu",
-    "yamllint"
+    "yamllint",
+    "semgrep"
   ]
 }


### PR DESCRIPTION
Part of #862 (SAST enforcement in the gate) — **M0**: ship semgrep in the baked worker toolchain so a uzi worker can run and validate the security gate's semgrep step (M2-M4).

## What
- Add `semgrep` (nixpkgs, v1.164.0) to `agent/devbox-global/devbox.json`, alongside `yamllint`/`shellcheck.bin` — the same "every worker should have it, restores fidelity of uzi's own gate" class.
- `devbox.lock` entry hand-edited in lockstep (pinned rev `20535e48`, `source: nixpkg`), per the file's convention (never `devbox add`).
- `toolchain-guard.tsv` row `semgrep  semgrep  semgrep --version` (the fail-closed build guard cross-checks every manifest package both directions).

## Why BYO-on-PATH via the baked toolchain
semgrep is Python/OCaml with no static binary, so it does not fit the pinned-download pattern (gitleaks/golangci). It follows the repo's non-Go gate-tool pattern (yamllint/shellcheck): `command -v` on PATH, delivered to workers by baking it here, and to devs/CI by their own install. Without it, a worker's `command -v semgrep` fails and the M2 `scripts/semgrep-gate.sh` would fail open / print SKIPPED.

## Verification (all offline-resolvable)
- `outputs [out dist]`, `outputsToInstall [out]`, and `out/bin/semgrep` present → bare `semgrep` carries the CLI, no `.bin`/`.out` selector (avoids the openssl.bin/file.out trap).
- out-output narinfo `4dhfl2628wgqj25rm9m0mn28cp5x3lhq` is **HTTP 200 on cache.nixos.org for x86_64-linux** at the pinned rev → the amd64 kaniko build substitutes it, not a from-source `semgrep-core` compile.
- `agent/test/templates-guardrails.test.ts` green (21/21), including "pins EVERY manifest package in devbox.lock" and "guards EVERY manifest package in toolchain-guard.tsv (both directions)".

## Rollout
This is the prerequisite for the semgrep gate milestones reaching a worker: after merge it needs a **release + worker-fleet roll** (`workers.image.tag` autobump) before M2-M4 can be sent to uzi. gosec/depguard (M1) have no such dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Semgrep to the global development toolchain.
  * Pinned the tool version for consistent development environments.
  * Verified that the Semgrep command-line tool is available after setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->