### PR TITLE
bug(agent): large `submit_plan` payloads intermittently rejected as unparseable JSON, forcing retry loops

### DIFF
--- a/agent/src/prompt.ts
+++ b/agent/src/prompt.ts
@@ -1012,6 +1012,19 @@ export function buildPlanPrompt(input: PlanPromptInput): string {
     "the plan as Markdown and STOP. Do NOT implement anything yet — a human must",
     "approve the plan first.",
     "",
+    // issue #858. The whole plan rides inside the submit_plan tool-call JSON as the
+    // `plan_md` string, and the SDK parses that JSON before uzi ever sees it — a
+    // malformed blob (unescaped control chars, a lone backslash in a Windows-style
+    // path, a truncated tail) is rejected by the harness, not uzi, and forces the
+    // lead to re-emit the whole plan. A nudge only: it shrinks, but cannot
+    // eliminate, model-side serialization failures. Kept in prompt.ts (not the
+    // schema) to stay minimal; inline plan_md acceptance is unchanged.
+    "When you serialize the plan into `plan_md`, keep the string valid JSON: write",
+    "file paths with `/` (or an escaped `\\\\`), avoid unescaped control characters,",
+    "and emit the plan in one complete piece rather than a truncated fragment — a",
+    "malformed `plan_md` is rejected before it reaches uzi and forces you to re-emit",
+    "the whole plan.",
+    "",
     // PRD #122 M1. Optional milestone breakdown on submit_plan. Unconditional inside
     // this builder because it is issue-only by construction (the executor calls it
     // for kind==="issue" only); the schema gate (signals.ts) is the belt to this

--- a/agent/test/prompt.test.ts
+++ b/agent/test/prompt.test.ts
@@ -88,6 +88,9 @@ describe("buildPlanPrompt", () => {
       prompt.includes("(or an escaped `\\\\`)"),
       "the prompt shows the escaped-backslash form for file paths",
     );
+    // The complete-output guidance: dropping the "one complete piece" clause
+    // (which guards against a truncated plan_md) must fail this test.
+    assert.match(prompt, /one complete piece/);
   });
 
   it("notes when no subagents are available", () => {

--- a/agent/test/prompt.test.ts
+++ b/agent/test/prompt.test.ts
@@ -76,6 +76,20 @@ describe("buildPlanPrompt", () => {
     assert.match(prompt, /Do NOT implement anything yet/i);
   });
 
+  it("nudges the lead to keep plan_md valid JSON (issue #858)", () => {
+    // The whole plan rides inside the submit_plan tool-call JSON; a malformed
+    // plan_md is rejected by the SDK before uzi sees it. The prompt must carry the
+    // serialization-hygiene nudge. Non-vacuous by revert: dropping the prompt line
+    // fails these assertions.
+    assert.match(prompt, /keep the string valid JSON/);
+    assert.match(prompt, /unescaped control characters/);
+    // The escaped-backslash guidance renders as a literal `\\` in the prompt.
+    assert.ok(
+      prompt.includes("(or an escaped `\\\\`)"),
+      "the prompt shows the escaped-backslash form for file paths",
+    );
+  });
+
   it("notes when no subagents are available", () => {
     const p = buildPlanPrompt({
       issueIid: 1,


### PR DESCRIPTION
Implements issue #858.

Closes #858

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-858`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated plans to use valid JSON formatting.
  - Added guidance to safely escape file paths and control characters.
  - Ensured plan content is complete and not unintentionally truncated.

- **Tests**
  - Added regression coverage for JSON validity, escaping, and complete plan output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->