### PR TITLE
Audit the project's documentation for mechanical defects: br…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2145,7 +2145,7 @@ through `[0.52.0]`.)
   behavior, set `run_eligible_labels` to just the primary label, or turn
   `eligible_label_waives_prd_link` off, from Admin → Instance settings. See
   [docs/board.md](docs/board.md#which-issues-show-up) and
-  [docs/admin-settings.md](docs/admin-settings.md#run-eligibility-and-board-membership).
+  [docs/admin-settings.md](docs/admin-settings.md#run-eligibility).
 
 - **Per-label counts on the Judge filter chips ([#244](https://github.com/vtmocanu/uzi/pull/244)).** Each chip now shows how
   many recommendation groups are in that category across your whole backlog, every

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -543,7 +543,7 @@ secrets from the kubelet — including the api pod's `UZI_SECRET_KEY`, the maste
 key that decrypts every user's forge PAT and Anthropic token. This is an
 owner-accepted risk on the mitigation terms below, for dev-cluster specifically —
 not a claim that non-rootless is safe by default. See
-`prds/89-optional-nonrootless-dind.md` (Security framing, Decision Log) for the
+`prds/done/89-optional-nonrootless-dind.md` (Security framing, Decision Log) for the
 full reasoning.
 
 **The mitigations (required together, not a menu):**

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -8929,7 +8929,7 @@ viewer" — the first path that writes judge text to a forge issue.
 A scoped fallback on PRD #83's rootless docker-worker tier (§297–305), added because the live
 dev-cluster nodes ship unprivileged user namespaces DISABLED, so
 rootless dockerd crash-loops there and #83's k8s definition of done is unreachable on this cluster.
-Owner decisions are recorded in `prds/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
+Owner decisions are recorded in `prds/done/89-optional-nonrootless-dind.md`'s Decision Log and are NOT
 duplicated into `specs/human.md` (they are #83 owner overrides, not new user-binding requirements);
 what follows is the AI/implementation record for rebuild-from-specs. The owner-stated frame (reference
 only): docker workers run on dev-cluster; the owner accepts the node-root residual on the mitigation


### PR DESCRIPTION
Ad-hoc scheduled prompt run (PRD #241 Decision 10). This run was created from a
schedule's stored prompt against this repository — there is no tracking issue, so
this MR references the task but closes nothing.

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.


---
Opened automatically by the uzi agent from branch `uzi/prompt-e60dd382-19ca-453a-9685-1a0ff9e9f0b0`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated run-eligibility documentation links to use the correct anchor.
  * Corrected Decision Log references for PRD `#89` to point to its completed location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->