### PR TITLE
Lead context meter (#516): robustness + doc follow-ups (O(n) fallback, lead-lane guard, tail latency, doc boundary)

### DIFF
--- a/agent/src/sdk-executor.ts
+++ b/agent/src/sdk-executor.ts
@@ -2251,10 +2251,14 @@ export class SdkExecutor implements Executor {
     // Issue #281: the lead's own text this turn, in emit order, for the no-progress
     // detector's verbatim-repeat check (joined into result.finalText below).
     const leadText: string[] = [];
-    // PRD #516 M1: the lead context reading is attached AT MOST ONCE per turn, on
-    // the same lead assistant frame that first latches usage. Turn-scoped so a turn
-    // with several assistant frames issues exactly one `getContextUsage()` call.
-    let contextAttached = false;
+    // PRD #516 M1 / issue #553 M2: the lead context reading is FIRED (not awaited)
+    // AT MOST ONCE per turn, on the first LEAD usage frame, and the resolved value
+    // is attached to the turn's TERMINAL result frame. Turn-scoped so a turn with
+    // several assistant frames issues exactly one `getContextUsage()` call; a
+    // non-undefined promise doubles as the "already fired" guard.
+    let contextPromise:
+      | Promise<{ used: number; window: number; pct: number } | undefined>
+      | undefined;
     let sawErrorResult = false;
     let errorSubtype = "unknown";
     // PRD #35. The observer rides the SAME iteration mapSdkMessage already does —
@@ -2350,24 +2354,44 @@ export class SdkExecutor implements Executor {
             // from a model-only frame. No usage ⇒ no model, deliberately.
             if (frameModel !== undefined) em.payload["model"] = frameModel;
             usageAttached = true;
-            // PRD #516 M1: CO-ATTACH the lead's live context-window fill on the SAME
-            // frame that got usage, once per turn. The first usage frame of a turn is
-            // the lead's assistant frame, and `getContextUsage()` is a main-loop-only
-            // control call, so this keys the reading to the lead and rides the
-            // consumer's existing `"usage" in payload` branch (Decision D5, D3). The
-            // `contextAttached` latch is set BEFORE the await so a slow/hanging call
-            // is issued at most once per turn; the read is timeout-guarded and never
-            // throws, so on absence/error/timeout no `context` key is written and the
-            // turn is unaffected (R1, R2, SC5). The await delays only this one em's
-            // emit; ordering is otherwise identical to before.
-            if (!contextAttached) {
-              contextAttached = true;
-              const context = await readLeadContext(
+            // PRD #516 M1 / issue #553 M2 (finding 2 + 3): FIRE the lead's live
+            // context-window read here, once per turn, on the first LEAD usage frame —
+            // but do NOT await it and do NOT attach on this frame. Two reasons: (a) a
+            // subagent frame can latch usage before the lead's within a turn, so the
+            // `em.agent === "lead"` guard keeps the reading keyed to the lead lane and
+            // off any subagent frame (finding 2); (b) awaiting inline sat on the hot
+            // message loop, so a hanging control call delayed every remaining frame of
+            // the turn by up to the timeout — firing without awaiting lets the read run
+            // concurrently while the turn streams (finding 3). The resolved value is
+            // attached below to the turn's terminal result frame. A non-undefined
+            // `contextPromise` doubles as the "already fired" guard, so `getContextUsage()`
+            // is issued at most once per turn.
+            //
+            // This floating (unawaited) promise is safe ONLY because `readLeadContext`
+            // NEVER rejects — it swallows every error/timeout to `undefined` (see its
+            // definition). If that contract ever changes, this becomes an unhandled
+            // rejection and must be re-guarded (e.g. `.catch(() => undefined)`).
+            if (contextPromise === undefined && em.agent === "lead") {
+              contextPromise = readLeadContext(
                 queryInstance,
                 this.contextUsageTimeoutMs,
               );
-              if (context) em.payload["context"] = context;
             }
+          }
+          // PRD #516 M1 / issue #553 M2: attach the (concurrently-read) lead context
+          // reading to the turn's TERMINAL result frame. Both result variants — success
+          // (`kind:"status"`) and error (`kind:"error"`) — come from mapResult with
+          // `agent: LEAD` and `payload.event === "result"`, so this is always the lead
+          // lane and always the LAST frame of the turn. Awaiting here therefore delays
+          // no in-turn frame; only turn completion waits, and only up to the timeout
+          // already baked into the read on a genuine hang (normally the read has long
+          // since resolved, so the residual await is ~0).
+          if (
+            contextPromise !== undefined &&
+            em.payload["event"] === "result"
+          ) {
+            const context = await contextPromise;
+            if (context) em.payload["context"] = context;
           }
           ctx.emit(em);
         }

--- a/agent/test/sdk-executor.test.ts
+++ b/agent/test/sdk-executor.test.ts
@@ -3948,7 +3948,7 @@ describe("SdkExecutor lead context-window meter (PRD #516 M1)", () => {
     return emits.filter((m) => m.payload["context"] !== undefined);
   }
 
-  it("attaches payload.context (mapped {used,window,pct}) to the SAME lead frame that carries usage", async () => {
+  it("attaches payload.context (mapped {used,window,pct}) to the terminal RESULT frame, not the usage frame", async () => {
     const { queryFn } = fakeTurnsWithContext(
       [
         [submitPlan("plan"), resultSuccess()],
@@ -3960,16 +3960,23 @@ describe("SdkExecutor lead context-window meter (PRD #516 M1)", () => {
     const result = await new SdkExecutor(nullLogger(), homeDir, { queryFn }).run(probe.ctx);
     assert.strictEqual(result.branch, "agent/issue-5");
 
+    // issue #553 M2: context rides the turn's terminal result frame now (fired off the
+    // hot loop, awaited at the result frame), NOT the assistant usage frame.
     const carriers = withContext(probe.emits);
-    assert.strictEqual(carriers.length, 1, "context attaches exactly once, on the lead usage frame");
+    assert.strictEqual(carriers.length, 1, "context attaches exactly once, on the result frame");
     assert.deepStrictEqual(carriers[0]!.payload["context"], {
       used: 156000,
       window: 200000,
       pct: 78,
     });
-    // Co-attached: the context rides the very frame that carries usage (the seam the
-    // web consumer reads inside its `"usage" in payload` branch).
-    assert.deepStrictEqual(carriers[0]!.payload["usage"], USAGE);
+    assert.strictEqual(carriers[0]!.payload["event"], "result", "the carrier is a terminal result frame");
+    assert.strictEqual(carriers[0]!.kind, "status", "the success result frame is a status message");
+    assert.strictEqual(carriers[0]!.payload["usage"], undefined, "the result frame carries no per-call USAGE (its usage is cumulative)");
+
+    // The assistant usage frame still carries usage, but no longer carries context.
+    const usageFrame = probe.emits.find((m) => m.payload["usage"] === USAGE);
+    assert.ok(usageFrame, "the assistant usage frame still carries the per-call usage");
+    assert.strictEqual(usageFrame!.payload["context"], undefined, "the usage frame carries no context");
   });
 
   it("preserves an unclamped pct > 100 (near/over-compaction) verbatim", async () => {
@@ -4035,5 +4042,56 @@ describe("SdkExecutor lead context-window meter (PRD #516 M1)", () => {
     assert.strictEqual(result.branch, "agent/issue-5");
     assert.strictEqual(withContext(probe.emits).length, 0, "an absent control method attaches no context");
     assert.ok(probe.emits.some((m) => m.payload["usage"] !== undefined), "usage still attaches");
+  });
+
+  /** A SUBAGENT assistant frame carrying per-call usage — hits the usage latch first
+   *  when emitted before the lead's frame in a turn (issue #553 finding 2). */
+  function subagentUsageFrame(text: string, subagentType = "coder"): SDKMessage {
+    return {
+      type: "assistant",
+      session_id: "sess-1",
+      subagent_type: subagentType,
+      parent_tool_use_id: "p1",
+      message: { usage: USAGE, content: [{ type: "text", text }] },
+    } as unknown as SDKMessage;
+  }
+
+  it("finding 2: a subagent usage frame BEFORE the lead's does not capture or block the lead context read", async () => {
+    // The subagent frame latches usage first this turn. Under the old design the inline
+    // co-attach fired on that first-usage frame with no lead guard, so context misattached
+    // to the subagent frame (dropped by the lead-only reader) AND blocked the lead's own
+    // later frame. Now the read fires only on the LEAD usage frame and is delivered on the
+    // terminal result frame.
+    const { queryFn } = fakeTurnsWithContext(
+      [
+        [submitPlan("plan"), resultSuccess()],
+        [
+          subagentUsageFrame("subagent working"),
+          leadUsageFrame("lead working"),
+          signalDone(),
+          resultSuccess(),
+        ],
+      ],
+      async () => ({ totalTokens: 156000, rawMaxTokens: 200000, percentage: 78 }),
+    );
+    const probe = makeCtx();
+    const result = await new SdkExecutor(nullLogger(), homeDir, { queryFn }).run(probe.ctx);
+    assert.strictEqual(result.branch, "agent/issue-5");
+
+    const carriers = withContext(probe.emits);
+    assert.strictEqual(carriers.length, 1, "context attaches exactly once");
+    // It is the terminal lead result frame, NOT a subagent frame.
+    assert.strictEqual(carriers[0]!.payload["event"], "result");
+    assert.strictEqual(carriers[0]!.agent, "lead");
+    assert.deepStrictEqual(carriers[0]!.payload["context"], {
+      used: 156000,
+      window: 200000,
+      pct: 78,
+    });
+    // No subagent frame carries context.
+    assert.ok(
+      !probe.emits.some((m) => m.agent === "coder" && m.payload["context"] !== undefined),
+      "no subagent frame carries context",
+    );
   });
 });

--- a/agent/test/sdk-executor.test.ts
+++ b/agent/test/sdk-executor.test.ts
@@ -4094,4 +4094,33 @@ describe("SdkExecutor lead context-window meter (PRD #516 M1)", () => {
       "no subagent frame carries context",
     );
   });
+
+  it("finding 2 (gate): a turn with ONLY a subagent usage frame and NO lead usage frame reads NO context", async () => {
+    // This is the discriminating test for finding 2's `em.agent === "lead"` fire-guard.
+    // The implement turn has a SUBAGENT usage frame (which latches usage first) but NEVER
+    // a lead usage frame before the terminal result frame. With the gate (current, correct)
+    // the read `contextPromise = readLeadContext(...)` NEVER fires — it is guarded to fire
+    // only on a LEAD usage frame — so the terminal result frame carries NO context. Delete
+    // the `&& em.agent === "lead"` guard and the subagent usage frame WOULD fire the read
+    // (the fire-once `contextPromise === undefined` guard alone would let it), so the result
+    // frame would then carry context and `withContext(...).length` would be 1, failing this
+    // assertion. `getContextUsage` returns a valid reading here on purpose: the assertion
+    // proves the read is SUPPRESSED by the lead-gate, not merely absent.
+    const { queryFn } = fakeTurnsWithContext(
+      [
+        [submitPlan("plan"), resultSuccess()],
+        [subagentUsageFrame("subagent working", "reviewer"), signalDone(), resultSuccess()],
+      ],
+      async () => ({ totalTokens: 156000, rawMaxTokens: 200000, percentage: 78 }),
+    );
+    const probe = makeCtx();
+    const result = await new SdkExecutor(nullLogger(), homeDir, { queryFn }).run(probe.ctx);
+    assert.strictEqual(result.branch, "agent/issue-5", "the run still completes normally");
+
+    assert.strictEqual(
+      withContext(probe.emits).length,
+      0,
+      "the read never fired (no lead usage frame), so no frame carries context",
+    );
+  });
 });

--- a/api/internal/uzidocs/embed/run-activity.md
+++ b/api/internal/uzidocs/embed/run-activity.md
@@ -196,7 +196,7 @@ Three states track how close the lead is to compaction:
 | State | Fill | Meaning |
 |---|---|---|
 | cool | `< 70%` | Plenty of room — a quiet steel bar, no glow. |
-| molten | `70–95%` | Filling toward the line — an orange glow. |
+| molten | `70 to <95%` | Filling toward the line — an orange glow. |
 | near-compaction | `≥ 95%` | Into the danger wash — a pulsing rose glow (steady, not pulsing, under reduced motion). |
 
 **100% is the compaction line**, not a 90% warning tick: the SDK's

--- a/docs/run-activity.md
+++ b/docs/run-activity.md
@@ -196,7 +196,7 @@ Three states track how close the lead is to compaction:
 | State | Fill | Meaning |
 |---|---|---|
 | cool | `< 70%` | Plenty of room — a quiet steel bar, no glow. |
-| molten | `70–95%` | Filling toward the line — an orange glow. |
+| molten | `70 to <95%` | Filling toward the line — an orange glow. |
 | near-compaction | `≥ 95%` | Into the danger wash — a pulsing rose glow (steady, not pulsing, under reduced motion). |
 
 **100% is the compaction line**, not a 90% warning tick: the SDK's

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -8929,7 +8929,7 @@ viewer" — the first path that writes judge text to a forge issue.
 A scoped fallback on PRD #83's rootless docker-worker tier (§297–305), added because the live
 dev-cluster nodes ship unprivileged user namespaces DISABLED, so
 rootless dockerd crash-loops there and #83's k8s definition of done is unreachable on this cluster.
-Owner decisions are recorded in `prds/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
+Owner decisions are recorded in `prds/done/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
 duplicated into `specs/human.md` (they are #83 owner overrides, not new user-binding requirements);
 what follows is the AI/implementation record for rebuild-from-specs. The owner-stated frame (reference
 only): docker workers run on dev-cluster; the owner accepts the node-root residual on the mitigation

--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -1306,6 +1306,24 @@ describe("ActivityFeed lead context-window meter", () => {
     expect(queryByTestId("lead-context-micrometer")).toBeNull();
   });
 
+  it("renders no meter when the parent passes leadContext={null} (sentinel suppresses the fallback derive)", () => {
+    // issue #553: a null prop means "the parent already derived; there is no reading" —
+    // the component MUST honor it and NOT fall back to deriving from `messages`, even
+    // though these messages DO carry a derivable lead context frame.
+    const { queryByTestId } = render(
+      <ActivityFeed
+        messages={[leadCtx(1, { used: 156_000, window: 200_000, pct: 78 })]}
+        run={runFixture({ status: "running", health: "ok" })}
+        runningLive
+        connected
+        terminal={false}
+        leadContext={null}
+      />,
+    );
+    expect(queryByTestId("lead-context-meter")).toBeNull();
+    expect(queryByTestId("lead-context-micrometer")).toBeNull();
+  });
+
   it("renders the lane meter on the LEAD lane with the true label", () => {
     const { getAllByTestId, container } = renderFeed([
       leadCtx(1, { used: 156_000, window: 200_000, pct: 78 }),

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -555,11 +555,15 @@ export function ActivityFeed({
   terminal: boolean;
   // PRD #40: per-result-frame token/cost deltas keyed by seq. Optional.
   phaseUsageBySeq?: Map<number, PhaseUsage>;
-  // PRD #516: the lead's live context-window fill. Optional — when the parent already
-  // derived RunUsage (RunView does, and threads phaseUsageBySeq from the same object),
-  // it passes leadContext too so this component does NOT re-run the full O(n) derive.
-  // Absent (standalone/tests) ⇒ fall back to deriving it from `messages` below.
-  leadContext?: LeadContext;
+  // PRD #516 / issue #553: the lead's live context-window fill. Three-state contract:
+  //   `undefined` ⇒ the parent did NOT derive (standalone/tests) — fall back to deriving
+  //                 it here from `messages` below.
+  //   `null`      ⇒ the parent derived but there is no reading (RunView threads
+  //                 `usage.leadContext ?? null`) — use undefined, do NOT re-derive.
+  //   an object   ⇒ the reading the parent already computed (RunView threads it from the
+  //                 same RunUsage object it built for phaseUsageBySeq, so the run view
+  //                 derives once, not twice), so this component skips the O(n) re-derive.
+  leadContext?: LeadContext | null;
 }) {
   const [showAll, setShowAll] = useState(false);
   // Opt-in Follow (Decision 3), default OFF — replaces the old whole-pane auto-jump.
@@ -588,7 +592,10 @@ export function ActivityFeed({
   // absent do we derive here, off `messages` (not `visible`) so the CAP that hides old
   // rows never drops a still-current reading. Feeds the lead-lane meter + crew micro-meter.
   const leadContext = useMemo(
-    () => leadContextProp ?? deriveRunUsage(messages).leadContext,
+    () =>
+      leadContextProp === undefined
+        ? deriveRunUsage(messages).leadContext
+        : (leadContextProp ?? undefined),
     [leadContextProp, messages],
   );
 

--- a/web/src/lib/runUsage.test.ts
+++ b/web/src/lib/runUsage.test.ts
@@ -1036,4 +1036,46 @@ describe("deriveRunUsage.leadContext", () => {
     // would leave the earlier usage-frame value (pct 20) winning.
     expect(d.leadContext).toEqual({ used: 156_000, window: 200_000, pct: 78 });
   });
+
+  it("IGNORES a USAGE frame whose agent is 'lead' but agent_instance is non-null (subagent lane)", () => {
+    // The lead lane is agent_instance ABSENT (null) AND the lead role — matching
+    // ActivityFeed's lane key and the comment near lines 208–212. A subagent-lane frame
+    // carrying a non-null agent_instance must never populate leadContext even when its
+    // agent field reads "lead". Covers the usage-frame predicate.
+    const d = deriveRunUsage([
+      {
+        ...assistantUsageCtx("lead", { input: 500, output: 50 }, { used: 190_000, window: 200_000, pct: 95 }),
+        agent_instance: "sub-123",
+      },
+    ]);
+    expect(d.leadContext).toBeUndefined();
+  });
+
+  it("IGNORES a RESULT frame whose agent is 'lead' but agent_instance is non-null (subagent lane)", () => {
+    // Same lead-lane guard on the result-frame carrier: a distinct non-null agent_instance
+    // is a subagent lane, so its context must not overwrite the real lead reading.
+    const reading = { used: 190_000, window: 200_000, pct: 95 };
+    const d = deriveRunUsage([
+      {
+        ...msg("status", "lead", {
+          event: "result",
+          subtype: "success",
+          num_turns: 1,
+          duration_ms: 100,
+          modelUsage: {
+            "claude-sonnet-5": {
+              inputTokens: 100,
+              outputTokens: 10,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
+              costUSD: 0.01,
+            },
+          },
+          context: reading,
+        }),
+        agent_instance: "sub-123",
+      },
+    ]);
+    expect(d.leadContext).toBeUndefined();
+  });
 });

--- a/web/src/lib/runUsage.test.ts
+++ b/web/src/lib/runUsage.test.ts
@@ -971,4 +971,69 @@ describe("deriveRunUsage.leadContext", () => {
     ]);
     expect(d.leadContext).toBeUndefined();
   });
+
+  it("populates leadContext from a lead RESULT frame — including a modelUsage-less/error one (read sits ABOVE the modelUsage early-out)", () => {
+    const reading = { used: 156_000, window: 200_000, pct: 78 };
+
+    // A success result frame WITH modelUsage still yields its context reading.
+    const withMu = deriveRunUsage([
+      msg("status", "lead", {
+        event: "result",
+        subtype: "success",
+        num_turns: 1,
+        duration_ms: 100,
+        modelUsage: {
+          "claude-sonnet-5": {
+            inputTokens: 100,
+            outputTokens: 10,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            costUSD: 0.01,
+          },
+        },
+        context: reading,
+      }),
+    ]);
+    expect(withMu.leadContext).toEqual(reading);
+
+    // The load-bearing case: an ERROR result frame with NO modelUsage. The old code's
+    // `if (!mu) continue` sat above the context read; the new placement reads context
+    // FIRST, so this modelUsage-less frame still delivers the meter.
+    const noMu = deriveRunUsage([
+      msg("error", "lead", {
+        event: "result",
+        subtype: "error_max_turns",
+        errors: [],
+        context: reading,
+      }),
+    ]);
+    expect(noMu.leadContext).toEqual(reading);
+  });
+
+  it("latest-wins across BOTH carriers: a later lead RESULT frame overrides an earlier lead usage frame", () => {
+    const d = deriveRunUsage([
+      // Earlier: M1-style lead usage frame carrying one reading.
+      assistantUsageCtx("lead", { input: 100, output: 10 }, { used: 40_000, window: 200_000, pct: 20 }),
+      // Later: M2-style lead terminal result frame carrying a DIFFERENT reading.
+      msg("status", "lead", {
+        event: "result",
+        subtype: "success",
+        num_turns: 1,
+        duration_ms: 100,
+        modelUsage: {
+          "claude-sonnet-5": {
+            inputTokens: 200,
+            outputTokens: 20,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            costUSD: 0.02,
+          },
+        },
+        context: { used: 156_000, window: 200_000, pct: 78 },
+      }),
+    ]);
+    // The result-frame (later in stream order) value wins. A broken result-frame read
+    // would leave the earlier usage-frame value (pct 20) winning.
+    expect(d.leadContext).toEqual({ used: 156_000, window: 200_000, pct: 78 });
+  });
 });

--- a/web/src/lib/runUsage.ts
+++ b/web/src/lib/runUsage.ts
@@ -622,10 +622,14 @@ export function deriveRunUsage(messages: RunMessage[]): RunUsage {
     if (isResultFrame(m)) {
       // PRD #516 / issue #553: the lead's context-window fill now ALSO rides the turn's
       // terminal result frame (moved off the usage frame to keep the worker's read off
-      // the hot loop — see sdk-executor.ts). Result frames are always the lead lane, so
-      // read latest-wins here, ABOVE the modelUsage early-out below, because an
+      // the hot loop — see sdk-executor.ts). A result frame's context is read only when
+      // it is actually the lead lane — keyed on `agent_instance` absence (null instance)
+      // AND the lead role, exactly like ActivityFeed's lane key and the comment near
+      // lines 208–212, so a subagent-lane result frame (distinct non-null agent_instance)
+      // whose agent is null/"lead" cannot overwrite the real lead reading. Read
+      // latest-wins here, ABOVE the modelUsage early-out below, because an
       // error/modelUsage-less result frame must still yield its context reading.
-      if ((m.agent ?? "lead") === "lead") {
+      if (!m.agent_instance && (m.agent ?? "lead") === "lead") {
         const rctx = readContext(payload?.["context"]);
         if (rctx) leadContext = rctx;
       }
@@ -689,10 +693,12 @@ export function deriveRunUsage(messages: RunMessage[]): RunUsage {
         // frames and the reader replays them, so removing it would blank every historical
         // run's meter, and it also covers resume-across-upgrade (old worker writes
         // usage-frame context, new worker writes result-frame context; latest-wins across
-        // the seq boundary picks the newer). Read it ONLY on the lead lane (keyed exactly
-        // like the usage sum above) — a subagent frame carrying a synthetic `context` is
-        // deliberately ignored (lead-only SDK constraint).
-        if (agent === "lead") {
+        // the seq boundary picks the newer). Read it ONLY on the lead lane — gated on
+        // `agent_instance` absence (null instance) AND the lead role, consistent with the
+        // usage-sum keying above and the comment near lines 208–212 — so a subagent frame
+        // (distinct non-null agent_instance) carrying a synthetic `context`, even one whose
+        // agent is null/"lead", is deliberately ignored (lead-only SDK constraint).
+        if (!m.agent_instance && agent === "lead") {
           const ctx = readContext(payload["context"]);
           if (ctx) leadContext = ctx;
         }

--- a/web/src/lib/runUsage.ts
+++ b/web/src/lib/runUsage.ts
@@ -620,6 +620,15 @@ export function deriveRunUsage(messages: RunMessage[]): RunUsage {
     }
 
     if (isResultFrame(m)) {
+      // PRD #516 / issue #553: the lead's context-window fill now ALSO rides the turn's
+      // terminal result frame (moved off the usage frame to keep the worker's read off
+      // the hot loop — see sdk-executor.ts). Result frames are always the lead lane, so
+      // read latest-wins here, ABOVE the modelUsage early-out below, because an
+      // error/modelUsage-less result frame must still yield its context reading.
+      if ((m.agent ?? "lead") === "lead") {
+        const rctx = readContext(payload?.["context"]);
+        if (rctx) leadContext = rctx;
+      }
       // A result frame NEVER falls through to the per-agent branch below, whether or
       // not it folded: its usage is the run's cumulative total, not one call's.
       const mu = readModelUsage(payload?.["modelUsage"]);
@@ -673,10 +682,16 @@ export function deriveRunUsage(messages: RunMessage[]): RunUsage {
       const u = readUsage(payload["usage"]);
       if (u) {
         const agent = m.agent ?? "lead";
-        // PRD #516: the lead's context-window fill co-rides this same usage-latched lead
-        // frame as `payload.context`. Read it ONLY on the lead lane (keyed exactly like
-        // the usage sum above) and keep the latest — a subagent frame carrying a
-        // synthetic `context` is deliberately ignored (lead-only SDK constraint).
+        // PRD #516 / issue #553: the lead's context-window fill may ride EITHER a lead
+        // usage frame (M1, this read) OR the lead terminal result frame (M2, read in the
+        // isResultFrame branch above) — latest-wins across both carriers. This usage-frame
+        // read is KEPT deliberately: already-persisted M1 runs carry context on lead usage
+        // frames and the reader replays them, so removing it would blank every historical
+        // run's meter, and it also covers resume-across-upgrade (old worker writes
+        // usage-frame context, new worker writes result-frame context; latest-wins across
+        // the seq boundary picks the newer). Read it ONLY on the lead lane (keyed exactly
+        // like the usage sum above) — a subagent frame carrying a synthetic `context` is
+        // deliberately ignored (lead-only SDK constraint).
         if (agent === "lead") {
           const ctx = readContext(payload["context"]);
           if (ctx) leadContext = ctx;

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -1418,7 +1418,9 @@ export function RunView() {
           connected={connected}
           terminal={terminal}
           phaseUsageBySeq={usage.phaseUsageBySeq}
-          leadContext={usage.leadContext}
+          // `?? null` tells ActivityFeed "the parent already derived; do not re-derive"
+          // (PRD #516 / issue #553): null distinguishes "no reading" from "not computed".
+          leadContext={usage.leadContext ?? null}
         />
       </Card>
 


### PR DESCRIPTION
Implements issue #553.

Closes #553

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-553`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-window usage reporting by attaching the latest reading to completed run results, including error results.
  * Prevented subagent activity from affecting lead-run context readings.
  * Ensured activity feeds distinguish unavailable context data from data that has not yet been calculated.
  * Preserved intermediate message delivery while context information is collected.
* **Documentation**
  * Clarified context-meter thresholds using the explicit range “70 to <95%.”
  * Updated a decision-log reference for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->