### PR TITLE
0.52.0 review follow-ups: cordon sibling surfaces, rune-safe terminal truncation, two test-coverage gaps

### DIFF
--- a/agent/test/runner-usage-limit-park.test.ts
+++ b/agent/test/runner-usage-limit-park.test.ts
@@ -610,6 +610,9 @@ describe("RunRunner — durable park (PRD #218 M1/M2/M3)", () => {
       });
       // No session_id ⇒ a fresh run.
       await runnerWith(factory, gitlab).execute(gitlabClaim(iid, {}));
+      // Guard against a vacuous pass: the executor must actually have run, else
+      // `seen[0]?.resumed !== true` is trivially true on an undefined seen[0].
+      assert.strictEqual(seen.length, 1, "the executor must have been invoked exactly once");
       assert.ok(
         seen[0]?.resumed !== true,
         `a fresh claim must not be flagged resumed, got ${String(seen[0]?.resumed)}`,

--- a/api/cmd/uzi/compacttext_test.go
+++ b/api/cmd/uzi/compacttext_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestCompactTextRuneSafe pins that compactText truncates on RUNES, not bytes (issue
+// #554): a multibyte rune straddling the 200-unit cap must not be split into an orphan
+// continuation byte. This guards the DIRECT callers (compactPayload, the steer-queue
+// body column) — unlike TestVersionCommandOutputStaysValidUTF8, whose cellText path
+// re-encodes an orphan to U+FFFD downstream and so could not catch a byte-slice here.
+//
+// The payload is 199 ASCII bytes then U+20AC (3 bytes): a byte slice at 200 would keep
+// exactly one byte of the euro sign, yielding invalid UTF-8 and no clean truncation.
+func TestCompactTextRuneSafe(t *testing.T) {
+	in := strings.Repeat("A", 199) + strings.Repeat("€", 4)
+	got := compactText(in)
+
+	if !utf8.ValidString(got) {
+		t.Errorf("compactText emitted invalid UTF-8 — the cap split a multibyte rune:\n%q", got)
+	}
+	if strings.ContainsRune(got, '�') {
+		t.Errorf("compactText left a U+FFFD replacement char at the cut — the rune was split:\n%q", got)
+	}
+	// Truncation still happened (the input exceeds 200 runes) and the ellipsis marks it.
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("compactText did not truncate an over-length input (no ellipsis):\n%q", got)
+	}
+	// The cap is 200 CONTENT runes plus the ellipsis: 199 'A' + one '€' = 200, then '…'.
+	if n := utf8.RuneCountInString(got); n != 201 {
+		t.Errorf("compactText kept %d runes, want 201 (200 content + ellipsis)", n)
+	}
+}

--- a/api/cmd/uzi/run.go
+++ b/api/cmd/uzi/run.go
@@ -1185,7 +1185,7 @@ func readPlanFile(env Env, path string) (string, error) {
 		}
 		return string(b), nil
 	}
-	b, err := os.ReadFile(path)
+	b, err := os.ReadFile(path) //nolint:gosec // G304: path is the operator's own --plan-file argument to their local CLI; reading the file they named is the intended behaviour, not untrusted inclusion.
 	if err != nil {
 		return "", uzicli.Exitf(uzicli.ExitUsage, "cannot read plan file: %v", err)
 	}
