### PR TITLE
docs(uzi-cli): ask the MR-rework choice when driving a run in Send-to-uzi Auto mode

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -43,14 +43,19 @@ Below, a run id is written `RUN` and a PR number `PR` in the example commands.
    cross-issue blocker** (the target depends on another run's code landing first, or a
    sharp same-file overlap). Independent issues parallelize fine — do not gate on ordinary
    parallelism; a file conflict that slips through is resolved at merge.
-2. **Create gated** (no `--plan-file`):
+2. **Decide MR-rework, then create gated** (no `--plan-file`):
 
    ```
-   uzi run create --repo REPO_ID --issue ISSUE_NUM --json
+   uzi run create --repo REPO_ID --issue ISSUE_NUM --mr-rework=false --json
    ```
 
-   Gated, so the lead plans and the budget scales to its milestones. Seeded runs get the
-   global default budget, too small for a multi-milestone PRD.
+   Pass `--mr-rework` (v0.70.0) to control whether uzi auto-reworks this run's MR from
+   review comments — the decision, the three-way flag, and when to ask the user live in the
+   `uzi-cli` skill's *Send to uzi* step 3 (one source of truth). **Driving in Auto mode you
+   usually want `--mr-rework=false`** so THIS session owns the CodeRabbit/human/bot fixes and
+   merges; its operational consequence is folded into step 6. Gated, so the lead plans and the
+   budget scales to its milestones. Seeded runs get the global default budget, too small for
+   a multi-milestone PRD.
 3. **Watch to the gate** with the bundled poller (see *Watching*).
 4. **Review the plan, then approve / revise / reject.** Read it from the run log:
 
@@ -67,9 +72,12 @@ Below, a run id is written `RUN` and a PR number `PR` in the example commands.
    result → diagnose (see *When a run fails*) and stop.
 6. **Get the MR and review the diff.** `uzi run get RUN --field mr_web_url`, then review
    (see *Reviewing the diff* below), plus `gh pr diff`. Verify the diff against the
-   approved plan. **Once any review finding lands (CodeRabbit, a human reviewer, or another
-   review bot), uzi's own `mr_rework` usually fixes it itself** — defer to it and review its
-   fix before merging (see *uzi may fix the CodeRabbit findings ITSELF*).
+   approved plan. **If you created the run with `--mr-rework=false` (step 2), no rework fires
+   on it — fix the review findings locally and merge, and skip the defer-and-recheck
+   coordination below.** Otherwise (inherited or `--mr-rework`): **once any review finding
+   lands (CodeRabbit, a human reviewer, or another review bot), uzi's own `mr_rework` usually
+   fixes it itself** — defer to it and review its fix before merging (see *uzi may fix the
+   CodeRabbit findings ITSELF*).
 7. **Merge** (see *Merging past branch protection*).
 8. **Watch post-merge CI and fix** (see *Post-merge CI*).
 

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -46,14 +46,17 @@ Below, a run id is written `RUN` and a PR number `PR` in the example commands.
 2. **Decide MR-rework, then create gated** (no `--plan-file`):
 
    ```
+   # build the flag from the decision: --mr-rework=false (off) | --mr-rework (on) | omit (inherit)
    uzi run create --repo REPO_ID --issue ISSUE_NUM --mr-rework=false --json
    ```
 
    Pass `--mr-rework` (v0.70.0) to control whether uzi auto-reworks this run's MR from
    review comments — the decision, the three-way flag, and when to ask the user live in the
-   `uzi-cli` skill's *Send to uzi* step 3 (one source of truth). **Driving in Auto mode you
-   usually want `--mr-rework=false`** so THIS session owns the CodeRabbit/human/bot fixes and
-   merges; its operational consequence is folded into step 6. Gated, so the lead plans and the
+   `uzi-cli` skill's *Send to uzi* step 3 (one source of truth). Build the flag from that
+   decision (omit for inherit, `--mr-rework` for on, `--mr-rework=false` for off) rather than
+   always forcing `=false`. **Driving in Auto mode you usually want `--mr-rework=false`** so
+   THIS session owns the CodeRabbit/human/bot fixes and merges; its operational consequence is
+   folded into step 6. Gated, so the lead plans and the
    budget scales to its milestones. Seeded runs get the global default budget, too small for
    a multi-milestone PRD.
 3. **Watch to the gate** with the bundled poller (see *Watching*).
@@ -72,12 +75,14 @@ Below, a run id is written `RUN` and a PR number `PR` in the example commands.
    result → diagnose (see *When a run fails*) and stop.
 6. **Get the MR and review the diff.** `uzi run get RUN --field mr_web_url`, then review
    (see *Reviewing the diff* below), plus `gh pr diff`. Verify the diff against the
-   approved plan. **If you created the run with `--mr-rework=false` (step 2), no rework fires
-   on it — fix the review findings locally and merge, and skip the defer-and-recheck
-   coordination below.** Otherwise (inherited or `--mr-rework`): **once any review finding
-   lands (CodeRabbit, a human reviewer, or another review bot), uzi's own `mr_rework` usually
-   fixes it itself** — defer to it and review its fix before merging (see *uzi may fix the
-   CodeRabbit findings ITSELF*).
+   approved plan. Branch on the run's **effective** rework value, not just the flag you
+   typed: **if rework is effectively off** (`--mr-rework=false`, OR you omitted the flag and
+   your account default is off — resolve it, do not assume inherited means on) **no rework
+   fires — fix the review findings locally and merge, and skip the defer-and-recheck
+   coordination below.** **If it is effectively on** (`--mr-rework`, or omitted with the
+   account default on): **once any review finding lands (CodeRabbit, a human reviewer, or
+   another review bot), uzi's own `mr_rework` usually fixes it itself** — defer to it and
+   review its fix before merging (see *uzi may fix the CodeRabbit findings ITSELF*).
 7. **Merge** (see *Merging past branch protection*).
 8. **Watch post-merge CI and fix** (see *Post-merge CI*).
 

