### PR TITLE
chore: set CodeRabbit profile to quiet

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,10 @@
 
 # Reduce review noise by focusing on actionable issues
 reviews:
+  # Only the most important findings inline; minor comments are collapsed into
+  # the summary. The structural counterpart to tone_instructions below.
+  profile: quiet
+
   # Two-step review: submit "Request changes" while issues are open, auto-switch
   # to "Approve" once they are resolved. (Not a severity filter; it can request
   # changes for lower-severity comments too.)


### PR DESCRIPTION
Sets `reviews.profile: quiet` so CodeRabbit surfaces only the most important findings inline and collapses the rest into the summary. Without an explicit profile it defaults to `chill`, which contradicts this config's noise-reduction intent; `quiet` is the structural counterpart to the existing root-level `tone_instructions`.

Surfaced by CodeRabbit reviewing the same config ported to the zeo repo (vtmocanu/zeo#22). Applied across uzi, fj-queue and zeo to keep the three configs consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings to reduce minor inline feedback while preserving important review comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->