### PR TITLE
report_only completion wrongly fails when the run previously parked with WIP (leftover wip(park) marker trips hasCheckpointRef)

### DIFF
--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -1577,15 +1577,63 @@ export class GitCache {
     return (await this.tryGit(barePath, ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`])) === 0;
   }
 
-  /** issue #299: true when origin's brokered checkpoint ref for `branch` is present in
-   *  the worker bare — i.e. some attempt of this run published committed work to
-   *  `refs/uzi-checkpoints/<branch>`. `fetch()` mirrors those refs into the bare
-   *  best-effort on every fetch, so this catches a checkpoint any PRIOR/cross-worker
-   *  attempt landed; the runner pairs it with its own `lastPublishedTip` to also catch a
-   *  checkpoint THIS worker published mid-run (not yet mirrored locally). The report-only
-   *  completion guard uses the union to refuse orphaning a published checkpoint. */
-  async hasCheckpointRef(barePath: string, branch: string): Promise<boolean> {
-    return this.refExists(barePath, `refs/uzi-checkpoints/${branch}`);
+  /** issue #299 / PRD #759 — true when origin's brokered checkpoint ref for `branch`
+   *  holds COMMITTED work that a report-only completion would orphan. `fetch()` mirrors
+   *  `refs/uzi-checkpoints/<branch>` into the bare best-effort on every fetch, so this
+   *  catches a checkpoint any PRIOR/cross-worker attempt landed; the runner pairs it with
+   *  its own `lastPublishedTip` to also catch a checkpoint THIS worker published mid-run
+   *  (not yet mirrored locally). The report-only completion guard uses the union to refuse
+   *  orphaning a published checkpoint.
+   *
+   *  The marker-only exception (PRD #759): a usage-limit park publishes a throwaway
+   *  `wip(park):` marker commit (WIP_PARK_COMMIT_PREFIX) to the checkpoint ref, and nothing
+   *  deletes it on resume. A checkpoint whose tip is ONLY such a marker — with no committed
+   *  milestone below it — is NOT committed work: it is an abandoned WIP marker, so this
+   *  returns false for it and a legitimate report-only completion is no longer failed on
+   *  its mere existence. A genuine committed milestone (a non-marker tip, or a marker sitting
+   *  ON TOP OF a real commit that strictly descends the recovery floor) still returns true.
+   *
+   *  Only a SINGLE leading marker is ever stripped, and that is sufficient: the reseed's
+   *  `reset --soft` (see runnerClone, git.ts ~654-669) removes an adopted marker from the
+   *  branch history, so a resumed branch never carries a marker into the work the agent
+   *  builds on. Any subsequent park therefore plants its marker on a parent that is a real
+   *  commit or the base — never on another marker — so a one-marker strip cannot miss a
+   *  buried committed milestone. */
+  async hasCommittedCheckpoint(barePath: string, branch: string): Promise<boolean> {
+    const ref = `refs/uzi-checkpoints/${branch}`;
+    // 1) No checkpoint ref → nothing to orphan.
+    if (!(await this.refExists(barePath, ref))) return false;
+    // 2) Resolve the tip. A non-marker tip is a genuine committed checkpoint — return true,
+    //    byte-identical to the pre-PRD-759 existence check for every real checkpoint.
+    const tip = (await this.tryGitStdout(barePath, ["rev-parse", "--verify", `${ref}^{commit}`])).trim();
+    if (!(await this.isWipParkMarker(barePath, tip))) return true;
+    // 3) The tip IS a `wip(park):` marker. The committed work (if any) is its parent and
+    //    below. A root-commit marker (no readable parent) has nothing committed below to
+    //    orphan → false (mirrors the root-marker handling in runnerClone, git.ts ~585-591).
+    const parent = (await this.tryGitStdout(barePath, ["rev-parse", "--verify", `${tip}^^{commit}`])).trim();
+    if (parent === "") return false;
+    // Compute the recovery floor exactly the way the reseed does (git.ts ~535): origin's
+    // branch if pushed, else the default branch. The parent is a marker-only checkpoint iff
+    // it is at or below that floor; it is a genuine committed milestone iff it STRICTLY
+    // descends the floor (isAncestor is TRUE at equality, so require a different SHA too).
+    try {
+      const floorRef = (await this.refExists(barePath, `refs/remotes/origin/${branch}`))
+        ? `refs/remotes/origin/${branch}`
+        : await this.defaultBranchRef(barePath);
+      const floorSha = (await this.tryGitStdout(barePath, ["rev-parse", "--verify", `${floorRef}^{commit}`])).trim();
+      if (floorSha === "") throw new Error(`cannot resolve floor SHA for ${floorRef}`);
+      return (await this.isAncestor(barePath, floorRef, parent)) && parent !== floorSha;
+    } catch (err) {
+      // Fail-safe: the floor could not be resolved. Preserve the guard rather than risk
+      // orphaning committed work below the marker.
+      this.log.warn("hasCommittedCheckpoint: could not resolve recovery floor — preserving guard", {
+        branch,
+        tip,
+        parent,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return true;
+    }
   }
 
   /** True when `ancestorRef` is an ancestor of (or equal to) `descendantRef` — i.e.

--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -1590,8 +1590,11 @@ export class GitCache {
    *  deletes it on resume. A checkpoint whose tip is ONLY such a marker — with no committed
    *  milestone below it — is NOT committed work: it is an abandoned WIP marker, so this
    *  returns false for it and a legitimate report-only completion is no longer failed on
-   *  its mere existence. A genuine committed milestone (a non-marker tip, or a marker sitting
-   *  ON TOP OF a real commit that strictly descends the recovery floor) still returns true.
+   *  its mere existence. The discriminator is ancestry, not descent: a marker-only checkpoint
+   *  is one whose parent is an ancestor-or-equal of the recovery floor; anything else (a
+   *  non-marker tip, or a marker whose parent STRICTLY DESCENDS the floor OR has DIVERGED from
+   *  it — the "main advanced during a park" shape) is a genuine committed milestone and still
+   *  returns true.
    *
    *  Only a SINGLE leading marker is ever stripped, and that is sufficient: the reseed's
    *  `reset --soft` (see runnerClone, git.ts ~654-669) removes an adopted marker from the
@@ -1612,17 +1615,33 @@ export class GitCache {
     //    orphan → false (mirrors the root-marker handling in runnerClone, git.ts ~585-591).
     const parent = (await this.tryGitStdout(barePath, ["rev-parse", "--verify", `${tip}^^{commit}`])).trim();
     if (parent === "") return false;
-    // Compute the recovery floor exactly the way the reseed does (git.ts ~535): origin's
-    // branch if pushed, else the default branch. The parent is a marker-only checkpoint iff
-    // it is at or below that floor; it is a genuine committed milestone iff it STRICTLY
-    // descends the floor (isAncestor is TRUE at equality, so require a different SHA too).
+    // Compute the recovery floor similar to the way the reseed does (git.ts ~535): origin's
+    // branch if pushed, else the default branch. (Only "similar to": the reseed excludes a
+    // DISJOINT origin ref via originExists = raw existence AND non-disjoint, git.ts:475/484,
+    // whereas this helper uses raw refExists. That is acceptable here because a disjoint
+    // origin floor only pushes toward BLOCK — the safe direction: a disjoint parent is not an
+    // ancestor of it, so the committed-work test below returns true.)
+    //
+    // The parent is a marker-only checkpoint iff it is an ancestor-or-equal of the floor;
+    // anything else — the parent STRICTLY descends the floor, OR it DIVERGED from the floor
+    // (shared ancestor, neither contains the other; the "main advanced during a park" shape) —
+    // is committed work that a report-only completion would orphan, so it still blocks. This
+    // mirrors the reseed's diverged-WIP leg (git.ts:713), which uses the same
+    // isAncestor(markerParent, floor) discriminator to decide "no committed milestones live
+    // below the marker". isAncestor is TRUE at equality, so the parent == floor case is a
+    // marker-only checkpoint (allow); it also returns false on a missing/broken ref, which
+    // fails safe toward BLOCK here.
     try {
       const floorRef = (await this.refExists(barePath, `refs/remotes/origin/${branch}`))
         ? `refs/remotes/origin/${branch}`
         : await this.defaultBranchRef(barePath);
-      const floorSha = (await this.tryGitStdout(barePath, ["rev-parse", "--verify", `${floorRef}^{commit}`])).trim();
-      if (floorSha === "") throw new Error(`cannot resolve floor SHA for ${floorRef}`);
-      return (await this.isAncestor(barePath, floorRef, parent)) && parent !== floorSha;
+      // Committed work exists below the marker iff the marker's parent is NOT an
+      // ancestor-or-equal of the recovery floor:
+      //   parent strictly descends floor → isAncestor(parent,floor) false → block ✓
+      //   parent == floor                → isAncestor true (true at equality) → allow ✓
+      //   parent is an ancestor of floor → isAncestor true                    → allow ✓
+      //   parent and floor DIVERGED      → isAncestor(parent,floor) false → block ✓
+      return !(await this.isAncestor(barePath, parent, floorRef));
     } catch (err) {
       // Fail-safe: the floor could not be resolved. Preserve the guard rather than risk
       // orphaning committed work below the marker.

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -1402,14 +1402,17 @@ export class RunRunner {
         // two signals, each covering a gap the other has:
         //   - lastPublishedTip: a checkpoint THIS worker confirmed-landed mid-run (set only
         //     on a landed publish), which may not yet be mirrored into the bare's local ref.
-        //   - hasCheckpointRef: origin's checkpoint ref, mirrored into the bare at
+        //   - hasCommittedCheckpoint: origin's checkpoint ref, mirrored into the bare at
         //     clone/fetch time — catches a checkpoint a PRIOR/cross-worker attempt landed.
+        //     Per PRD #759 it IGNORES a marker-only `wip(park):` checkpoint (an abandoned
+        //     usage-limit-park WIP marker with no committed milestone below it), while a
+        //     real committed milestone still blocks.
         // A genuine zero-code run trips NEITHER (nothing committed ⇒ no pack ⇒ no publish),
         // so it still completes report-only below. Refuse loudly, mirroring the
         // undeclared-empty-diff FAIL path, rather than opening a delete-ref capability.
         const publishedCheckpoint =
           lastPublishedTip !== undefined ||
-          (await this.git.hasCheckpointRef(barePath, runnerClone.branch));
+          (await this.git.hasCommittedCheckpoint(barePath, runnerClone.branch));
         if (publishedCheckpoint) {
           batcher.emit({
             kind: "status",
@@ -1480,11 +1483,13 @@ export class RunRunner {
           // orphaning: if this run DID publish a checkpoint to origin (a mid-run milestone
           // landed there), there IS committed work to land, so fall through to the push+MR
           // path. Only the genuinely-empty case completes report-only with no MR. Detection
-          // reuses the SAME publishedCheckpoint union the declared-report_only path uses.
+          // reuses the SAME publishedCheckpoint union the declared-report_only path uses,
+          // which (PRD #759) ignores a marker-only `wip(park):` checkpoint while a real
+          // committed milestone still blocks.
           if (result.scopeCapped) {
             const publishedCheckpoint =
               lastPublishedTip !== undefined ||
-              (await this.git.hasCheckpointRef(barePath, runnerClone.branch));
+              (await this.git.hasCommittedCheckpoint(barePath, runnerClone.branch));
             if (!publishedCheckpoint) {
               batcher.emit({
                 kind: "status",
@@ -1552,12 +1557,14 @@ export class RunRunner {
           // (refs/uzi-checkpoints/<branch>), completing report-only would orphan that ref.
           // This mirrors the declared report_only terminal above: detect via the UNION of
           // lastPublishedTip (a checkpoint THIS worker confirmed-landed mid-run) and
-          // hasCheckpointRef (origin's checkpoint ref, mirrored into the bare at
-          // clone/fetch time — catches a prior/cross-worker landing). A genuine zero-code
-          // prompt run trips NEITHER and still completes report-only below.
+          // hasCommittedCheckpoint (origin's checkpoint ref, mirrored into the bare at
+          // clone/fetch time — catches a prior/cross-worker landing; per PRD #759 it ignores
+          // a marker-only `wip(park):` checkpoint while a real committed milestone still
+          // blocks). A genuine zero-code prompt run trips NEITHER and still completes
+          // report-only below.
           const publishedCheckpoint =
             lastPublishedTip !== undefined ||
-            (await this.git.hasCheckpointRef(barePath, runnerClone.branch));
+            (await this.git.hasCommittedCheckpoint(barePath, runnerClone.branch));
           if (publishedCheckpoint) {
             batcher.emit({
               kind: "status",

--- a/agent/test/git-cross-worker-recovery.test.ts
+++ b/agent/test/git-cross-worker-recovery.test.ts
@@ -72,6 +72,15 @@ function worker(name: string): GitCache {
   return new GitCache(dataDir, nullLogger());
 }
 
+/** Build a commit object directly in the bare (no worktree) and return its sha. `parents`
+ *  empty makes a root commit. Used to construct precise checkpoint tip shapes (a wip(park)
+ *  marker with/without a committed parent) deterministically for the hasCommittedCheckpoint
+ *  unit tests — no timing, no working tree. */
+function mkCommit(bare: string, tree: string, parents: string[], subject: string): string {
+  const pargs = parents.flatMap((p) => ["-p", p]);
+  return gitIn(bare, [...IDENT, "commit-tree", tree, ...pargs, "-m", subject]);
+}
+
 /** Advance the fixture origin's `main` by one commit and return its new tip. Simulates
  *  `main` moving forward DURING a park, which is what diverges a set-aside checkpoint. */
 function advanceOriginMain(file: string, content: string): string {
@@ -480,5 +489,108 @@ describe("cross-worker checkpoint recovery (PRD #628 M3)", () => {
     assert.strictEqual(rc.seededFrom, "default", "no checkpoint ⇒ a fresh start from the default branch");
     assert.strictEqual(rc.priorCommits, 0);
     assert.notStrictEqual(rc.checkpointSetAside, true);
+  });
+});
+
+describe("GitCache.hasCommittedCheckpoint (issue #771 / PRD #759)", () => {
+  // The report-only orphan guard must fire on a checkpoint that holds COMMITTED work but
+  // NOT on one whose tip is only an abandoned `wip(park):` marker (the usage-limit park
+  // planted it and nothing deletes it on resume). Each case constructs a real
+  // refs/uzi-checkpoints/<branch> in a fresh bare with plumbing (commit-tree + update-ref)
+  // and asserts the helper directly — deterministic, no timing/sleep.
+
+  it("returns FALSE for a marker-only checkpoint (tip is a wip(park) marker whose parent is the floor) — issue #771", async () => {
+    // THE failing-first case: a park with no committed work below the marker. The parent IS
+    // the recovery floor, so nothing would be orphaned. Under the old existence-only guard
+    // this returned TRUE (the bug — a legitimate report_only wrongly FAILED);
+    // hasCommittedCheckpoint now returns false.
+    const gitB = worker("workerB");
+    const bareB = await gitB.ensureClone(fx.originPath);
+    const branch = "agent/issue-771-marker-only";
+    const floor = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main"]);
+    const floorTree = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main^{tree}"]);
+    const marker = mkCommit(bareB, floorTree, [floor], `${WIP_PARK_COMMIT_PREFIX} interrupted work auto-saved`);
+    gitIn(bareB, ["update-ref", `refs/uzi-checkpoints/${branch}`, marker]);
+    assert.strictEqual(
+      gitIn(bareB, ["log", "-1", "--format=%s", marker]).startsWith(WIP_PARK_COMMIT_PREFIX),
+      true,
+      "precondition: the checkpoint tip is a wip(park) marker",
+    );
+    assert.strictEqual(
+      gitIn(bareB, ["rev-parse", `${marker}^`]),
+      floor,
+      "precondition: the marker's parent is the floor (no committed work below it)",
+    );
+    assert.strictEqual(
+      await gitB.hasCommittedCheckpoint(bareB, branch),
+      false,
+      "a marker-only checkpoint holds no committed work to orphan",
+    );
+  });
+
+  it("returns TRUE for a real committed milestone tip (no marker)", async () => {
+    // Byte-identical to the pre-PRD-759 behaviour for every non-marker checkpoint tip.
+    const gitB = worker("workerB");
+    const bareB = await gitB.ensureClone(fx.originPath);
+    const branch = "agent/issue-771-real-tip";
+    const floor = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main"]);
+    const floorTree = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main^{tree}"]);
+    const milestone = mkCommit(bareB, floorTree, [floor], "real committed milestone");
+    gitIn(bareB, ["update-ref", `refs/uzi-checkpoints/${branch}`, milestone]);
+    assert.strictEqual(
+      await gitB.hasCommittedCheckpoint(bareB, branch),
+      true,
+      "a genuine committed checkpoint tip still blocks a report-only completion",
+    );
+  });
+
+  it("returns TRUE for a wip(park) marker sitting ON TOP OF a committed milestone (parent strictly descends the floor)", async () => {
+    // fork → m1(committed) → wip-marker: the marker's parent (m1) strictly descends the
+    // floor, so there IS committed work below the marker to orphan.
+    const gitB = worker("workerB");
+    const bareB = await gitB.ensureClone(fx.originPath);
+    const branch = "agent/issue-771-marker-over-milestone";
+    const floor = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main"]);
+    const floorTree = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main^{tree}"]);
+    const milestone = mkCommit(bareB, floorTree, [floor], "real committed milestone");
+    const marker = mkCommit(bareB, floorTree, [milestone], `${WIP_PARK_COMMIT_PREFIX} interrupted work auto-saved`);
+    gitIn(bareB, ["update-ref", `refs/uzi-checkpoints/${branch}`, marker]);
+    assert.notStrictEqual(milestone, floor, "precondition: the milestone strictly descends the floor");
+    assert.strictEqual(
+      await gitB.hasCommittedCheckpoint(bareB, branch),
+      true,
+      "a committed milestone below the marker still blocks",
+    );
+  });
+
+  it("returns FALSE when no checkpoint ref exists", async () => {
+    const gitB = worker("workerB");
+    const bareB = await gitB.ensureClone(fx.originPath);
+    const branch = "agent/issue-771-no-ref";
+    assert.strictEqual(
+      refInBare(bareB, `refs/uzi-checkpoints/${branch}`),
+      false,
+      "precondition: no checkpoint ref for this branch",
+    );
+    assert.strictEqual(await gitB.hasCommittedCheckpoint(bareB, branch), false);
+  });
+
+  it("returns FALSE for a root-commit wip(park) marker (marker with no parent)", async () => {
+    // A marker planted on a repo with no commit below it — nothing committed to orphan.
+    const gitB = worker("workerB");
+    const bareB = await gitB.ensureClone(fx.originPath);
+    const branch = "agent/issue-771-root-marker";
+    const floorTree = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main^{tree}"]);
+    const rootMarker = mkCommit(bareB, floorTree, [], `${WIP_PARK_COMMIT_PREFIX} root-commit park`);
+    gitIn(bareB, ["update-ref", `refs/uzi-checkpoints/${branch}`, rootMarker]);
+    assert.throws(
+      () => gitIn(bareB, ["rev-parse", "--verify", `${rootMarker}^`]),
+      "precondition: the marker is a root commit (no parent)",
+    );
+    assert.strictEqual(
+      await gitB.hasCommittedCheckpoint(bareB, branch),
+      false,
+      "a root-commit marker has nothing committed below to orphan",
+    );
   });
 });

--- a/agent/test/git-cross-worker-recovery.test.ts
+++ b/agent/test/git-cross-worker-recovery.test.ts
@@ -575,6 +575,44 @@ describe("GitCache.hasCommittedCheckpoint (issue #771 / PRD #759)", () => {
     assert.strictEqual(await gitB.hasCommittedCheckpoint(bareB, branch), false);
   });
 
+  it("returns TRUE for a wip(park) marker over a DIVERGED committed milestone (parent diverges from the floor — main advanced during the park)", async () => {
+    // Case 4, the direction the old `isAncestor(floor, parent) && parent !== floor` return
+    // MISSED: the milestone M and the floor F share a common ancestor but neither contains
+    // the other (the "main advanced during a park" shape). M is a genuine committed milestone
+    // a report-only completion would orphan, so the helper must BLOCK (true). The old return
+    // yielded FALSE here (isAncestor(floor, M) is false for a diverged M), the dangerous
+    // under-block; the fix's `!isAncestor(parent, floor)` yields true, mirroring the reseed's
+    // diverged-WIP leg (git.ts:713).
+    const gitB = worker("workerB");
+    // Build the floor A→B: advance origin/main once so its tip B has a parent A, THEN clone
+    // worker B's bare so its refs/remotes/origin/main resolves to B.
+    const floorB = advanceOriginMain("floor-advance.txt", "second floor commit\n");
+    const bareB = await gitB.ensureClone(fx.originPath);
+    const branch = "agent/issue-771-diverged-milestone";
+    const floor = gitIn(bareB, ["rev-parse", "refs/remotes/origin/main"]);
+    assert.strictEqual(floor, floorB, "precondition: worker B's floor is the advanced tip B");
+    const forkA = gitIn(bareB, ["rev-parse", `${floor}^`]); // A = parent of the floor tip B
+    const forkTree = gitIn(bareB, ["rev-parse", `${forkA}^{tree}`]);
+    // M: a committed milestone whose parent is A (NOT B), so M and B diverge — neither is an
+    // ancestor of the other.
+    const milestone = mkCommit(bareB, forkTree, [forkA], "diverged committed milestone");
+    const marker = mkCommit(bareB, forkTree, [milestone], `${WIP_PARK_COMMIT_PREFIX} interrupted work auto-saved`);
+    gitIn(bareB, ["update-ref", `refs/uzi-checkpoints/${branch}`, marker]);
+    assert.throws(
+      () => gitIn(bareB, ["merge-base", "--is-ancestor", milestone, floor]),
+      "precondition: the milestone is NOT an ancestor of the floor (diverged)",
+    );
+    assert.throws(
+      () => gitIn(bareB, ["merge-base", "--is-ancestor", floor, milestone]),
+      "precondition: the floor is NOT an ancestor of the milestone (diverged, not merely behind)",
+    );
+    assert.strictEqual(
+      await gitB.hasCommittedCheckpoint(bareB, branch),
+      true,
+      "a diverged committed milestone below the marker still blocks a report-only completion",
+    );
+  });
+
   it("returns FALSE for a root-commit wip(park) marker (marker with no parent)", async () => {
     // A marker planted on a repo with no commit below it — nothing committed to orphan.
     const gitB = worker("workerB");

--- a/agent/test/runner-checkpoint.test.ts
+++ b/agent/test/runner-checkpoint.test.ts
@@ -679,7 +679,7 @@ describe("RunRunner — report_only after a checkpoint is refused (issue #299)",
   // This pins the SAME-WORKER leg of the union guard: a run that publishes a checkpoint
   // mid-run (lastPublishedTip advances on the confirmed publish) and THEN declares
   // report_only must FAIL, because a report-only completion opens no branch/MR and would
-  // orphan the published refs/uzi-checkpoints/<branch>. hasCheckpointRef is NOT stubbed
+  // orphan the published refs/uzi-checkpoints/<branch>. hasCommittedCheckpoint is NOT stubbed
   // here (the fixture bare carries no mirrored checkpoint ref — the publish went through
   // the client spy), so the guard trips on lastPublishedTip alone.
   it("fails a report_only completion after this worker published a checkpoint", async () => {

--- a/agent/test/runner-push-mr.test.ts
+++ b/agent/test/runner-push-mr.test.ts
@@ -458,20 +458,20 @@ describe("RunRunner — worker-performed push + MR", () => {
 
   // issue #299: a report-only completion opens NO branch/MR, so if this run already
   // published committed work to a checkpoint ref on origin, completing report-only would
-  // orphan it. This pins the cross-worker leg of the union guard: hasCheckpointRef true
-  // (origin carries a checkpoint a prior attempt landed, mirrored into the bare) while
-  // this worker published nothing itself. It must FAIL with an actionable reason, opening
-  // NEITHER a push NOR an MR — mirroring the undeclared-empty-diff FAIL path.
+  // orphan it. This pins the cross-worker leg of the union guard: hasCommittedCheckpoint
+  // true (origin carries a COMMITTED checkpoint a prior attempt landed, mirrored into the
+  // bare) while this worker published nothing itself. It must FAIL with an actionable
+  // reason, opening NEITHER a push NOR an MR — mirroring the undeclared-empty-diff FAIL path.
   it("fails a report-only run that published a checkpoint (orphan guard), opening NO MR (issue #299)", async () => {
     const { gitlab, calls } = fakeGitlab();
     let pushed = false;
     git.pushBranch = (async () => {
       pushed = true;
     }) as typeof git.pushBranch;
-    // A checkpoint ref for this run's branch already exists on origin (mirrored into the
-    // bare) — this worker did not publish it, so lastPublishedTip stays undefined and the
-    // guard must key on hasCheckpointRef.
-    git.hasCheckpointRef = (async () => true) as typeof git.hasCheckpointRef;
+    // A committed checkpoint ref for this run's branch already exists on origin (mirrored
+    // into the bare) — this worker did not publish it, so lastPublishedTip stays undefined
+    // and the guard must key on hasCommittedCheckpoint.
+    git.hasCommittedCheckpoint = (async () => true) as typeof git.hasCommittedCheckpoint;
     const exec: Executor = {
       run: async (ctx) => ({
         branch: ctx.branch,
@@ -546,8 +546,8 @@ describe("RunRunner — worker-performed push + MR", () => {
   // guard as the declared report_only path. A zero-commit prompt run that ALREADY published
   // a checkpoint ref to origin must FAIL (not complete report-only, not open an MR) — else
   // completing report-only would orphan refs/uzi-checkpoints/<branch>. This mirrors the
-  // declared-path orphan test above, keyed on hasCheckpointRef (a prior/cross-worker landing
-  // mirrored into the bare) with lastPublishedTip staying undefined.
+  // declared-path orphan test above, keyed on hasCommittedCheckpoint (a prior/cross-worker
+  // committed landing mirrored into the bare) with lastPublishedTip staying undefined.
   it("fails a zero-commit prompt run that published a checkpoint (orphan guard), opening NO MR (issue #299)", async () => {
     const { gitlab, calls } = fakeGitlab();
     let pushed = false;
@@ -556,9 +556,9 @@ describe("RunRunner — worker-performed push + MR", () => {
     }) as typeof git.pushBranch;
     // Confirmed-empty diff ([], not null): the prompt run committed nothing at signal_done.
     git.changedFiles = (async () => []) as typeof git.changedFiles;
-    // ...but a checkpoint ref for this branch already exists on origin (mirrored into the
-    // bare). Completing report-only would orphan it, so the terminal must FAIL instead.
-    git.hasCheckpointRef = (async () => true) as typeof git.hasCheckpointRef;
+    // ...but a committed checkpoint ref for this branch already exists on origin (mirrored
+    // into the bare). Completing report-only would orphan it, so the terminal must FAIL instead.
+    git.hasCommittedCheckpoint = (async () => true) as typeof git.hasCommittedCheckpoint;
     const claim = gitlabClaim(27, { kind: "prompt" });
     await runner(new StubExecutor(nullLogger()), gitlab).execute(claim);
 


### PR DESCRIPTION
Implements issue #771.

Closes #771

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-771`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint recovery to distinguish completed work from temporary parking markers.
  * Prevented false blocking when only marker checkpoints exist.
  * Continued blocking completion when committed milestone work is detected.
  * Applied consistent orphan-check handling across report-only, empty-diff, and zero-diff completion scenarios.

* **Tests**
  * Added coverage for missing, diverged, root, marker-only, and committed checkpoints.
  * Updated recovery and checkpoint validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->