### PR TITLE
Cleanup: GitHub Projects sync board-access follow-ups (from #568 review)

### DIFF
--- a/api/internal/forgesvc/projectsync.go
+++ b/api/internal/forgesvc/projectsync.go
@@ -251,37 +251,57 @@ func (s *ProjectSyncService) Adopt(ctx context.Context, repoID uuid.UUID, projec
 	return nil
 }
 
-// projectSyncPreamble runs the preconditions Adopt and Provision share and returns
-// the resolved repo row + the type-asserted ProjectBoardSyncer. The check order and
-// the CLEAR sentinels it returns (ErrProjectSyncDisabled / NotGitHub / Unsupported /
-// MissingScope, and a bare pgx.ErrNoRows for an unknown repo id) are exactly what the
-// admin handler maps to a 4xx — extracting it keeps the two entry points DRY without
-// changing either's observable behavior.
-func (s *ProjectSyncService) projectSyncPreamble(ctx context.Context, repoID uuid.UUID) (store.GetRepoByIDRow, forge.ProjectBoardSyncer, error) {
+// projectSyncResolve runs the preconditions that need NO live forge round-trip: the
+// instance kill-switch, repo lookup (unknown id → a bare pgx.ErrNoRows the handler maps
+// to 404), the GitHub-only check, the forge build, and the ProjectBoardSyncer capability
+// assertion. It returns the resolved repo row, the type-asserted syncer, and the
+// underlying forge.Forge (so a caller that still wants the scope preflight can run it).
+// The CLEAR sentinels it returns (ErrProjectSyncDisabled / NotGitHub / Unsupported, plus
+// the bare pgx.ErrNoRows) are exactly what the admin handler maps to a 4xx.
+//
+// projectSyncPreamble layers the live scope preflight (ensureProjectScope → TokenInfo)
+// on top; the pure read path (GetVisibility) calls projectSyncResolve directly to skip
+// that extra introspection round-trip on the common panel-open path (issue #569 finding
+// #2) — a scope-missing token fails the visibility read itself.
+func (s *ProjectSyncService) projectSyncResolve(ctx context.Context, repoID uuid.UUID) (store.GetRepoByIDRow, forge.ProjectBoardSyncer, forge.Forge, error) {
 	enabled, err := s.settings.GithubProjectSyncEnabled(ctx)
 	if err != nil {
-		return store.GetRepoByIDRow{}, nil, fmt.Errorf("project sync: read kill-switch: %w", err)
+		return store.GetRepoByIDRow{}, nil, nil, fmt.Errorf("project sync: read kill-switch: %w", err)
 	}
 	if !enabled {
-		return store.GetRepoByIDRow{}, nil, ErrProjectSyncDisabled
+		return store.GetRepoByIDRow{}, nil, nil, ErrProjectSyncDisabled
 	}
 
 	repo, err := s.store.GetRepoByID(ctx, repoID)
 	if err != nil {
 		// pgx.ErrNoRows for an unknown id — the handler maps it to 404.
-		return store.GetRepoByIDRow{}, nil, err
+		return store.GetRepoByIDRow{}, nil, nil, err
 	}
 	if repo.ForgeType != string(forge.TypeGitHub) {
-		return store.GetRepoByIDRow{}, nil, ErrProjectSyncNotGitHub
+		return store.GetRepoByIDRow{}, nil, nil, ErrProjectSyncNotGitHub
 	}
 
 	f, err := s.forges.ForgeForConnection(repo.ForgeType, repo.BaseUrl, repo.TokenCiphertext)
 	if err != nil {
-		return store.GetRepoByIDRow{}, nil, fmt.Errorf("project sync: build forge: %w", err)
+		return store.GetRepoByIDRow{}, nil, nil, fmt.Errorf("project sync: build forge: %w", err)
 	}
 	syncer, ok := f.(forge.ProjectBoardSyncer)
 	if !ok {
-		return store.GetRepoByIDRow{}, nil, ErrProjectSyncUnsupported
+		return store.GetRepoByIDRow{}, nil, nil, ErrProjectSyncUnsupported
+	}
+	return repo, syncer, f, nil
+}
+
+// projectSyncPreamble runs the preconditions the write paths (Adopt, Provision,
+// SetVisibility, ShareWithUser, Unshare) and the RepoOwnerType read share: everything
+// projectSyncResolve checks, plus the live scope preflight (ensureProjectScope, which
+// adds MissingScope to the sentinel set). The check order is exactly what the admin
+// handler maps to a 4xx — keeping the entry points DRY without changing any observable
+// behavior.
+func (s *ProjectSyncService) projectSyncPreamble(ctx context.Context, repoID uuid.UUID) (store.GetRepoByIDRow, forge.ProjectBoardSyncer, error) {
+	repo, syncer, f, err := s.projectSyncResolve(ctx, repoID)
+	if err != nil {
+		return store.GetRepoByIDRow{}, nil, err
 	}
 	if err := ensureProjectScope(ctx, f); err != nil {
 		return store.GetRepoByIDRow{}, nil, err
@@ -1086,10 +1106,14 @@ func (s *ProjectSyncService) Disable(ctx context.Context, repoID uuid.UUID) erro
 }
 
 // GetVisibility reads the linked board's current `public` flag from GitHub (PRD
-// #557 M2). It runs the shared projectSyncPreamble (instance-flag gate, GitHub-only,
-// forge build, ProjectBoardSyncer assertion, scope preflight), then reads the link
-// row for the board's node id and issues a single `node(...ProjectV2{public})`
-// query. A repo with no link row surfaces pgx.ErrNoRows verbatim (handler → 404).
+// #557 M2). Unlike the write paths it runs projectSyncResolve (instance-flag gate,
+// GitHub-only, forge build, ProjectBoardSyncer assertion) but NOT the scope preflight:
+// this is the lazy read issued on every Board-access panel open (D4), and the extra
+// f.TokenInfo introspection round-trip only buys a cleaner 422 — a scope-missing token
+// fails the visibility query itself, so the preflight is dropped from this hot path
+// (issue #569 finding #2). It then reads the link row for the board's node id and issues
+// a single `node(...ProjectV2{public})` query. A repo with no link row surfaces
+// pgx.ErrNoRows verbatim (handler → 404).
 //
 // A stale/deleted board node id makes graphqlDo wrap GitHub's NOT_FOUND with
 // forge.ErrGitHubUserNotFound (that wrap is applied to EVERY NOT_FOUND, not just a
@@ -1097,7 +1121,7 @@ func (s *ProjectSyncService) Disable(ctx context.Context, repoID uuid.UUID) erro
 // ShareWithUser/Unshare maps to ErrProjectSyncUserNotFound (422). So a stale board
 // propagates as a generic error → the handler's default 500, exactly as intended.
 func (s *ProjectSyncService) GetVisibility(ctx context.Context, repoID uuid.UUID) (bool, error) {
-	_, syncer, err := s.projectSyncPreamble(ctx, repoID)
+	_, syncer, _, err := s.projectSyncResolve(ctx, repoID)
 	if err != nil {
 		return false, err
 	}
@@ -1131,8 +1155,11 @@ func (s *ProjectSyncService) RepoOwnerType(ctx context.Context, repoID uuid.UUID
 }
 
 // SetVisibility writes the linked board's `public` flag on GitHub (PRD #557 M2) via
-// `updateProjectV2`. Same preamble + link-row read as GetVisibility. As with
-// GetVisibility, a stale board node id propagates as a generic error (→ 500), not
+// `updateProjectV2`. As a WRITE it runs the full projectSyncPreamble (including the
+// scope preflight), unlike GetVisibility which drops the preflight (issue #569 finding
+// #2) — so a scope-missing token is rejected here with ErrProjectSyncMissingScope but
+// reads through on GetVisibility. The link-row read is the same. As with GetVisibility,
+// a stale board node id propagates as a generic error (→ 500), not
 // ErrProjectSyncUserNotFound — the not-found translation is scoped to the username
 // resolve step in ShareWithUser/Unshare, never the visibility path.
 func (s *ProjectSyncService) SetVisibility(ctx context.Context, repoID uuid.UUID, public bool) error {

--- a/api/internal/forgesvc/projectsync_test.go
+++ b/api/internal/forgesvc/projectsync_test.go
@@ -24,8 +24,9 @@ import (
 type fakeProjectSyncer struct {
 	*fakeForge
 
-	scopes   []string
-	tokenErr error
+	scopes         []string
+	tokenErr       error
+	tokenInfoCalls int
 
 	slugOwner, slugRepo string
 	slugErr             error
@@ -125,6 +126,7 @@ type createFieldCall struct {
 }
 
 func (f *fakeProjectSyncer) TokenInfo(context.Context) (forge.TokenInfo, error) {
+	f.tokenInfoCalls++
 	if f.tokenErr != nil {
 		return forge.TokenInfo{}, f.tokenErr
 	}
@@ -1850,6 +1852,53 @@ func TestGetVisibilityReturnsForgeValue(t *testing.T) {
 	if !public {
 		t.Errorf("want public=true from the forge, got %v", public)
 	}
+}
+
+// GetVisibility is the lazy panel-open read: it must NOT run the scope preflight (issue
+// #569 finding #2). A scope-missing token (no "project" scope) that would trip the write
+// path's ErrProjectSyncMissingScope must instead read through — the read succeeds and
+// makes ZERO TokenInfo introspection round-trips. SetVisibility (the write path) with the
+// SAME token still rejects with ErrProjectSyncMissingScope AND does call TokenInfo, so the
+// preamble split changed only the read path's behavior.
+func TestGetVisibilitySkipsScopePreflight(t *testing.T) {
+	repoID := uuid.New()
+
+	t.Run("read reads through a scope-missing token without introspection", func(t *testing.T) {
+		syncer := boardAccessSyncer()
+		syncer.scopes = []string{"repo"} // no "project" scope
+		syncer.visibilityReturn = true
+		st := boardAccessStore(repoID, "PVT_1")
+		svc := NewProjectSync(st, fakeForgeBuilder{f: syncer}, fakeSyncSettings{enabled: true}, nil)
+
+		public, err := svc.GetVisibility(context.Background(), repoID)
+		if err != nil {
+			t.Fatalf("GetVisibility must read through a scope-missing token, got %v", err)
+		}
+		if !public {
+			t.Errorf("want public=true from the forge, got %v", public)
+		}
+		if syncer.tokenInfoCalls != 0 {
+			t.Errorf("read path must make no TokenInfo introspection round-trip, got %d", syncer.tokenInfoCalls)
+		}
+	})
+
+	t.Run("write still enforces scope via TokenInfo", func(t *testing.T) {
+		syncer := boardAccessSyncer()
+		syncer.scopes = []string{"repo"} // no "project" scope
+		st := boardAccessStore(repoID, "PVT_1")
+		svc := NewProjectSync(st, fakeForgeBuilder{f: syncer}, fakeSyncSettings{enabled: true}, nil)
+
+		err := svc.SetVisibility(context.Background(), repoID, true)
+		if !errors.Is(err, ErrProjectSyncMissingScope) {
+			t.Fatalf("write path must still reject a scope-missing token with ErrProjectSyncMissingScope, got %v", err)
+		}
+		if syncer.tokenInfoCalls == 0 {
+			t.Errorf("write path must run the scope preflight (TokenInfo), got 0 calls")
+		}
+		if len(syncer.setVisibilityCalls) != 0 {
+			t.Errorf("a scope-missing write must not reach the forge, got %v", syncer.setVisibilityCalls)
+		}
+	})
 }
 
 // SetVisibility(true) calls the syncer with the link's ProjectNodeID and public=true.

--- a/api/internal/handler/admin_github_project_sync.go
+++ b/api/internal/handler/admin_github_project_sync.go
@@ -44,6 +44,40 @@ func parseOwnerKind(s string) (forge.ProjectV2OwnerKind, bool) {
 	}
 }
 
+// ownerOrAdminRepoID resolves the path :id as a uuid and enforces the owner-or-admin
+// authorization every github-project-sync handler shares: an authenticated user is
+// required (401 if none), the id must parse (400), and a non-admin must own the repo —
+// a GetRepoForUser miss maps to 404 (foreign/unknown id) and any other store error to
+// 500. On the not-ok path it writes the response and returns ok=false; the caller then
+// simply `return`s. Extracting it collapses the ~20-line block that was copy-pasted
+// verbatim across all the handlers below into one edit-once authorization boundary
+// (issue #569 finding #1). No handler uses the auth user after the preflight, so a
+// (uuid.UUID, bool) return is sufficient.
+func (h *Handler) ownerOrAdminRepoID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	user, ok := mw.UserFromContext(r.Context())
+	if !ok {
+		httpx.Error(w, http.StatusUnauthorized, "authentication required")
+		return uuid.Nil, false
+	}
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
+		return uuid.Nil, false
+	}
+	if !user.IsAdmin {
+		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				httpx.Error(w, http.StatusNotFound, "repo not found")
+				return uuid.Nil, false
+			}
+			slog.Error("github project sync: owner preflight", "error", err)
+			httpx.Error(w, http.StatusInternalServerError, "internal error")
+			return uuid.Nil, false
+		}
+	}
+	return id, true
+}
+
 // AdoptGithubProjectSync is the adopt/link write (PRD #364 M3, relocated to
 // owner-or-admin by issue #534 D4): link an EXISTING GitHub Projects v2 board to this
 // repo's label board and seed it. Mounted under the per-repo RequireAuth group, so it
@@ -52,26 +86,9 @@ func parseOwnerKind(s string) (forge.ProjectV2OwnerKind, bool) {
 // the preflight. The repo target comes from the path; the body carries only the
 // project coordinates.
 func (h *Handler) AdoptGithubProjectSync(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	var req adoptGithubProjectSyncRequest
 	if err := httpx.DecodeJSON(r, &req); err != nil {
@@ -107,26 +124,9 @@ func (h *Handler) AdoptGithubProjectSync(w http.ResponseWriter, r *http.Request)
 // stored link). A repo with no link row maps to 404 ("not linked") via the not-linked
 // sentinel. Success is 200 {"status":"resynced"}.
 func (h *Handler) ResyncGithubProjectSync(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	if h.projectSync == nil {
 		slog.Error("github project sync resync: service not wired")
@@ -148,26 +148,9 @@ func (h *Handler) ResyncGithubProjectSync(w http.ResponseWriter, r *http.Request
 // (the coordinates come from the stored link). A repo with no link row maps to 404 ("not
 // linked") via the not-linked sentinel. Success is 200 {"status":"columns_created"}.
 func (h *Handler) AutoCreateGithubProjectColumns(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	if h.projectSync == nil {
 		slog.Error("github project sync autocreate-columns: service not wired")
@@ -198,26 +181,9 @@ type provisionGithubProjectSyncRequest struct {
 // error mapping; it persists owned_by_uzi=true. Success is 201 Created (a new board
 // was made).
 func (h *Handler) ProvisionGithubProjectSync(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	var req provisionGithubProjectSyncRequest
 	if err := httpx.DecodeJSON(r, &req); err != nil {
@@ -246,26 +212,9 @@ func (h *Handler) ProvisionGithubProjectSync(w http.ResponseWriter, r *http.Requ
 // path-scoped shape as the adopt route. It does not touch the project board itself
 // (M7 refines that).
 func (h *Handler) DisableGithubProjectSync(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	if h.projectSync == nil {
 		slog.Error("github project sync disable: service not wired")
@@ -306,26 +255,9 @@ type getGithubProjectSyncStatusResponse struct {
 // (GetRepoForUser preflight, 404 for a foreign/unknown id), while an admin skips it.
 // A repo with no link row is a (different) 404: "no link = not sync-enabled".
 func (h *Handler) GetGithubProjectSyncStatus(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	if h.projectSync == nil {
 		slog.Error("github project sync status: service not wired")
@@ -373,26 +305,9 @@ func (h *Handler) GetGithubProjectSyncStatus(w http.ResponseWriter, r *http.Requ
 // sibling routes: a non-admin must own the repo (GetRepoForUser preflight, 404 for a
 // foreign/unknown id), an admin skips it; the preflight runs BEFORE the nil-guard.
 func (h *Handler) GetGithubProjectOwnerType(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	if h.projectSync == nil {
 		slog.Error("github project sync owner-type: service not wired")
@@ -429,26 +344,9 @@ type collaboratorRequest struct {
 // (GetRepoForUser preflight, 404 for a foreign/unknown id), an admin skips it. The
 // preflight runs BEFORE the nil-guard so a non-owner is 404'd regardless.
 func (h *Handler) GetGithubProjectVisibility(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	if h.projectSync == nil {
 		slog.Error("github project sync visibility: service not wired")
@@ -469,26 +367,9 @@ func (h *Handler) GetGithubProjectVisibility(w http.ResponseWriter, r *http.Requ
 // owner-or-admin preflight runs BEFORE the body decode and BEFORE the nil-guard, so a
 // non-owner is 404'd even with an empty/absent body.
 func (h *Handler) SetGithubProjectVisibility(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	var req setVisibilityRequest
 	if err := httpx.DecodeJSON(r, &req); err != nil {
@@ -515,26 +396,9 @@ func (h *Handler) SetGithubProjectVisibility(w http.ResponseWriter, r *http.Requ
 // ErrProjectSyncUserNotFound → 422 (not a 500). Same owner-or-admin, path-scoped shape
 // as the status route; the preflight runs BEFORE body decode and the nil-guard.
 func (h *Handler) ShareGithubProjectSync(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	var req collaboratorRequest
 	if err := httpx.DecodeJSON(r, &req); err != nil {
@@ -563,26 +427,9 @@ func (h *Handler) ShareGithubProjectSync(w http.ResponseWriter, r *http.Request)
 // reads it fine). Same owner-or-admin, path-scoped shape; the preflight runs BEFORE
 // body decode and the nil-guard.
 func (h *Handler) UnshareGithubProjectSync(w http.ResponseWriter, r *http.Request) {
-	user, ok := mw.UserFromContext(r.Context())
+	id, ok := h.ownerOrAdminRepoID(w, r)
 	if !ok {
-		httpx.Error(w, http.StatusUnauthorized, "authentication required")
 		return
-	}
-	id, err := uuid.Parse(chi.URLParam(r, "id"))
-	if err != nil {
-		httpx.Error(w, http.StatusBadRequest, "invalid repo id")
-		return
-	}
-	if !user.IsAdmin {
-		if _, err := h.q.GetRepoForUser(r.Context(), store.GetRepoForUserParams{ID: id, UserID: user.ID}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				httpx.Error(w, http.StatusNotFound, "repo not found")
-				return
-			}
-			slog.Error("github project sync: owner preflight", "error", err)
-			httpx.Error(w, http.StatusInternalServerError, "internal error")
-			return
-		}
 	}
 	var req collaboratorRequest
 	if err := httpx.DecodeJSON(r, &req); err != nil {

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -8929,7 +8929,7 @@ viewer" — the first path that writes judge text to a forge issue.
 A scoped fallback on PRD #83's rootless docker-worker tier (§297–305), added because the live
 dev-cluster nodes ship unprivileged user namespaces DISABLED, so
 rootless dockerd crash-loops there and #83's k8s definition of done is unreachable on this cluster.
-Owner decisions are recorded in `prds/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
+Owner decisions are recorded in `prds/done/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
 duplicated into `specs/human.md` (they are #83 owner overrides, not new user-binding requirements);
 what follows is the AI/implementation record for rebuild-from-specs. The owner-stated frame (reference
 only): docker workers run on dev-cluster; the owner accepts the node-root residual on the mitigation

--- a/web/src/pages/Repos.test.tsx
+++ b/web/src/pages/Repos.test.tsx
@@ -1198,6 +1198,48 @@ describe("Repos — Board access (PRD #557 M4)", () => {
     expect(within(panel).getByRole("switch", { name: "Board visibility" }).getAttribute("aria-checked")).toBe("true");
   });
 
+  it("a visibility READ failure renders the mapped friendly copy, not the raw server message (#569 finding #3)", async () => {
+    // The lazy visibility GET fails with a 409 whose raw sentinel is the server's
+    // instance-flag message. The read path must map it through syncErrorMessage exactly
+    // like the toggle write does, so the same cause reads identically on read and write —
+    // not the raw sentinel.
+    mockApi.getProjectSyncVisibility.mockRejectedValue(
+      new ApiError(409, "github project sync is disabled instance-wide"),
+    );
+    const panel = await openSyncPanel("vtmocanu/gh");
+    await within(panel).findByText("Board access");
+
+    // Friendly mapped copy renders…
+    expect(
+      await within(panel).findByText(/turned off for this instance — ask an admin to enable it/i),
+    ).toBeTruthy();
+    // …and the raw server sentinel does NOT (proves the mapping, non-vacuously).
+    expect(within(panel).queryByText(/disabled instance-wide/i)).toBeNull();
+  });
+
+  it("a transient toggle failure keeps the known Private caption and shows the error separately (#569 finding #4)", async () => {
+    // Read succeeds (private). The toggle write then fails transiently. syncPublic stays a
+    // valid boolean, so the caption must keep showing "Private board" — never mask a known
+    // state as "Visibility unavailable" — while the error renders in its own alert below.
+    mockApi.setProjectSyncVisibility.mockRejectedValue(new Error("network blip"));
+    const panel = await openSyncPanel("vtmocanu/gh");
+    await within(panel).findByText("Board access");
+    // The fetched private-state caption is shown before the toggle attempt.
+    expect(await within(panel).findByText("Private board")).toBeTruthy();
+
+    fireEvent.click(within(panel).getByRole("switch", { name: "Board visibility" }));
+
+    // The error surfaces (its own alert)…
+    expect(await within(panel).findByText(/Something went wrong/i)).toBeTruthy();
+    // …and the known-state caption is NOT masked as unavailable.
+    expect(within(panel).getByText("Private board")).toBeTruthy();
+    expect(within(panel).queryByText("Visibility unavailable")).toBeNull();
+    // The controlled toggle stayed at its last-known position (private → off).
+    expect(
+      within(panel).getByRole("switch", { name: "Board visibility" }).getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
   it("Share calls the collaborators endpoint and shows a success confirmation", async () => {
     mockApi.shareProjectSync.mockResolvedValue(null);
     const panel = await openSyncPanel("vtmocanu/gh");

--- a/web/src/pages/Repos.tsx
+++ b/web/src/pages/Repos.tsx
@@ -175,9 +175,10 @@ export function Repos() {
         setSyncPublic(vis.public);
       } catch (visErr) {
         setSyncPublic(null);
-        setSyncVisibilityError(
-          visErr instanceof ApiError ? visErr.message : "Couldn't read the board's visibility.",
-        );
+        // Route the read failure through the SAME mapper as the toggle write
+        // (syncErrorMessage), so the same 409/422 cause renders identical friendly
+        // copy whether it surfaced on read or on write (#569 finding #3).
+        setSyncVisibilityError(syncErrorMessage(visErr));
       }
     } catch (err) {
       if (err instanceof ApiError && err.status === 404) {
@@ -1516,13 +1517,18 @@ export function Repos() {
                             onChange={(next) => toggleVisibility(syncRepo.id, next)}
                           />
                           <span className="text-sm text-fg">
-                            {syncVisibilityError
-                              ? "Visibility unavailable"
-                              : syncPublic === null
-                                ? "Loading visibility…"
-                                : syncPublic === true
-                                  ? "Public board"
-                                  : "Private board"}
+                            {/* Key off syncPublic first: a transient toggle failure
+                                leaves syncPublic a valid boolean, so keep the known
+                                Public/Private caption and let the separate alert below
+                                carry the error. Only a truly-unknown state (null)
+                                reads as unavailable/loading (#569 finding #4). */}
+                            {syncPublic === null
+                              ? syncVisibilityError
+                                ? "Visibility unavailable"
+                                : "Loading visibility…"
+                              : syncPublic === true
+                                ? "Public board"
+                                : "Private board"}
                           </span>
                         </div>
                         {syncPublic === true && (


### PR DESCRIPTION
Implements issue #569.

Closes #569

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-569`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub project synchronization authorization and error handling.
  * Visibility checks now work even when token scope details cannot be retrieved.
  * Visibility controls preserve and display the last known Public or Private state after temporary update failures.
  * Standardized visibility error messages across project synchronization actions.
* **Documentation**
  * Corrected a referenced product requirements document path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->