### PR TITLE
docs(agent): de-hardcode SDK version in resume-preflight comments (#723)

### DIFF
--- a/agent/src/sdk-session.ts
+++ b/agent/src/sdk-session.ts
@@ -88,15 +88,19 @@
 // the one residual false-absent path in the glob, and dropping it makes "the glob's only
 // error is a false present" exactly true rather than nearly true.
 //
-// VERSION-COUPLED to @anthropic-ai/claude-agent-sdk 0.3.201: the transcript LAYOUT
-// (`$HOME/.claude/projects/<dir>/<session-id>.jsonl`) is the CLI's private on-disk
+// VERSION-COUPLED to the bundled Claude Code CLI's transcript LAYOUT
+// (`$HOME/.claude/projects/<dir>/<session-id>.jsonl`), the CLI's private on-disk
 // format, not a documented contract. The glob depends only on the `.jsonl`-named-by-
 // session-id leaf and the two-level projects/<dir> nesting — NOT on the encoding rule,
 // which is exactly why globbing survives an encoding change. A layout change would make
 // this find nothing and fail OPEN (degrade toward today's loud failure), never toward a
 // silent fresh start — but nothing in CI would notice it had stopped firing, so an SDK
-// bump needs this re-verified. The layout, the local pre-network resolution, and the
-// realpath-before-encode behaviour were each established independently by researcher-105
+// bump needs this re-verified. The pinned SDK version lives in agent/package.json and is
+// deliberately NOT restated as a number here — a hardcoded version is exactly what went
+// stale (issue #723). The `0.3.201` figures elsewhere in this header are the ORIGINAL
+// measurement provenance (issue #105), not a currentness claim; the layout was re-checked
+// unchanged against the then-pinned SDK for #723. The layout, the local pre-network
+// resolution, and the realpath-before-encode behaviour were each established independently by researcher-105
 // (shipped bundle + live harness) and by this author (direct CLI runs), so the claims
 // above are corroborated, not single-sourced.
 

--- a/agent/src/sdk-spawn.ts
+++ b/agent/src/sdk-spawn.ts
@@ -1,8 +1,10 @@
 // Detached spawn for the SDK subprocess + process-group kill.
 //
-// The default SDK spawn does NOT set `detached` (verified against
-// @anthropic-ai/claude-agent-sdk 0.3.201: no `detached:true` in the bundled
-// spawn), so its child is not a process-group leader and `process.kill(-pid)`
+// The default SDK spawn does NOT set `detached` (verified against the bundled SDK
+// spawn: no `detached:true`. The pinned version lives in agent/package.json, not
+// restated here — the `0.3.201` this was first measured at is provenance, not a
+// currentness pin, and re-checking on an SDK bump is a behaviour check, not a number
+// bump; issue #723), so its child is not a process-group leader and `process.kill(-pid)`
 // cannot reach a bash the agent backgrounded. Passing this as
 // `Options.spawnClaudeCodeProcess` spawns the Claude Code CLI in its OWN group
 // (`detached: true` ⇒ setsid on POSIX), so a watchdog trip can group-kill the


### PR DESCRIPTION
Resolves the stale-version drift in #723 and records the investigate-first decision for both asks.

## What changed
Comment-only, two files in the `agent/` worker. `sdk-session.ts` and `sdk-spawn.ts` hardcoded `0.3.201` in present-tense "VERSION-COUPLED to ..." comments, which went stale once the SDK bumped past it (now 0.3.241). The coupling now points at `agent/package.json` (the real source of truth), so the comments never need a version bump again. The `0.3.201` figures are kept only as clearly-labelled historical measurement provenance.

## Decision recorded for #723 (no code change beyond comments)

**Item 1 (adopt the SDK session-reading APIs): do not adopt.**
`sdk-session.ts` is a resume *preflight* (issue #105): it answers "will the bundled CLI resolve `--resume <id>` locally?" via a file existence check, not by parsing transcript content. Its load-bearing safety property is a one-directional error (only a survivable false-present, never a destructive false-absent) plus fail-open on EACCES. The new `getSessionMessages` / `getSessionInfo` APIs read message content and collapse "not found" with "could not read" (undefined/empty, EACCES behaviour undocumented; `getSessionInfo`'s undefined is also overloaded with sidechain/no-summary), so adopting them risks silently dropping a live session, the exact mode the current code prevents. The transcript layout was re-verified unchanged at 0.3.241, which is the maintenance the drift actually called for.

**Item 2 (subagent depth-cap lowered 5 to 1 at SDK 0.3.217): non-issue.**
Every builtin subagent is denied the Agent tool (`agents.ts`), so uzi's fan-out is strictly depth-1 (lead + 11 roles = 12, under the 20-concurrent cap). A worker that never spawned nested subagents cannot be regressed by the cap change.

## Validation
Comment-only; no behaviour, type, or test surface touched. CI runs `task gate:agent`.

Closes #723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the SDK version is sourced for transcript layout validation.
  * Documented that the default spawn behavior remains non-detached.
  * Clarified that the referenced SDK version is historical context, not a fixed pin.
  * Added guidance to re-check behavior after SDK upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->