### PR TITLE
Schedule edit modal: Repo dropdown preselects the wrong repo and can't repoint a default job

### DIFF
--- a/web/src/components/ScheduleModal.test.tsx
+++ b/web/src/components/ScheduleModal.test.tsx
@@ -549,6 +549,61 @@ describe("the edit-mode repo selector (PRD #344 Feature A)", () => {
     // and provokes a server 422.
     expect(mockApi.updateSchedule.mock.calls[0]?.[1]?.repo_id).toBeUndefined();
   });
+
+  it("shows a DEFAULT job's actual repo read-only, not repos[0] (issue #731)", async () => {
+    // listRepos deliberately omits the job's repo, so a <select> would fall back to
+    // its first option (an unrelated repo). A default renders read-only instead.
+    mockApi.listRepos.mockResolvedValue({
+      repos: [{ id: "repo-other", path_with_namespace: "vtmocanu/other" }] as unknown as Awaited<
+        ReturnType<typeof api.listRepos>
+      >["repos"],
+    });
+    render(
+      <MemoryRouter>
+        <ScheduleModal
+          editing={schedFixture({
+            origin: "default",
+            catalog_slug: "prd-sweep",
+            repo_id: "repo-uzi",
+            repo_path: "vtmocanu/uzi",
+          })}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockApi.listRepos).toHaveBeenCalled());
+    // The actual repo is shown from the DTO's repo_path, not the first listRepos result.
+    expect(screen.getByText("vtmocanu/uzi")).toBeTruthy();
+    // No editable Repo select at all for a default.
+    expect(screen.queryByLabelText("Repo")).toBeNull();
+    // The unrelated repo is never presented.
+    expect(screen.queryByText("vtmocanu/other")).toBeNull();
+  });
+
+  it("selects the actual repo even when listRepos omits it, for a non-default edit (issue #731)", async () => {
+    // The job's repo is missing from listRepos, so without a synthetic option the native
+    // select would render repo-other as its value. The synthetic leading option prevents it.
+    mockApi.listRepos.mockResolvedValue({
+      repos: [{ id: "repo-other", path_with_namespace: "vtmocanu/other" }] as unknown as Awaited<
+        ReturnType<typeof api.listRepos>
+      >["repos"],
+    });
+    render(
+      <MemoryRouter>
+        <ScheduleModal
+          editing={schedFixture({ repo_id: "repo-uzi", repo_path: "vtmocanu/uzi" })}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockApi.listRepos).toHaveBeenCalled());
+    const select = screen.getByLabelText("Repo") as HTMLSelectElement;
+    await waitFor(() => expect(select.value).toBe("repo-uzi"));
+  });
 });
 
 describe("the mock updateSchedule repoint branch (PRD #344 Feature A)", () => {

--- a/web/src/components/ScheduleModal.tsx
+++ b/web/src/components/ScheduleModal.tsx
@@ -665,27 +665,43 @@ export function ScheduleModal({
               is a multi-repo picker (PRD #636 Decision 6): N repos → N independent schedules. */}
           {!pinned &&
             (isEdit ? (
-              <Field label="Repo" htmlFor="sched-repo">
-                <Select
-                  id="sched-repo"
-                  value={repoId}
-                  onChange={(e) => setRepoId(e.target.value)}
-                  disabled={isDefault || target === "issue"}
-                >
-                  {repos.length === 0 && <option value="">No repos available</option>}
-                  {repos.map((r) => (
-                    <option key={r.id} value={r.id}>
-                      {r.path_with_namespace}
-                    </option>
-                  ))}
-                </Select>
-                {target === "issue" && (
-                  <p className="mt-1 text-[11px] text-faint">
-                    An issue-target schedule can't be repointed — its issue number is
-                    repo-specific. Delete and recreate it on the new repo.
-                  </p>
-                )}
-              </Field>
+              isDefault ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-muted">Repo</span>
+                  <span className="inline-flex items-center gap-1 text-[13px] font-semibold text-fg">
+                    <span aria-hidden="true" className="text-muted">
+                      <LockIcon />
+                    </span>
+                    {editing?.repo_path || editing?.repo_id}
+                    <span className="text-[11px] font-normal text-faint">· fixed for this default</span>
+                  </span>
+                </div>
+              ) : (
+                <Field label="Repo" htmlFor="sched-repo">
+                  <Select
+                    id="sched-repo"
+                    value={repoId}
+                    onChange={(e) => setRepoId(e.target.value)}
+                    disabled={target === "issue"}
+                  >
+                    {repos.length === 0 && !repoId && <option value="">No repos available</option>}
+                    {repoId && !repos.some((r) => r.id === repoId) && (
+                      <option value={repoId}>{editing?.repo_path || repoId}</option>
+                    )}
+                    {repos.map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {r.path_with_namespace}
+                      </option>
+                    ))}
+                  </Select>
+                  {target === "issue" && (
+                    <p className="mt-1 text-[11px] text-faint">
+                      An issue-target schedule can't be repointed — its issue number is
+                      repo-specific. Delete and recreate it on the new repo.
+                    </p>
+                  )}
+                </Field>
+              )
             ) : (
               <div className="space-y-1.5">
                 <RepoMultiSelect


### PR DESCRIPTION
Implements issue #731.

Closes #731

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-731`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Catalog-default schedules now display their configured repository as read-only, including its path or ID.
  - Added a notice explaining that the repository is fixed for catalog-default schedules.
  - Non-default schedules continue to support repository selection, including repositories not currently listed.

- **Bug Fixes**
  - Prevented catalog-default schedules from incorrectly falling back to the first available repository.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->