### PR TITLE
Runs view: make the PR/MR chip a clickable deep-link to the forge request

### DIFF
--- a/web/src/pages/RunsList.test.tsx
+++ b/web/src/pages/RunsList.test.tsx
@@ -416,6 +416,67 @@ describe("RunsList — usage meta line (PRD #40)", () => {
   });
 })
 
+// Issue #803: the MR/PR chip on a run row is a real deep-link to the forge request,
+// mirroring IssueView/Board — preferring the persisted mr_web_url and otherwise
+// reconstructing it from the run's own issue URL (GitLab /-/issues/ shape).
+describe("RunsList — MR/PR chip deep-links (issue #803)", () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { is_admin: false },
+      vaultUnlocked: true,
+    } as unknown as ReturnType<typeof useAuth>);
+  });
+
+  it("the runs list MR chip deep-links to the persisted forge URL", async () => {
+    mockApi.listRuns.mockResolvedValue({
+      runs: [
+        aRun({
+          id: "run-1",
+          issue_title: "Linked run",
+          status: "running",
+          mr_iid: 799,
+          mr_state: "opened",
+          mr_web_url: "https://gitlab.example.com/g/p/-/merge_requests/799",
+        }),
+      ],
+    });
+
+    const { container } = renderRuns();
+
+    await waitFor(() => expect(screen.getByText("Linked run")).toBeTruthy());
+    const chip = container.querySelector('a[href*="merge_requests"]') as HTMLAnchorElement | null;
+    expect(chip).not.toBeNull();
+    expect(chip?.getAttribute("href")).toBe("https://gitlab.example.com/g/p/-/merge_requests/799");
+    expect(chip?.getAttribute("target")).toBe("_blank");
+    // The row's own run-detail link still stands (click-separation intent): the chip is
+    // independently clickable, the rest of the card follows the stretched link.
+    expect(container.querySelector('a[href="/runs/run-1"]')).not.toBeNull();
+  });
+
+  it("the runs list MR chip falls back to the issue-derived forge URL when mr_web_url is null", async () => {
+    mockApi.listRuns.mockResolvedValue({
+      runs: [
+        aRun({
+          id: "run-1",
+          issue_title: "Derived-link run",
+          status: "running",
+          mr_iid: 799,
+          mr_state: "opened",
+          mr_web_url: null,
+          issue_web_url: "https://gitlab.example.com/g/p/-/issues/42",
+        }),
+      ],
+    });
+
+    const { container } = renderRuns();
+
+    await waitFor(() => expect(screen.getByText("Derived-link run")).toBeTruthy());
+    const chip = container.querySelector('a[href*="merge_requests"]') as HTMLAnchorElement | null;
+    expect(chip).not.toBeNull();
+    expect(chip?.getAttribute("href")).toBe("https://gitlab.example.com/g/p/-/merge_requests/799");
+  });
+});
+
 describe("RunsList — global judge-triage strip removed (PRD #98 Decision 7)", () => {
   it("no longer renders the aggregate strip (its home is now the Judge page header)", async () => {
     mockApi.listRuns.mockResolvedValue({ runs: [aRun({ issue_title: "A run" })] });

--- a/web/src/pages/RunsList.tsx
+++ b/web/src/pages/RunsList.tsx
@@ -18,12 +18,13 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, NavLink, Outlet, useOutletContext, useSearchParams } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
-import { api, ApiError, isTerminalRun, type AdminWorker, type RunListItem, type RunUsage } from "../lib/api";
+import { api, ApiError, isTerminalRun, preferForgeUrl, type AdminWorker, type RunListItem, type RunUsage } from "../lib/api";
 import { Alert, Badge, Card, EmptyState, Input, ListSkeleton, PageHeader, SectionTitle, StatusPill, cx } from "../components/ui";
 import { ActivityIcon } from "../components/icons";
 import { MrChip } from "../components/MrChip";
 import { RunIssueRef } from "../components/RunIssueRef";
 import { mrAbbrev } from "../lib/forgeNoun";
+import { mergeRequestUrl, projectWebUrlFromIssue } from "../lib/forgeUrls";
 import { effectiveRunStatus, isStoppedRun, milestoneBadge, milestoneBadgeText, mrChipState } from "../lib/runBadge";
 import { RunPriorityBadge } from "../components/RunPriorityBadge";
 import { formatTokens, formatCost } from "../lib/formatTokens";
@@ -241,6 +242,17 @@ function RunRow({
   // MR chip state (PRD #33): open renders exactly as before; merged/closed get a
   // label and closed is muted + struck. This is a per-run frozen hint.
   const mrState = mrChipState(run.mr_state);
+  // Issue #803: make the MR/PR chip a real deep-link. Prefer the persisted forge URL
+  // (mr_web_url); fall back to reconstructing it from the run's own issue URL, which
+  // only works for GitLab's /-/issues/ shape (projectWebUrlFromIssue), exactly as
+  // IssueView does. preferForgeUrl/mergeRequestUrl guard non-https/empty inputs and
+  // return null, so a malformed value degrades to the inert <span> chip.
+  const mrHref = preferForgeUrl(
+    run.mr_web_url,
+    run.mr_iid != null && run.issue_web_url
+      ? mergeRequestUrl(projectWebUrlFromIssue(run.issue_web_url), run.mr_iid)
+      : null,
+  );
   // PRD #122: compact milestone progress for the row; null on a non-milestone run,
   // which then renders no new badge (the row had none before this feature).
   const ms = milestoneBadge(run);
@@ -330,10 +342,12 @@ function RunRow({
                 forgeType={run.forge_type}
                 mrIid={run.mr_iid}
                 mrState={mrState}
-                href={null}
+                href={mrHref}
                 // Issue #485 review FIX 1: raised above the card's stretched-link overlay
-                // (relative z-10) so its native `title` (MR state) fires on hover; the
-                // href-less chip is not click-to-navigate, which is fine for a status chip.
+                // (relative z-10) so its native `title` fires on hover AND so the chip is
+                // independently clickable — clicking it opens the PR/MR on the forge in a
+                // new tab (`target="_blank"`), while clicking elsewhere on the card follows
+                // the stretched link to the run detail view (issue #803).
                 className="relative z-10 font-medium"
               />
             )}


### PR DESCRIPTION
Implements issue #803.

Closes #803

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-803`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Merge/pull request chips now link to the associated forge page.
  - GitLab merge-request links are reconstructed when a direct URL is unavailable.
  - Links open in a new tab while preserving access to run details from the surrounding row.

- **Bug Fixes**
  - Invalid or unavailable merge-request URLs no longer create unusable links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->