@@ -2047,11 +2047,8 @@ func shortInstanceID(id string) string {
 
 // capCell truncates a table cell to max RUNES, appending an ellipsis. Rune-based
 // per the house idiom (workersvc.deriveChatTitle): byte-slicing splits a multibyte
-// codepoint into invalid UTF-8. Note the neighbouring compactText still byte-slices
-// at its 200-char cap — milder there, since a mangled rune reaches a terminal rather
-// than an INSERT, but the two are inconsistent and compactText is the one that is
-// wrong. Left alone here: it is shared with the payload and steer-body columns, so
-// changing it changes output this milestone does not own.
+// codepoint into invalid UTF-8. The neighbouring compactText caps on runes for the
+// same reason (issue #554); the two are now consistent.
 func capCell(s string, max int) string {
 	if utf8.RuneCountInString(s) <= max {
 		return s
@@ -2068,14 +2065,20 @@ func compactPayload(raw json.RawMessage) string {
 
 // compactText sanitizes untrusted free text and folds it to a single truncated
 // line for a human table cell (Risk 13): C0/C1 controls stripped, newlines
-// collapsed to spaces, capped at 200 chars. Shared by compactPayload (message
+// collapsed to spaces, capped at 200 RUNES. Shared by compactPayload (message
 // payloads) and the steer-queue body column.
+//
+// The cap is rune-based (issue #554): a byte slice at 200 bytes could split a
+// multibyte rune straddling the boundary, emitting an orphan continuation byte —
+// invalid UTF-8 to a terminal on the direct callers, and a U+FFFD mojibake glyph
+// on the paths that re-encode downstream (cellText's strings.Map). capCell above
+// caps on runes for the same reason.
 func compactText(s string) string {
 	s = sanitizeTTY(strings.TrimSpace(s))
 	s = strings.ReplaceAll(s, "\n", " ")
 	const max = 200
-	if len(s) > max {
-		return s[:max] + "…"
+	if utf8.RuneCountInString(s) > max {
+		return string([]rune(s)[:max]) + "…"
 	}
 	return s
 }

--- a/api/cmd/uzi/run.go
+++ b/api/cmd/uzi/run.go
@@ -2077,8 +2077,15 @@ func compactText(s string) string {
 	s = sanitizeTTY(strings.TrimSpace(s))
 	s = strings.ReplaceAll(s, "\n", " ")
 	const max = 200
-	if utf8.RuneCountInString(s) > max {
-		return string([]rune(s)[:max]) + "…"
+	// Range yields each rune's start byte index, so we can slice at the 201st
+	// rune's boundary without allocating a []rune for the whole input — payloads
+	// forwarded through compactPayload can be up to the client's 32 MiB cap.
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i] + "…"
+		}
+		n++
 	}
 	return s
 }

--- a/api/cmd/uzi/versioncheck_test.go
+++ b/api/cmd/uzi/versioncheck_test.go
@@ -634,22 +634,19 @@ func TestVersionCommandSanitizesServerBuildInfo(t *testing.T) {
 	}
 }
 
-// 🔴 PINS A SAFETY PROPERTY THAT IS EMERGENT FROM STATEMENT ORDERING, WITH NOTHING
-// ELSE HOLDING IT.
+// PINS that the version render path emits valid UTF-8 when the server string ends in a
+// multibyte rune at the truncation boundary.
 //
-// compactText truncates with `s[:200]` — 200 BYTES, not runes — so a multi-byte rune
-// straddling that boundary is cut in half and the tail is an orphan continuation
-// byte. The output is nevertheless valid UTF-8, but ONLY because cellText runs its
-// outer strings.Map AFTER that slice, and Map re-encodes the orphan as U+FFFD.
-//
-// Swap those two steps, or call compactText alone on this path, and uzi emits
-// invalid UTF-8 derived from attacker-chosen input — with every existing assertion
-// still green, because the bytes carry no control character and sit on one line.
-// That is what this test exists for; it is not a duplicate of the control-character
-// tests above.
+// compactText now caps on RUNES (issue #554), so it never splits a rune and the render
+// path is valid UTF-8 with no U+FFFD at the cut. Before that fix compactText byte-sliced
+// at 200 bytes: a rune straddling the boundary was cut in half, and the output stayed
+// valid here ONLY because cellText's outer strings.Map re-encoded the orphan byte as
+// U+FFFD downstream — the direct compactText callers (compactPayload, the steer body
+// column) had no such re-encode and emitted invalid UTF-8. This test guards the whole
+// render path; the direct-caller property is pinned by TestCompactTextRuneSafe.
 //
 // The payload puts the boundary inside a 3-byte rune deliberately: 199 ASCII bytes
-// then U+20AC, so the slice keeps one byte of it.
+// then U+20AC, so a byte slice would have kept one byte of it.
 func TestVersionCommandOutputStaysValidUTF8(t *testing.T) {
 	withVersion(t, "v1.2.3")
 	payload := strings.Repeat("A", 199) + strings.Repeat("€", 4)

--- a/api/cmd/uzi/versioncheck_test.go
+++ b/api/cmd/uzi/versioncheck_test.go
@@ -663,6 +663,12 @@ func TestVersionCommandOutputStaysValidUTF8(t *testing.T) {
 		t.Errorf("stdout is not valid UTF-8 — the byte-slice truncation cut a rune and "+
 			"nothing re-encoded the orphan:\n%.120q", out)
 	}
+	// utf8.ValidString is true for U+FFFD, so it alone cannot catch a regression to
+	// byte-slicing: cellText's strings.Map re-encodes an orphan byte as U+FFFD, which
+	// stays "valid". Reject the replacement rune so this test actually fails on that path.
+	if strings.ContainsRune(out, '�') {
+		t.Errorf("stdout contains U+FFFD — a rune was split and re-encoded downstream:\n%.120q", out)
+	}
 }
 
 // --json stays BYTE-EXACT, and the reason is the DESTINATION rather than the encoder:

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -8929,7 +8929,7 @@ viewer" — the first path that writes judge text to a forge issue.
 A scoped fallback on PRD #83's rootless docker-worker tier (§297–305), added because the live
 dev-cluster nodes ship unprivileged user namespaces DISABLED, so
 rootless dockerd crash-loops there and #83's k8s definition of done is unreachable on this cluster.
-Owner decisions are recorded in `prds/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
+Owner decisions are recorded in `prds/done/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
 duplicated into `specs/human.md` (they are #83 owner overrides, not new user-binding requirements);
 what follows is the AI/implementation record for rebuild-from-specs. The owner-stated frame (reference
 only): docker workers run on dev-cluster; the owner accepts the node-root residual on the mitigation

--- a/web/src/pages/Board.test.tsx
+++ b/web/src/pages/Board.test.tsx
@@ -1909,6 +1909,71 @@ describe("Board — search + per-lane paging (PRD #304)", () => {
     );
   });
 
+  // Same route-swap trap for sortMode: the [repoId] effect at Board.tsx re-reads the
+  // persisted mode when :id changes without a remount. repo-1 has no saved mode (default
+  // "manual"); repo-2 saved "title". Delete the sortMode re-read effect and the combobox
+  // stays "manual" after the swap → this fails.
+  it("re-reads the persisted sortMode when the route repo id changes without a remount", async () => {
+    store.set("uzi.board.repo-2.sortMode", '"title"');
+    const NavProbe = () => {
+      const nav = useNavigate();
+      return <button onClick={() => nav("/repos/repo-2/board")}>go repo2</button>;
+    };
+    render(
+      <MemoryRouter initialEntries={["/repos/repo-1/board"]}>
+        <Routes>
+          <Route path="/repos/:id/board" element={<Board />} />
+        </Routes>
+        <NavProbe />
+      </MemoryRouter>,
+    );
+    await screen.findByText("Backlog");
+    // repo-1 has no saved mode → the default "manual".
+    expect((screen.getByRole("combobox", { name: "Sort" }) as HTMLSelectElement).value).toBe("manual");
+
+    fireEvent.click(screen.getByRole("button", { name: "go repo2" }));
+    await waitFor(() =>
+      expect((screen.getByRole("combobox", { name: "Sort" }) as HTMLSelectElement).value).toBe("title"),
+    );
+  });
+
+  // Same route-swap trap for sortDir: the [repoId] effect re-reads the persisted direction
+  // for the new repo. repo-2 saved mode "updated" (DEFAULT_SORT_DIR desc) with sortDir
+  // "asc" — the OPPOSITE of the mode default, which is what makes the direction assertion
+  // non-vacuous: only the re-read effect can produce ascending. Delete the sortDir re-read
+  // effect and the toggle stays at repo-1's manual/descending after the swap → this fails.
+  it("re-reads the persisted sortDir when the route repo id changes without a remount", async () => {
+    store.set("uzi.board.repo-2.sortMode", '"updated"');
+    store.set("uzi.board.repo-2.sortDir", '"asc"');
+    const NavProbe = () => {
+      const nav = useNavigate();
+      return <button onClick={() => nav("/repos/repo-2/board")}>go repo2</button>;
+    };
+    render(
+      <MemoryRouter initialEntries={["/repos/repo-1/board"]}>
+        <Routes>
+          <Route path="/repos/:id/board" element={<Board />} />
+        </Routes>
+        <NavProbe />
+      </MemoryRouter>,
+    );
+    await screen.findByText("Backlog");
+    // repo-1 has no saved mode → Manual, so the direction toggle is present but disabled.
+    expect((screen.getByRole("combobox", { name: "Sort" }) as HTMLSelectElement).value).toBe("manual");
+    expect((screen.getByRole("button", { name: /Sort direction/ }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "go repo2" }));
+    // repo-2's persisted mode "updated" adopts, and its persisted "asc" (opposite of the
+    // updated=desc default) adopts too — so the toggle reads ascending and is enabled.
+    await waitFor(() =>
+      expect((screen.getByRole("combobox", { name: "Sort" }) as HTMLSelectElement).value).toBe("updated"),
+    );
+    const dir = screen.getByRole("button", { name: /Sort direction/ }) as HTMLButtonElement;
+    expect(dir.disabled).toBe(false);
+    expect(dir.textContent).toBe("↑ Ascending");
+    expect(dir.getAttribute("aria-pressed")).toBe("false");
+  });
+
   // --- M6: THE freeze guard. Cap and/or search hide cards from the render set; the
   // reorder freeze must still submit the UNFILTERED payload order (Decision 2). ---
   it("freezes hidden-by-cap cards: reorder submits iids beyond the visible cap", async () => {

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -471,3 +471,40 @@ describe("Dashboard milestone badge (PRD #122)", () => {
     expect(screen.queryByText(/^M\d+\/\d+$/)).toBeNull();
   });
 });
+
+describe("Dashboard Worker-load card surfaces the cordon badge (PRD #496)", () => {
+  const flush = async () => {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  };
+  // The Worker-load card only renders workers passing hasStats (stats_source and
+  // stats_mem_bytes both non-null — see WorkerStats.hasStats), so every fixture here
+  // sets those so the worker appears in the card at all.
+  const withStats = (over: Partial<Worker>): Worker =>
+    aWorker({ stats_source: "cgroup", stats_mem_bytes: 1_000_000, ...over });
+
+  it("shows the cordoned pill for a drained worker holding no runs", async () => {
+    mockApi.listWorkers.mockResolvedValue({
+      workers: [withStats({ draining_since: "2026-07-05T12:00:00Z", active_runs: 0 })],
+    });
+    renderDashboard();
+    await flush();
+    // Anchor on the card title so a mutation that drops the worker (not just the badge)
+    // still fails at the badge lookup below.
+    expect(screen.getByText("Worker load")).toBeTruthy();
+    expect(screen.getByText("cordoned")).toBeTruthy();
+    expect(screen.queryByText("draining")).toBeNull();
+  });
+
+  it("shows the draining pill for a cordoned worker still holding a run", async () => {
+    mockApi.listWorkers.mockResolvedValue({
+      workers: [withStats({ draining_since: "2026-07-05T12:00:00Z", active_runs: 1 })],
+    });
+    renderDashboard();
+    await flush();
+    expect(screen.getByText("Worker load")).toBeTruthy();
+    expect(screen.getByText("draining")).toBeTruthy();
+    expect(screen.queryByText("cordoned")).toBeNull();
+  });
+});

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import { mrAbbrev } from "../lib/forgeNoun";
 import { YourUsageCard, FactoryTotalCard, PerUserUsageTable } from "../components/UsageCards";
 import { RunHealthBadge } from "../components/RunHealthBadge";
 import { WorkerStatLine, hasStats } from "../components/WorkerStats";
+import { WorkerCordonBadge } from "../components/WorkerCordonBadge";
 import { usePollWhileVisible } from "../lib/usePollWhileVisible";
 import { Badge, Button, Card, cx, PageHeader, SectionTitle, Skeleton, StatTile, StatusPill } from "../components/ui";
 import { CheckIcon, ChevronRightIcon } from "../components/icons";
@@ -254,6 +255,7 @@ export function Dashboard() {
                     <Badge tone={w.status === "online" ? "ok" : "neutral"} dot>
                       {w.status}
                     </Badge>
+                    <WorkerCordonBadge worker={w} />
                     <span className="truncate text-sm font-medium text-fg">{w.name}</span>
                   </div>
                   <WorkerStatLine worker={w} />

--- a/web/src/pages/RunsList.test.tsx
+++ b/web/src/pages/RunsList.test.tsx
@@ -201,6 +201,53 @@ describe("RunsList — the admin fleet list carries no format characters (#124)"
   });
 });
 
