### PR TITLE
Sidebar footer: version badge is over-indented and its build-info popover is not centered in the rail

### DIFF
--- a/web/src/components/BuildInfoPopover.test.tsx
+++ b/web/src/components/BuildInfoPopover.test.tsx
@@ -694,10 +694,13 @@ describe("BuildInfoPopover — panel width is state-dependent so it fits the exp
     const cls = popover().className;
     expect(cls).toContain("w-[222px]");
     expect(cls).not.toContain("w-[226px]");
-    // Fitting the rail took BOTH levers: 222px alone at the old `left-2` inset (left
-    // 20) still reaches right 242, a 2px spill. Pin the inset too, so a revert to
-    // `left-2` that keeps the width reintroduces the overflow and this test catches it.
-    expect(cls).toContain("left-1");
+    // The expanded panel now CENTERS in the 240px rail via `-left-[3px]`: host `px-3`
+    // (12px) − 3px = 9px left edge, width 222 → right edge 231, i.e. equal 9px gaps.
+    // A revert to `left-1` or `left-2` re-pins it left and breaks the centering, so
+    // pin the inset too and these guards catch that. (The literal "-left-[3px]" does
+    // not contain the substrings "left-1" or "left-2", so both negatives stay valid.)
+    expect(cls).toContain("-left-[3px]");
+    expect(cls).not.toContain("left-1");
     expect(cls).not.toContain("left-2");
   });
 
@@ -706,5 +709,15 @@ describe("BuildInfoPopover — panel width is state-dependent so it fits the exp
     const cls = popover().className;
     expect(cls).toContain("w-[226px]");
     expect(cls).not.toContain("w-[222px]");
+  });
+
+  it("expanded: the version badge uses the aligned px-1.5 padding, not px-3", () => {
+    // The footer wrapper (AppShell.tsx) adds px-3 (12px); the badge's own px-1.5 (6px)
+    // sums to 18px, aligning the version text with the nav icon column. A revert to
+    // px-3 double-indents it and breaks that alignment, so guard the padding directly.
+    render(<BuildInfoPopover info={mockBuildInfo} now={NOW} />);
+    const badge = screen.getByRole("button", { name: "v0.4.2" });
+    expect(badge.className).toContain("px-1.5");
+    expect(badge.className).not.toContain("px-3");
   });
 });

--- a/web/src/components/BuildInfoPopover.tsx
+++ b/web/src/components/BuildInfoPopover.tsx
@@ -383,7 +383,7 @@ export function BuildInfoPopover({
         className={cx(
           "block w-full truncate text-left font-mono text-faint transition-colors",
           "hover:bg-raised hover:text-fg focus-visible:text-fg",
-          collapsed ? "px-1 py-1.5 text-center text-[9px]" : "px-3 py-1.5 text-[10px]",
+          collapsed ? "px-1 py-1.5 text-center text-[9px]" : "px-1.5 py-1.5 text-[10px]",
         )}
       >
         {label}
@@ -426,21 +426,21 @@ export function BuildInfoPopover({
           // else for a 226px panel to go, and it is why the no-clipping note above
           // matters.
           //
-          // WIDTH and inset are BOTH state-dependent, and they trade against each
-          // other on the expanded rail. Expanded the rail is 240px (`w-60`,
-          // AppShell.tsx); the panel's left edge is host `px-3` (12px) + this inset,
-          // so a fixed 226px panel at `left-2` reached x=246 and spilled 6px past the
-          // rail onto <main>. Fitting it needs BOTH the wider room `left-1` buys and a
-          // bounded width: at `left-1` the left edge is 12 + 4 = 16, so width 222 →
-          // right 238, i.e. a 2px gap inside the 240 rail. 222 (not less) because the
-          // widest row — Built, a 21-glyph `29 Aug 2026 20:57 UTC` in mono — needs a
-          // ~132px value column, and the value column is width − 88 (p-3 24 + border 2
-          // + label-col 50 + gap-x-3 12); 222 − 88 = 134 clears it, 218 (130) wrapped
-          // `UTC` to a second line on Linux mono stacks (measured in a real browser;
-          // jsdom does no layout so the unit test can only assert the width is
-          // state-dependent). Collapsed keeps `left-1 w-[226px]` — a 56px rail cannot
-          // contain any reasonable width, so its overhang stays as documented above.
-          collapsed ? "left-1 w-[226px]" : "left-1 w-[222px]",
+          // WIDTH and inset are BOTH state-dependent. Expanded the panel is CENTERED
+          // in the rail. The rail is 240px (`w-60`, AppShell.tsx); the panel's left
+          // edge is host `px-3` (12px) + this inset, so `-left-[3px]` puts it at
+          // 12 − 3 = 9px, and width 222 → right edge 231. That leaves a 9px gap on the
+          // left and 240 − 231 = 9px on the right — equal gaps, i.e. the panel sits
+          // centered in the rail rather than pinned to one side. 222 (not less)
+          // because the widest row — Built, a 21-glyph `29 Aug 2026 20:57 UTC` in
+          // mono — needs a ~132px value column, and the value column is width − 88
+          // (p-3 24 + border 2 + label-col 50 + gap-x-3 12); 222 − 88 = 134 clears it,
+          // 218 (130) wrapped `UTC` to a second line on Linux mono stacks (measured in
+          // a real browser; jsdom does no layout so the unit test can only assert the
+          // inset and width are state-dependent). Collapsed keeps `left-1 w-[226px]` —
+          // a 56px rail cannot contain any reasonable width, so its overhang stays as
+          // documented above.
+          collapsed ? "left-1 w-[226px]" : "-left-[3px] w-[222px]",
           "transition-opacity duration-150 motion-reduce:transition-none",
           open ? "opacity-100" : "pointer-events-none opacity-0",
         )}


### PR DESCRIPTION
Implements issue #864.

Closes #864

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-864`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the expanded build information popover’s alignment within the navigation rail.
  * Adjusted the expanded version badge spacing for a more compact appearance.
  * Preserved the existing collapsed layout and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->