### PR TITLE
Remove Demo mode toggle from sidebar (keep it in Settings)

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -11,8 +11,8 @@ import { useAuth } from "../auth/AuthContext";
 import { api, MOCK_MODE, type Branding, type BuildInfo, type Repo } from "../lib/api";
 import { prefs } from "../lib/prefs";
 import { presetAssetForSlug, presetForSlug } from "../lib/brandPresets";
-import { cx, Toggle } from "./ui";
-import { useDemoMode, setDemoMode } from "../lib/demoMode";
+import { cx } from "./ui";
+import { useDemoMode } from "../lib/demoMode";
 import { maskEmail, maskName, maskRepoPath } from "../lib/demoMask";
 import { VaultBadge, VaultLockedBanner } from "./VaultControls";
 import { UpdateEscalationBanner } from "./UpdateEscalationBanner";
@@ -925,23 +925,6 @@ function SidebarContent({
                     </button>
                   </>
                 )}
-              </div>
-              {/* Demo-mode quick toggle (PRD #886 M2). A menu-style row inside the
-                  sidebar chrome — NOT a floating/overlay badge, which would land in
-                  the screenshot. Shows the state ("Demo mode: On/Off") as the cue and
-                  is wired to the same per-device store as the Settings toggle, so both
-                  and the whole UI update live in this tab. Rendered only in the
-                  expanded cluster (the home for it); the collapsed rail is left
-                  uncluttered — demo mode is toggled from the expanded rail or Settings. */}
-              <div className="mt-1 flex items-center justify-between gap-2 rounded-md px-1 py-1.5">
-                <span className="truncate text-xs font-medium text-fg">
-                  Demo mode: {demoMode ? "On" : "Off"}
-                </span>
-                <Toggle
-                  checked={demoMode}
-                  onChange={setDemoMode}
-                  label="Demo mode"
-                />
               </div>
               {/* Claude rate-limit micro-meters (PRD #53): two 5px bars under the
                   user block. Self-gates — renders nothing without a live reading. */}


### PR DESCRIPTION
Implements issue #891.

Closes #891

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-891`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the demo-mode quick toggle from the sidebar.
  * Demo mode can no longer be controlled from the sidebar footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->