### PR TITLE
Base-align overlay follow-ups (#627): double-fault preserved-patch superset, redundant changedFiles, merge-push non-ff routing

### DIFF
--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -2050,8 +2050,11 @@ export class RunRunner {
                     // Issue #631: a non-fast-forward rejection (an already-published branch — a resume, or
                     // the self_improve fixed branch — whose merge push cannot fast-forward) can't be cleared
                     // by the rebase fallback (it also can't force-push), so preserve the diff and fail typed
-                    // rather than escape to the generic catch (raw message, no preserved_patch). Mirrors the
-                    // overlay push catch (:2020) and pushAlignedOrPreserve (:1945-1946).
+                    // rather than escape to the generic catch (raw message, no preserved_patch). This
+                    // matches pushAlignedOrPreserve (:1945-1946), which likewise fails typed on non-ff.
+                    // (The overlay push catch at :2020 handles non-ff differently — it can still fall
+                    // back to merge/rebase — so this arm deliberately does NOT mirror it: once at the
+                    // merge, a rebase cannot clear a non-ff on an already-published branch.)
                     runLog.info(
                       "finalize base-align: merge push rejected non-fast-forward; preserving diff and failing typed",
                       { run_id: runId },

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -1734,11 +1734,14 @@ export class RunRunner {
       // that preserves the agent's diff for a human to land — instead of face-planting into
       // GitHub's opaque "without workflow scope" rejection and discarding the committed work.
       // Serves every forge-pushing kind (the failed path is not issue-gated).
+      // #377 / issue #631: computed once here, reused by the base-align overlay gate below
+      // (both read changedFiles(barePath, trackingRef)); recomputed there only if this failed open.
+      let changedForWf: string[] | null = null;
       if (claim.repo.forge_type === "github") {
         // Capture the narrowed bare path in a const the SAME way the push block does
         // (barePath is an outer `let string | undefined` and TS drops the narrowing here).
         const wfBarePath = barePath;
-        const changedForWf = await this.git.changedFiles(wfBarePath, trackingRef);
+        changedForWf = await this.git.changedFiles(wfBarePath, trackingRef);
         // D6: a null diff (diff-computation failure) fails OPEN to the normal push — do not
         // fail a possibly-legitimate non-workflow run on an inability to compute the diff.
         const wfHits =
@@ -1857,19 +1860,21 @@ export class RunRunner {
           } else {
             // The conflict-failure path (M2). The abort already ran inside
             // alignBranchWithDefault; here we preserve the diff via #377's preserved_patch and
-            // fail typed. When a strategy conflicts BEFORE any fetchAndPush (the common case),
-            // `trackingRef` still points at the agent's pre-align committed work, so
-            // workflowScopeDiff captures exactly the human-landable diff. Note a subtle
-            // exception (issue #627): a strategy that ALIGNED and then had its push rejected
-            // (the overlay's arm (c), or a merge whose push was workflow-scope-rejected) already
-            // re-fetched the ALIGNED tip into `trackingRef`; if a LATER strategy then conflicts
-            // and lands here, the preserved patch is a SUPERSET — it still contains every agent
-            // commit (the aligned tip is a fast-forward/replay of the agent work, so nothing is
-            // lost), plus the aligning strategy's own workflow-subtree/merge changes. That is a
-            // rare double-fault (a push rejection followed by a conflict) and never drops work.
+            // fail typed. We diff the pre-align agent tip (`originalAgentTip`, declared at :1848,
+            // non-null under the :1852 guard) — NOT `trackingRef` — so the preserved patch is
+            // exactly the agent's human-landable work. Issue #631: when a strategy ALIGNED and
+            // then had its push rejected (the overlay's arm (c), or a merge/rebase whose push was
+            // rejected) `fetchAndPush` re-fetched the ALIGNED tip into `trackingRef`, so diffing
+            // `trackingRef` yielded a SUPERSET (agent work PLUS the aligning strategy's own
+            // workflow-subtree/merge changes) if a LATER strategy then conflicted and landed here.
+            // Diffing `originalAgentTip` eliminates that superset: its objects were fetched into
+            // the worker bare by the finalize `fetchAgentBranch` before any align, so
+            // workflowScopeDiff resolves it. In the non-push conflict paths originalAgentTip ==
+            // trackingRef, so those are unchanged; in the clobber-safety path (a branch that
+            // edited a workflow) originalAgentTip carries that edit, so it is still preserved.
             const defTip = defaultTip;
             const failBaseAlignConflict = async () => {
-              const rawPatch = await this.git.workflowScopeDiff(alignBarePath, trackingRef);
+              const rawPatch = await this.git.workflowScopeDiff(alignBarePath, originalAgentTip);
               const patch = rawPatch === null ? undefined : redactText(rawPatch);
               batcher.emit({
                 kind: "status",
@@ -1967,7 +1972,12 @@ export class RunRunner {
             // allowed ONLY when the diff succeeded AND the branch provably modified NO workflow
             // file. Any other case (null diff, or a real workflow edit) falls straight into the
             // EXISTING merge → rebase → preserve chain, unchanged.
-            const alignChanged = await this.git.changedFiles(alignBarePath, trackingRef);
+            // Issue #631: reuse the #377 guard's changedFiles result (identical barePath+trackingRef);
+            // recompute only when #377 failed open (null diff), so a transient diff failure gets a retry.
+            const alignChanged =
+              changedForWf === null
+                ? await this.git.changedFiles(alignBarePath, trackingRef)
+                : changedForWf;
             const alignWfHits =
               alignChanged === null
                 ? null
@@ -2036,6 +2046,19 @@ export class RunRunner {
                 try {
                   await fetchAndPush();
                 } catch (e) {
+                  if (isNonFastForwardRejection(e)) {
+                    // Issue #631: a non-fast-forward rejection (an already-published branch — a resume, or
+                    // the self_improve fixed branch — whose merge push cannot fast-forward) can't be cleared
+                    // by the rebase fallback (it also can't force-push), so preserve the diff and fail typed
+                    // rather than escape to the generic catch (raw message, no preserved_patch). Mirrors the
+                    // overlay push catch (:2020) and pushAlignedOrPreserve (:1945-1946).
+                    runLog.info(
+                      "finalize base-align: merge push rejected non-fast-forward; preserving diff and failing typed",
+                      { run_id: runId },
+                    );
+                    await failBaseAlignConflict();
+                    return;
+                  }
                   if (!isWorkflowScopeRejection(e)) throw e;
                   // The merge did NOT clear GitHub's workflow-scope rejection → the proven
                   // rebase fallback (#422). alignBranchWithDefault rewinds to originalAgentTip

--- a/agent/test/runner-base-align.test.ts
+++ b/agent/test/runner-base-align.test.ts
@@ -548,6 +548,174 @@ describe("RunRunner — finalize base-align (PRD #456)", () => {
     assert.strictEqual(pushCalls, 2, "overlay push (rejected) then the fallback push (succeeds)");
     assert.strictEqual(calls.length, 1, "the PR was opened once after the successful fallback push");
   });
+
+  // (k) issue #631 (Item 1 regression) DOUBLE-FAULT: the overlay ALIGNS then its push is
+  // workflow-scope-rejected → the merge/rebase fallback both CONFLICT on an unrelated
+  // non-workflow file → failBaseAlignConflict preserves the diff. Pre-fix the preserved diff
+  // was taken from `trackingRef`, which the overlay's fetchAndPush had already advanced to the
+  // ALIGNED tip — so it carried the workflow-subtree change as a SUPERSET. Post-fix it is the
+  // pre-align agent tip's diff: exactly the agent's human-landable work, with NO workflow file.
+  it("(k) double-fault: overlay push rejected then merge+rebase conflict → preserved patch is the agent's work only, NOT a workflow superset", async () => {
+    seedWorkflowsOnOrigin();
+    const { github, calls } = fakeGitHub();
+    const strategies = spyAlign();
+    let pushCalls = 0;
+    git.pushBranch = (async () => {
+      pushCalls++;
+      // The overlay's push is workflow-scope-rejected → falls back to merge/rebase; the
+      // fallback then conflicts, so there is no second push.
+      throw new Error(
+        "git push origin ... failed: ! [remote rejected] refs/uzi-runner/agent/issue-61 -> agent/issue-61 " +
+          "(refusing to allow a Personal Access Token to create or update workflow " +
+          "`.github/workflows/ci.yml` without workflow scope)",
+      );
+    }) as typeof git.pushBranch;
+    // Branch edits a non-workflow file; main advances BOTH the workflow file AND the SAME
+    // non-workflow file divergently → the overlay aligns the workflow subtree (the branch
+    // touched no workflow, so canOverlay is true) but a whole-tree merge AND rebase both
+    // conflict on conflict.txt.
+    const exec = committingExecutor(
+      { "conflict.txt": "branch side\n" },
+      { "conflict.txt": "main side\n", ".github/workflows/ci.yml": CI_V2 },
+    );
+
+    const claim = githubClaim(61);
+    await githubRunner(github, exec).execute(claim);
+
+    const statuses = api.states.filter((s) => s.runId === claim.run_id).map((s) => s.body.status);
+    assert.deepStrictEqual(statuses, ["running", "running", "failed"]);
+    assert.strictEqual(strategies[0], "workflow-subtree", "the overlay was tried FIRST");
+    assert.ok(
+      strategies.includes("merge") && strategies.includes("rebase"),
+      "the fallback merge+rebase ran after the overlay push rejection",
+    );
+    assert.strictEqual(pushCalls, 1, "only the overlay push (rejected); the conflicting fallback pushes nothing");
+    const failed = api.states.find((s) => s.runId === claim.run_id && s.body.status === "failed")!.body;
+    assert.strictEqual(failed.fail_origin, "finalize_base_align_conflict");
+    assert.ok(failed.preserved_patch, "the pre-align diff is preserved for a human to land");
+    assert.match(failed.preserved_patch!, /conflict\.txt/, "the preserved patch carries the agent's work");
+    // The regression guard: pre-fix this diff came from the aligned overlay tip and carried the
+    // workflow-subtree change; post-fix it is the original agent tip's diff, so it must NOT.
+    assert.ok(
+      !failed.preserved_patch!.includes(".github/workflows/ci.yml"),
+      "the preserved patch must not carry the workflow-subtree superset",
+    );
+    assert.strictEqual(calls.length, 0, "no PR opened on the conflict fail");
+  });
+
+  // (l) issue #631 (Item 3): the merge is PRIMARY (null #377 diff → overlay skipped) and its
+  // push is rejected NON-FAST-FORWARD (an already-published branch — a resume, or the
+  // self_improve fixed branch — whose merge push cannot fast-forward). The rebase fallback also
+  // cannot force-push, so this must route to the typed preserve-and-fail — NOT rethrow to the
+  // generic catch (raw message, no preserved_patch), and NOT attempt a rebase.
+  it("(l) merge-fallback push rejected non-fast-forward → typed fail + preserved_patch, no rebase, no raw catch", async () => {
+    seedWorkflowsOnOrigin();
+    // null diff → overlay skipped → the merge is the primary align strategy.
+    git.changedFiles = (async () => null) as typeof git.changedFiles;
+    const { github, calls } = fakeGitHub();
+    const strategies = spyAlign();
+    const nonFfMsg =
+      "git push origin ... failed: ! [rejected] agent/issue-62 -> agent/issue-62 (non-fast-forward)\n" +
+      "error: failed to push some refs to '...'\n" +
+      "hint: Updates were rejected because the tip of your current branch is behind\n" +
+      "hint: its remote counterpart. Integrate the remote changes (e.g.\n" +
+      "hint: 'git pull ...') before pushing again.";
+    let pushCalls = 0;
+    git.pushBranch = (async () => {
+      pushCalls++;
+      // The merge push cannot fast-forward an already-published branch.
+      throw new Error(nonFfMsg);
+    }) as typeof git.pushBranch;
+    const exec = committingExecutor({ "impl.ts": "export const x = 1;\n" }, { ".github/workflows/ci.yml": CI_V2 });
+
+    const claim = githubClaim(62);
+    await githubRunner(github, exec).execute(claim);
+
+    const statuses = api.states.filter((s) => s.runId === claim.run_id).map((s) => s.body.status);
+    assert.deepStrictEqual(statuses, ["running", "running", "failed"]);
+    assert.deepStrictEqual(strategies, ["merge"], "non-ff must not trigger a rebase attempt");
+    assert.strictEqual(pushCalls, 1, "only the merge push (rejected non-ff); no rebase push");
+    const failed = api.states.find((s) => s.runId === claim.run_id && s.body.status === "failed")!.body;
+    assert.strictEqual(failed.fail_origin, "finalize_base_align_conflict", "typed fail, not the generic catch");
+    assert.ok(failed.preserved_patch, "the pre-align diff is preserved for a human to land");
+    assert.match(failed.preserved_patch!, /impl\.ts/, "the preserved patch carries the agent's work");
+    assert.ok(
+      !(failed.failure_reason ?? "").includes("non-fast-forward"),
+      "the raw non-fast-forward text must not reach failure_reason (that would mean the generic catch)",
+    );
+    assert.strictEqual(calls.length, 0, "no PR opened");
+  });
+
+  // (m) issue #631 (Item 2 dedup): on the overlay-primary path the base-align gate REUSES the
+  // #377 guard's changedFiles result (identical barePath+trackingRef) instead of recomputing
+  // it. The two counted calls are the undeclared-zero-diff guard (:1471) plus the #377 guard;
+  // the align gate adds NONE (pre-fix it recomputed, making it one more — see (n)).
+  it("(m) overlay-primary path reuses the #377 changedFiles result (no redundant recompute)", async () => {
+    seedWorkflowsOnOrigin();
+    const { github, calls } = fakeGitHub();
+    let changedCalls = 0;
+    const realChanged = git.changedFiles.bind(git);
+    git.changedFiles = (async (...args: Parameters<typeof git.changedFiles>) => {
+      changedCalls++;
+      return realChanged(...args);
+    }) as typeof git.changedFiles;
+    const realPush = git.pushBranch.bind(git);
+    git.pushBranch = (async (...args: Parameters<typeof git.pushBranch>) =>
+      realPush(...args)) as typeof git.pushBranch;
+    // Real, non-null diff: the branch edits a non-workflow file, main advances the workflow
+    // file → the overlay aligns and pushes (as in (h)).
+    const exec = committingExecutor(
+      { "conflict.txt": "branch side\n" },
+      { ".github/workflows/ci.yml": CI_V2 },
+    );
+
+    const claim = githubClaim(63);
+    await githubRunner(github, exec).execute(claim);
+
+    const statuses = api.states.filter((s) => s.runId === claim.run_id).map((s) => s.body.status);
+    assert.deepStrictEqual(statuses, ["running", "running", "completed"]);
+    assert.strictEqual(calls.length, 1, "the overlaid branch was pushed and a PR opened");
+    assert.strictEqual(
+      changedCalls,
+      2,
+      "changedFiles: zero-diff guard + #377 guard; the align gate reuses, not recomputes",
+    );
+  });
+
+  // (n) issue #631 (Item 2): when #377's changedFiles FAILS OPEN (null diff), the base-align
+  // gate must RECOMPUTE rather than reuse the null — so a transient diff failure still gets a
+  // retry. Here changedFiles always returns null: the zero-diff guard (:1471), the #377 guard,
+  // AND the align-gate recompute all fire → exactly one more call than (m), and the run still
+  // reaches the fallback merge→rebase.
+  it("(n) null #377 diff still recomputes at the base-align gate", async () => {
+    seedWorkflowsOnOrigin();
+    const { github } = fakeGitHub();
+    const strategies = spyAlign();
+    let changedCalls = 0;
+    git.changedFiles = (async () => {
+      changedCalls++;
+      return null;
+    }) as typeof git.changedFiles;
+    git.pushBranch = (async () => {}) as typeof git.pushBranch;
+    // The branch edits the SAME workflow file main diverges → the fallback merge/rebase
+    // conflicts (as in (i)), proving the run reached the fallback after the recompute.
+    const exec = committingExecutor(
+      { ".github/workflows/ci.yml": "name: ci\non: [branch-edit]\njobs: {}\n" },
+      { ".github/workflows/ci.yml": CI_V2 },
+    );
+
+    const claim = githubClaim(64);
+    await githubRunner(github, exec).execute(claim);
+
+    const statuses = api.states.filter((s) => s.runId === claim.run_id).map((s) => s.body.status);
+    assert.deepStrictEqual(statuses, ["running", "running", "failed"]);
+    assert.deepStrictEqual(strategies, ["merge", "rebase"], "the run reached the fallback merge→rebase");
+    assert.strictEqual(
+      changedCalls,
+      3,
+      "zero-diff guard + #377 guard + align-gate recompute (a null result is not reused)",
+    );
+  });
 });
 
 describe("isNonFastForwardRejection", () => {


### PR DESCRIPTION
Implements issue #631.

Closes #631

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-631`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow change detection by reusing successful results and retrying only when necessary.
  - Preserved the correct original changes when base alignment encounters conflicts.
  - Improved handling of rejected alignment updates by reporting a clear conflict instead of attempting an unsafe rebase.
  - Ensured changed-file information is recalculated when initial detection cannot determine a result.

- **Tests**
  - Added regression coverage for base alignment, conflict preservation, update rejection, and changed-file detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->