+// PRD #496 M2: the admin all-workers strip surfaces the cordon/drain state, not just a
+// bare online badge, for a worker whose draining_since is set.
+describe("RunsList — the admin fleet list surfaces the cordon badge (PRD #496)", () => {
+  const adminAuth = () =>
+    vi.mocked(useAuth).mockReturnValue({
+      user: { is_admin: true },
+      vaultUnlocked: true,
+    } as unknown as ReturnType<typeof useAuth>);
+
+  const adminWorker = (over: Record<string, unknown>) => ({
+    id: "w1", name: "prodbox", status: "online", owner_email: "someone@else.test",
+    kind: "hosted", hosted_size: null, busy: false, active_runs: 0, max_concurrent_runs: null,
+    template_declared: null, template_reported: null, version: null, last_heartbeat_at: null,
+    created_at: "2026-01-01T00:00:00Z", draining_since: null,
+    ...over,
+  });
+
+  it("shows the cordoned pill for a drained worker holding no runs", async () => {
+    adminAuth();
+    mockApi.listRuns.mockResolvedValue({ runs: [] });
+    mockApi.adminListRuns.mockResolvedValue({ runs: [] });
+    mockApi.adminListWorkers.mockResolvedValue({
+      workers: [adminWorker({ draining_since: "2026-01-02T00:00:00Z", active_runs: 0 })],
+    } as never);
+
+    renderRuns();
+    // Anchor on the owner email, which no mutation of the badge can move.
+    await waitFor(() => expect(screen.getByText("someone@else.test")).toBeTruthy());
+    expect(screen.getByText("cordoned")).toBeTruthy();
+    expect(screen.queryByText("draining")).toBeNull();
+  });
+
+  it("shows the draining pill for a cordoned worker still holding a run", async () => {
+    adminAuth();
+    mockApi.listRuns.mockResolvedValue({ runs: [] });
+    mockApi.adminListRuns.mockResolvedValue({ runs: [] });
+    mockApi.adminListWorkers.mockResolvedValue({
+      workers: [adminWorker({ draining_since: "2026-01-02T00:00:00Z", active_runs: 1 })],
+    } as never);
+
+    renderRuns();
+    await waitFor(() => expect(screen.getByText("someone@else.test")).toBeTruthy());
+    expect(screen.getByText("draining")).toBeTruthy();
+    expect(screen.queryByText("cordoned")).toBeNull();
+  });
+});
+
 describe("RunsList — the run title carries no format characters (#124)", () => {
   it("strips bidi/zero-width characters out of the forge-supplied title", async () => {
     vi.mocked(useAuth).mockReturnValue({

--- a/web/src/pages/RunsList.tsx
+++ b/web/src/pages/RunsList.tsx
@@ -31,6 +31,7 @@ import { runDurationLabel } from "../lib/runDuration";
 import { useNow } from "../lib/rateLimits";
 import { hasTemplateDrift } from "../lib/workerTemplates";
 import { WorkerRunBadge } from "../components/WorkerRunBadge";
+import { WorkerCordonBadge } from "../components/WorkerCordonBadge";
 import { RunHealthBadge } from "../components/RunHealthBadge";
 import { JudgeRunBadge } from "../components/JudgeRunBadge";
 import { RunCredential } from "../components/RunCredential";
@@ -629,6 +630,7 @@ export function RunsList() {
                       <Badge tone={w.status === "online" ? "ok" : "neutral"} dot>
                         {w.status}
                       </Badge>
+                      <WorkerCordonBadge worker={w} />
                       <WorkerRunBadge worker={w} />
                     </div>
                   </li>


### PR DESCRIPTION
Implements issue #554.

Closes #554

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-554`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Text previews now truncate safely by characters, preserving valid UTF-8 for multilingual content.
  * Board sorting preferences now reload correctly when navigating between repositories.
  * Worker status displays accurate **cordoned** and **draining** indicators based on active runs.

* **Tests**
  * Added coverage for UTF-8-safe truncation, repository-specific sorting, worker status badges, and claim execution behavior.

* **Documentation**
  * Updated a referenced decision-log path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->