### PR TITLE
Sidebar branding: large gap between the "uzinele întunecate" tagline and the "powered by" line

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -652,6 +652,16 @@ function SidebarContent({
     navigate("/login");
   };
 
+  // Whether the below-wordmark "powered by" row renders, mirroring PoweredBy's
+  // own gating for slot="below" (null when collapsed / no branding / mode
+  // "none"; resolves to "topright" only for logo+topright, else "below"). Used
+  // to trim the wordmark Link's bottom padding so the row tucks up close.
+  const belowPoweredByPresent =
+    !collapsed &&
+    !!branding &&
+    branding.brand_mode !== "none" &&
+    !(branding.brand_mode === "logo" && branding.brand_placement === "topright");
+
   return (
     <div className="flex h-full flex-col">
       {/* Header cluster: the app wordmark/logo Link and the below-wordmark "powered
@@ -663,8 +673,14 @@ function SidebarContent({
           onClick={onNavigate}
           title={collapsed ? (showName ? "uzi · uzinele întunecate" : "app logo") : undefined}
           className={cx(
-            "flex items-center py-4",
-            collapsed ? "justify-center px-2" : "gap-2.5 px-4",
+            "flex items-center",
+            // When the below-wordmark "powered by" row renders (its own gating,
+            // mirrored here), drop the Link's bottom padding so the row tucks
+            // ~4px under the tagline, matching AdminBranding's `mt-1` preview
+            // (issue #866). Otherwise keep the symmetric py-4.
+            collapsed
+              ? "justify-center px-2 py-4"
+              : cx("gap-2.5 px-4 pt-4", belowPoweredByPresent ? "pb-0" : "pb-4"),
           )}
         >
           <AppMark branding={branding} className="h-8 w-8 rounded-lg text-lg" />


### PR DESCRIPTION
Implements issue #866.

Closes #866

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-866`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar header spacing when a “powered by” block appears beneath the wordmark.
  * Preserved balanced spacing for collapsed sidebars and top-right branding layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->