--- a/api/internal/uzicli/skill/SKILL.md
+++ b/api/internal/uzicli/skill/SKILL.md
@@ -716,11 +716,15 @@ never forces past a bad plan, a blocked merge, or an unfixable pipeline.
    value — omit it to inherit the account default, `--mr-rework=false` to force it off for
    this run, `--mr-rework` to force it on. **Ask the user with one `AskUserQuestion`** unless
    they already stated a preference (or a Custom-mode answer already covered it). The choice
-   changes step 8/9: with `--mr-rework=false` no rework fires, so **you** fix the review
-   findings locally and merge — which is what an Auto-mode driver taking the helm usually
-   wants; leaving it on (or inherited) means uzi's own `mr_rework` may fix and push to the
-   branch on review comments, so defer to it and review its fix before merging, and watch for
-   the double-fix collision (never amend the same branch while a rework is in flight). Then:
+   changes step 8/9 by the run's **effective** rework value, which for an omitted flag is the
+   account default (which itself may be off), not "on": if rework is effectively **off**
+   (`--mr-rework=false`, or omitted while your account default is off) no rework fires, so
+   **you** fix the review findings locally and merge — which is what an Auto-mode driver
+   taking the helm usually wants; if it is effectively **on** (`--mr-rework`, or omitted while
+   the account default is on) uzi's own `mr_rework` may fix and push to the branch on review
+   comments, so defer to it and review its fix before merging, and watch for the double-fix
+   collision (never amend the same branch while a rework is in flight). When you omitted the
+   flag, resolve the account default before deciding — do not assume inherited means on. Then:
 
    ```
    uzi run create --repo <id> --issue <iid> --mr-rework=false --json   # or --mr-rework, or omit to inherit

--- a/api/internal/uzicli/skill/SKILL.md
+++ b/api/internal/uzicli/skill/SKILL.md
@@ -711,7 +711,21 @@ never forces past a bad plan, a blocked merge, or an unfixable pipeline.
    - **On a confident blocker, `AskUserQuestion`:** proceed now / wait for `#N` to
      merge first (then resume from step 3) / proceed anyway. Do not decide it for
      the user.
-3. **Create the gated run.** `uzi run create --repo <id> --issue <iid> --json`,
+3. **Decide MR-rework, then create the gated run.** First choose whether uzi should
+   auto-rework THIS run's MR from review comments, and pass the matching `--mr-rework`
+   value — omit it to inherit the account default, `--mr-rework=false` to force it off for
+   this run, `--mr-rework` to force it on. **Ask the user with one `AskUserQuestion`** unless
+   they already stated a preference (or a Custom-mode answer already covered it). The choice
+   changes step 8/9: with `--mr-rework=false` no rework fires, so **you** fix the review
+   findings locally and merge — which is what an Auto-mode driver taking the helm usually
+   wants; leaving it on (or inherited) means uzi's own `mr_rework` may fix and push to the
+   branch on review comments, so defer to it and review its fix before merging, and watch for
+   the double-fix collision (never amend the same branch while a rework is in flight). Then:
+
+   ```
+   uzi run create --repo <id> --issue <iid> --mr-rework=false --json   # or --mr-rework, or omit to inherit
+   ```
+
    with no `--plan-file`, so the lead plans and the budget scales to its
    milestones.
 4. **Wait for the gate.** `uzi run wait <run-id>` stops at `awaiting_approval` (or


### PR DESCRIPTION
## What

The Send-to-uzi Auto-mode recipe created runs with a bare `uzi run create`, so a driven run inherited the account default for the MR review-rework watcher (`--mr-rework`, PRD #841). When the local session takes the helm to fix CodeRabbit/human/bot review findings itself and merge, an inherited-on rework races the local fix (the double-fix collision). The driver should decide rework per run instead.

## Changes (docs/skill only)

- **`api/internal/uzicli/skill/SKILL.md`** (bundled uzi-cli skill, the single source of truth for the Send-to-uzi recipe): step 3 now decides MR-rework first, asks the user with one `AskUserQuestion` when they have not already stated a preference, and passes the three-way flag (`--mr-rework=false` force off, `--mr-rework` force on, omit to inherit). Notes how the choice changes the local merge / CI-fix steps.
- **`.claude/skills/uzi-watcher/SKILL.md`** (operational playbook): step 2 points at that canonical step and defaults an Auto-mode driver to `--mr-rework=false`; step 6 folds in the operational consequence (rework off ⇒ fix findings locally, skip the defer-and-recheck coordination).

## Notes

- `--mr-rework` already exists in the CLI (v0.70.0); this only documents using it in the recipe.
- Skill drift control `TestSkillMatchesCommandTree` stays green (verified locally): no new flags/commands introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added merge-request rework options when creating gated runs: inherit the account default, enable rework, or disable it.
  * Auto mode now uses the effective rework setting to determine whether findings are fixed locally or deferred.

* **Documentation**
  * Clarified the available flag modes and how omitted settings inherit the account default.
  * Updated examples and guidance for merge-request review handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->