### PR TITLE
feat(dx): auto-generate local secrets on first `docker compose up` (#894)

### DIFF
--- a/.claude/rules/stack.md
+++ b/.claude/rules/stack.md
@@ -14,7 +14,7 @@ chart. The repo-wide map is the root `CLAUDE.md`.
 ### Full stack
 
 ```sh
-cp .env.example .env                 # set JWT_SECRET, UZI_SECRET_KEY, POSTGRES_PASSWORD
+./scripts/init-env.sh                # generate JWT_SECRET, UZI_SECRET_KEY, POSTGRES_PASSWORD into .env (once; no-op if .env exists)
 docker compose up                    # web on http://127.0.0.1:8080
 docker compose --profile agent up    # additionally start a worker (needs join token)
 ```

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Copy to .env and fill in JWT_SECRET and POSTGRES_PASSWORD before `docker compose up`.
+# Run `./scripts/init-env.sh` to generate JWT_SECRET, UZI_SECRET_KEY and
+# POSTGRES_PASSWORD into a fresh .env automatically (generate-once; it never
+# overwrites an existing .env). Or copy this file to .env and fill those three in
+# by hand before `docker compose up`.
 
 # REQUIRED. HS256 signing key for session JWTs. The API refuses to start if this
 # is missing, empty, or a known placeholder. Generate one with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ through `[0.52.0]`.)
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/init-env.sh` generates the local secrets so a fresh `docker compose up` just works ([#894](https://github.com/vtmocanu/uzi/issues/894)).**
+  A new `./scripts/init-env.sh` (also `task init`) writes `.env` with freshly generated `JWT_SECRET`, `UZI_SECRET_KEY` and `POSTGRES_PASSWORD`, starting from `.env.example` so every other option stays documented; it is generate-once (writes only when `.env` is absent and never regenerates, keeping the encryption key and Postgres password stable), the `${VAR:?}` compose guards are unchanged so a non-local misconfig still fails loudly, and the Kubernetes/Helm deploy still uses explicit secrets.
+
 ## [0.72.1] - 2026-08-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ AI dark factory. Local laptop demo: Go API + React SPA + PostgreSQL, run via doc
 ## Quick Start
 
 ```sh
-cp .env.example .env
-# set JWT_SECRET, UZI_SECRET_KEY and POSTGRES_PASSWORD in .env, e.g.:
-#   openssl rand -hex 64      -> JWT_SECRET
-#   openssl rand -base64 32   -> UZI_SECRET_KEY
-#   openssl rand -hex 24      -> POSTGRES_PASSWORD
+./scripts/init-env.sh   # generate JWT_SECRET, UZI_SECRET_KEY, POSTGRES_PASSWORD into .env (once)
 docker compose up
 ```
+
+`init-env.sh` writes `.env` only if it is absent and never regenerates, so the
+encryption key and Postgres password stay stable across restarts. Prefer to set
+them by hand? `cp .env.example .env` and fill the three values in (`openssl rand
+-hex 64` / `-base64 32` / `-hex 24` respectively).
 
 Open <http://127.0.0.1:8080> and register. The first registered account becomes admin — or set `UZI_SEED_EMAIL`/`UZI_SEED_PASSWORD` in `.env` to provision an admin automatically at startup (see [configuration.md](docs/configuration.md)). Admins can define agent templates under **Agents**; any user can connect their own Anthropic token under **Settings** (see [docs/anthropic-token.md](docs/anthropic-token.md)).
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -184,6 +184,16 @@ tasks:
     cmds:
       - task --list
 
+  # NOT a gate target and NOT under gate: it WRITES the tree (a .env with fresh
+  # secrets) and is a convenience entry point for the laptop dev loop, not a check.
+  # The script is the source of truth (docs point at it directly for the no-`task`
+  # new-user path); this just gives `task init` the same one-liner. Generate-once:
+  # re-running is a no-op when .env exists (issue #894).
+  init:
+    desc: generate the local docker-compose secrets into .env once (no-op if .env exists)
+    cmds:
+      - ./scripts/init-env.sh
+
   gate:
     desc: The whole gate, repo-wide checks then every component, serially
     cmds:

--- a/api/internal/uzidocs/embed/installation.md
+++ b/api/internal/uzidocs/embed/installation.md
@@ -23,15 +23,25 @@ cd uzi
 ## Configure
 
 ```sh
-cp .env.example .env
+./scripts/init-env.sh
 ```
 
-Fill in the two required values (both refused at boot / by compose if left empty):
+This generates the three required secrets and writes them to `.env` (starting from
+`.env.example`, so every other option stays documented and editable):
 
-- `JWT_SECRET` — `openssl rand -hex 64`
-- `POSTGRES_PASSWORD` — `openssl rand -hex 24`
+- `JWT_SECRET`: session signing key (`openssl rand -hex 64`)
+- `UZI_SECRET_KEY`: base64 master key that encrypts secrets at rest (`openssl rand -base64 32`)
+- `POSTGRES_PASSWORD`: bundled Postgres password (`openssl rand -hex 24`)
 
-The rest have sane defaults for local use. See [configuration.md](configuration.md) for the full list.
+All three are refused at boot / by compose if left empty. The script is
+**generate-once**: it writes `.env` only if it is absent and never regenerates,
+because `UZI_SECRET_KEY` (rotating it makes stored tokens undecryptable) and
+`POSTGRES_PASSWORD` (only used to init the `pgdata` volume on first run) must stay
+stable. The rest have sane defaults for local use; see
+[configuration.md](configuration.md) for the full list.
+
+Prefer to do it by hand? `cp .env.example .env` and fill those three values in.
+With `task` installed, `task init` runs the same script.
 
 ## Run
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,15 +23,25 @@ cd uzi
 ## Configure
 
 ```sh
-cp .env.example .env
+./scripts/init-env.sh
 ```
 
-Fill in the two required values (both refused at boot / by compose if left empty):
+This generates the three required secrets and writes them to `.env` (starting from
+`.env.example`, so every other option stays documented and editable):
 
-- `JWT_SECRET` — `openssl rand -hex 64`
-- `POSTGRES_PASSWORD` — `openssl rand -hex 24`
+- `JWT_SECRET`: session signing key (`openssl rand -hex 64`)
+- `UZI_SECRET_KEY`: base64 master key that encrypts secrets at rest (`openssl rand -base64 32`)
+- `POSTGRES_PASSWORD`: bundled Postgres password (`openssl rand -hex 24`)
 
-The rest have sane defaults for local use. See [configuration.md](configuration.md) for the full list.
+All three are refused at boot / by compose if left empty. The script is
+**generate-once**: it writes `.env` only if it is absent and never regenerates,
+because `UZI_SECRET_KEY` (rotating it makes stored tokens undecryptable) and
+`POSTGRES_PASSWORD` (only used to init the `pgdata` volume on first run) must stay
+stable. The rest have sane defaults for local use; see
+[configuration.md](configuration.md) for the full list.
+
+Prefer to do it by hand? `cp .env.example .env` and fill those three values in.
+With `task` installed, `task init` runs the same script.
 
 ## Run
 

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Generate the local docker-compose secrets ONCE and persist them, so a fresh
+# checkout's `docker compose up` just works (issue #894).
+#
+# Writes .env only if it is ABSENT. This is generate-once-and-persist, never
+# regenerate. That is a hard requirement, not a nicety:
+#   - UZI_SECRET_KEY encrypts secrets at rest (AES-256-GCM); regenerating it makes
+#     every previously stored PAT / Anthropic token undecryptable, a data-loss
+#     footgun, so it MUST stay stable.
+#   - POSTGRES_PASSWORD initializes the pgdata volume on first run; changing it
+#     later does not re-init an existing volume, so it also has to persist.
+#   - JWT_SECRET is milder (regenerating just drops sessions).
+#
+# The three ${VAR:?} guards in docker-compose.yml stay untouched: a non-local
+# misconfig (compose up with no .env) still fails loudly. This only removes the
+# by-hand step on the supported laptop path. The k8s/Helm deploy stays on explicit
+# secrets and never uses this.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT/.env"
+EXAMPLE="$ROOT/.env.example"
+
+if [ -e "$ENV_FILE" ]; then
+  echo "init-env: .env already exists; leaving it untouched (secrets persist)."
+  exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "init-env: openssl not found; install it or write .env by hand from .env.example" >&2
+  exit 1
+fi
+
+# JWT_SECRET: HS256 signing key (128 hex chars). UZI_SECRET_KEY: base64-encoded
+# 32-byte master key; the two formats DIFFER and neither is interchangeable
+# (UZI_SECRET_KEY refuses to boot on non-base64). POSTGRES_PASSWORD: 48 hex chars.
+jwt="$(openssl rand -hex 64)"
+key="$(openssl rand -base64 32)"
+pw="$(openssl rand -hex 24)"
+
+umask 077  # .env holds secrets: create it 0600.
+
+if [ -f "$EXAMPLE" ]; then
+  # Start from the fully-documented example so the user keeps every option
+  # (OIDC, Slack, seeds, tuning knobs) at hand, and fill only the three empty
+  # required assignments. awk matches the exact `VAR=` lines; openssl hex/base64
+  # output carries no backslashes, so passing the values via -v is safe.
+  awk -v jwt="$jwt" -v key="$key" -v pw="$pw" '
+    $0 == "JWT_SECRET="        { print "JWT_SECRET=" jwt; next }
+    $0 == "UZI_SECRET_KEY="    { print "UZI_SECRET_KEY=" key; next }
+    $0 == "POSTGRES_PASSWORD=" { print "POSTGRES_PASSWORD=" pw; next }
+    { print }
+  ' "$EXAMPLE" >"$ENV_FILE"
+else
+  # No example on disk (unusual): write a minimal but complete .env.
+  cat >"$ENV_FILE" <<EOF
+JWT_SECRET=$jwt
+UZI_SECRET_KEY=$key
+POSTGRES_PASSWORD=$pw
+EOF
+fi
+
+echo "init-env: wrote $ENV_FILE with freshly generated secrets. Run: docker compose up"

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -21,8 +21,28 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="$ROOT/.env"
 EXAMPLE="$ROOT/.env.example"
 
+# The three vars docker-compose.yml requires with no default (${VAR:?} / bare).
+REQUIRED="JWT_SECRET UZI_SECRET_KEY POSTGRES_PASSWORD"
+
+# has_value FILE VAR — true iff FILE carries a non-empty `VAR=<something>` line.
+has_value() { grep -q "^$2=." "$1"; }
+
+# Never clobber an existing .env (that is what "persist" means). But an existing
+# file with an unfilled required var is NOT done: report it plainly and fail,
+# rather than printing "secrets persist" over a .env that will bounce off the
+# compose ${VAR:?} guards. Common trigger: a prior manual `cp .env.example .env`
+# with the values left blank.
 if [ -e "$ENV_FILE" ]; then
-  echo "init-env: .env already exists; leaving it untouched (secrets persist)."
+  missing=""
+  for v in $REQUIRED; do
+    has_value "$ENV_FILE" "$v" || missing="$missing $v"
+  done
+  if [ -n "$missing" ]; then
+    echo "init-env: .env exists but has no value for:${missing}" >&2
+    echo "init-env: fill those in, or 'rm .env' and re-run to generate a fresh one. Leaving .env untouched." >&2
+    exit 1
+  fi
+  echo "init-env: .env already exists with all required secrets set; leaving it untouched."
   exit 0
 fi
 
@@ -40,6 +60,12 @@ pw="$(openssl rand -hex 24)"
 
 umask 077  # .env holds secrets: create it 0600.
 
+# Write to a temp file on the same filesystem, then rename into place. An
+# interrupted or failed write can never leave a truncated .env that the
+# existence guard above would then lock in.
+tmp="$(mktemp "$ENV_FILE.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
 if [ -f "$EXAMPLE" ]; then
   # Start from the fully-documented example so the user keeps every option
   # (OIDC, Slack, seeds, tuning knobs) at hand, and fill only the three empty
@@ -50,14 +76,32 @@ if [ -f "$EXAMPLE" ]; then
     $0 == "UZI_SECRET_KEY="    { print "UZI_SECRET_KEY=" key; next }
     $0 == "POSTGRES_PASSWORD=" { print "POSTGRES_PASSWORD=" pw; next }
     { print }
-  ' "$EXAMPLE" >"$ENV_FILE"
+  ' "$EXAMPLE" >"$tmp"
 else
   # No example on disk (unusual): write a minimal but complete .env.
-  cat >"$ENV_FILE" <<EOF
+  cat >"$tmp" <<EOF
 JWT_SECRET=$jwt
 UZI_SECRET_KEY=$key
 POSTGRES_PASSWORD=$pw
 EOF
 fi
+
+# Confirm each required secret landed as the value we just generated, before
+# committing the file. This catches a drifted .env.example whose `VAR=` lines no
+# longer match the awk guards above (rename, a non-empty placeholder like
+# REPLACE_ME, trailing whitespace): in every such case the value read back would
+# not equal what we generated, which a bare non-empty check would miss.
+# value_of prints the text after the FIRST '=' on VAR's line (so a '=' inside a
+# base64 value survives).
+value_of() { awk -F= -v k="$2" '$1==k { sub(/^[^=]*=/, ""); print; exit }' "$1"; }
+if [ "$(value_of "$tmp" JWT_SECRET)" != "$jwt" ] ||
+   [ "$(value_of "$tmp" UZI_SECRET_KEY)" != "$key" ] ||
+   [ "$(value_of "$tmp" POSTGRES_PASSWORD)" != "$pw" ]; then
+  echo "init-env: generated secrets did not apply cleanly (is .env.example intact?); .env not written" >&2
+  exit 1
+fi
+
+mv "$tmp" "$ENV_FILE"
+trap - EXIT
 
 echo "init-env: wrote $ENV_FILE with freshly generated secrets. Run: docker compose up"


### PR DESCRIPTION
Closes #894.

## What

New `scripts/init-env.sh` (and a `task init` wrapper) generates the three required local secrets into `.env` on a fresh checkout, so `docker compose up` just works without the by-hand three-secret step.

- Generates `JWT_SECRET` (hex 64), `UZI_SECRET_KEY` (base64 32), `POSTGRES_PASSWORD` (hex 24), starting from `.env.example` so every other option stays documented and editable.
- Generate-once-and-persist: writes `.env` only when absent and never regenerates. Rotating `UZI_SECRET_KEY` makes stored tokens undecryptable and `POSTGRES_PASSWORD` only inits the `pgdata` volume on first run, so both must stay stable across restarts.
- Creates `.env` mode 0600 (`umask 077`) since it holds secrets.
- The `${VAR:?}` guards in `docker-compose.yml` are untouched, so a non-local misconfig (compose up with no `.env`) still fails loudly. The Kubernetes/Helm deploy stays on explicit secrets and never uses this.

## Docs

- `docs/installation.md` Configure step now runs the script (also fixes the two-vs-three required-secrets drift noted in #888).
- `README.md` Quick Start, `.env.example` header and `.claude/rules/stack.md` point at the script.
- `CHANGELOG.md` `[Unreleased]` entry added.
- Blog follow-up intentionally left for the maintainer.

## Verification

- `task gate:repo` green (shellcheck, yamllint, formula, gitleaks).
- `TestEmbeddedDocsMatchSource` green (embed mirror re-synced via `task docs:sync`).
- `task check-docs:web` / `check-changelog:web` green.
- Ran the script against a temp checkout: fills the three required lines, `.env` is 0600, re-run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated local environment setup that generates and saves required authentication, encryption, and database secrets.
  * Added a `task init` command for one-step initialization.
  * Existing environment files remain unchanged when initialization is rerun, while incomplete configurations are detected.

* **Documentation**
  * Updated installation guides, quick-start instructions, configuration guidance, and changelog to explain automated and manual setup options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->