### PR TITLE
self_improve run fails on `fetchAgentBranch`: legacy flat `refs/uzi-runner/uzi/self-improve` ref D/F-conflicts with the new per-cycle `refs/uzi-runner/uzi/self-improve/<runId>` tracking ref (regression from #774 / ADR 0686 D9)

### DIFF
--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -940,6 +940,11 @@ export class GitCache {
   async fetchAgentBranch(barePath: string, clonePath: string, branch: string, runId: string): Promise<string> {
     const dst = runnerTrackingRef(branch);
     await this.withLock(barePath, async () => {
+      // issue #887: clear any legacy FLAT tracking ref that is a strict path-prefix
+      // (directory ancestor) of `dst`, or the fetch below aborts. See the helper's own
+      // doc for the full mechanism. Runs FIRST, under the same lock as the fetch/stamp,
+      // so the namespace is clear before the ref-store tries to create the dst directory.
+      await this.clearConflictingAncestorTrackingRefs(barePath, dst);
       await this.runGit(barePath, [
         "-c", "protocol.file.allow=user",
         "fetch", "--no-tags", `file://${clonePath}`,
@@ -952,6 +957,64 @@ export class GitCache {
       await this.runGit(barePath, ["config", "--local", runnerTrackingOwnerKey(branch), runId]);
     });
     return dst;
+  }
+
+  /**
+   * issue #887 — clear a legacy FLAT tracking ref that path-blocks the fetch's dst ref.
+   *
+   * git's ref store is a directory tree: a ref FILE at `refs/uzi-runner/uzi/self-improve`
+   * and a ref DIRECTORY at `refs/uzi-runner/uzi/self-improve/<runId>` cannot coexist,
+   * because the leaf file occupies the very path the directory needs (a D/F — directory/
+   * file — conflict). Before PRD #774 / ADR 0686 D9, a self_improve run's tracking ref was
+   * the flat leaf `refs/uzi-runner/uzi/self-improve`; #774 moved it to the per-run
+   * namespace `refs/uzi-runner/uzi/self-improve/<runId>`. On a worker whose persistent bare
+   * still carries the pre-#774 flat leaf, that leaf is a strict path-prefix (ancestor) of
+   * the new dst, so `fetch … :refs/uzi-runner/uzi/self-improve/<runId>` fails the whole
+   * update with "some local refs could not be updated" and the run dies. self_improve is
+   * the ONLY run kind whose ref shape changed leaf→namespace, so it is the only observed
+   * failure — we clear exactly the ancestor refs that can block dst.
+   *
+   * The mirror case — a legacy per-run DIRECTORY blocking a new FLAT leaf (a descendant path
+   * blocking its own ancestor) — is deliberately OUT OF SCOPE: no run kind moved
+   * namespace→leaf, so it does not arise here, and handling it would mean deleting a whole
+   * live subtree on a guess.
+   *
+   * Any conflicting ancestor found is ARCHIVED (its tip may carry unmerged commits) under
+   * refs/uzi-archive/<sanitized>/<sha> before it is deleted, and its dangling PRD #218
+   * owner-config key is cleared. Deepest-first so a partially-migrated bare with several
+   * stacked ancestors is cleaned bottom-up.
+   */
+  private async clearConflictingAncestorTrackingRefs(barePath: string, dst: string): Promise<void> {
+    // Only refs inside the tracking namespace can D/F-conflict with a tracking-ref dst.
+    if (!dst.startsWith(RUNNER_TRACKING_PREFIX)) return;
+    const suffix = dst.slice(RUNNER_TRACKING_PREFIX.length);
+    const parts = suffix.split("/");
+    // Cumulative prefixes STRICTLY shorter than the full branch: every part except the last.
+    // For suffix "uzi/self-improve/<runId>" this yields the branches "uzi" and
+    // "uzi/self-improve", i.e. the candidate refs refs/uzi-runner/uzi and
+    // refs/uzi-runner/uzi/self-improve — never the namespace root and never dst itself.
+    const candidates: string[] = [];
+    let acc = "refs/uzi-runner";
+    for (const part of parts.slice(0, -1)) {
+      acc = `${acc}/${part}`;
+      candidates.push(acc);
+    }
+    // Deepest-first: delete the most specific blocking leaf before its shorter ancestors.
+    for (const candidate of candidates.reverse()) {
+      if (!(await this.refExists(barePath, candidate))) continue;
+      const sha = (await this.runGit(barePath, ["rev-parse", candidate])).trim();
+      // Archive first so a possibly-unmerged tip is never lost by the delete. The
+      // <sanitized>/<sha> shape is D/F-safe within refs/uzi-archive (the sha leaf never
+      // collides with a sibling branch's subtree) and idempotent (re-archiving the same
+      // tip writes the same ref to the same sha).
+      const ancestorBranch = candidate.slice(RUNNER_TRACKING_PREFIX.length);
+      const sanitized = ancestorBranch.replace(/[^A-Za-z0-9_-]/g, "-");
+      await this.runGit(barePath, ["update-ref", `refs/uzi-archive/${sanitized}/${sha}`, sha]);
+      await this.runGit(barePath, ["update-ref", "-d", candidate]);
+      // Clear the now-dangling PRD #218 owner stamp for the deleted ref. tryGit swallows
+      // exit 5 (key absent), which runGit would instead throw on — see the helper notes.
+      await this.tryGit(barePath, ["config", "--local", "--unset", runnerTrackingOwnerKey(ancestorBranch)]);
+    }
   }
 
   /** PRD #122 M6: the tip of the worker-side tracking ref `fetchAgentBranch` wrote

--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -143,8 +143,18 @@ function runnerTrackingRef(branch: string): string {
 // ONLY when the stamp matches the claiming run. This is a worker-owned `config --local`
 // write, the same posture as disableAutoMaintenance — no new trust boundary. The key is
 // dot/slash-free so the dotted git-config name parses (`git config uzi-trackowner.<x>`).
+//
+// issue #887 — the branch is carried in a git-config SUBSECTION, not flattened into the
+// variable name. git parses `section.subsection.variable` by the FIRST and LAST dot, so
+// the middle keeps the branch VERBATIM (slashes and dots included) and the variable is the
+// fixed `owner`. The earlier form flattened `/`->`-` into the variable name, which collided:
+// `uzi/self-improve` and a literal `uzi-self-improve` mapped to the same key, so clearing
+// one branch's owner stamp (clearConflictingAncestorTrackingRefs) could wipe the other's
+// and cost a later resume its unpushed recovery state. The subsection encoding is reversible
+// and collision-free — distinct branches always land in distinct `[uzi-trackowner "<branch>"]`
+// blocks. (Legacy two-part stamps on a persistent bare become dead config no read touches.)
 function runnerTrackingOwnerKey(branch: string): string {
-  return `uzi-trackowner.${branch.replace(/[^A-Za-z0-9_-]/g, "-")}`;
+  return `uzi-trackowner.${branch}.owner`;
 }
 
 export interface RunnerClone {

--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -141,8 +141,7 @@ function runnerTrackingRef(branch: string): string {
 // while claiming to have recovered its own). So alongside the ref we stamp the writing
 // run's id into the worker bare's own config, and the reseed reads the tracking ref back
 // ONLY when the stamp matches the claiming run. This is a worker-owned `config --local`
-// write, the same posture as disableAutoMaintenance — no new trust boundary. The key is
-// dot/slash-free so the dotted git-config name parses (`git config uzi-trackowner.<x>`).
+// write, the same posture as disableAutoMaintenance — no new trust boundary.
 //
 // issue #887 — the branch is carried in a git-config SUBSECTION, not flattened into the
 // variable name. git parses `section.subsection.variable` by the FIRST and LAST dot, so

--- a/agent/test/git.test.ts
+++ b/agent/test/git.test.ts
@@ -1368,8 +1368,14 @@ describe("issue #887 — fetchAgentBranch clears a D/F-conflicting legacy ancest
     // path-blocks refs/uzi-runner/uzi/self-improve/<runId>.
     const mainSha = gitIn(bare, ["rev-parse", "refs/remotes/origin/main"]);
     gitIn(bare, ["update-ref", "refs/uzi-runner/uzi/self-improve", mainSha]);
-    // Its dangling PRD #218 owner stamp (sanitized branch "uzi-self-improve").
-    gitIn(bare, ["config", "--local", "uzi-trackowner.uzi-self-improve", "old-run"]);
+    // Its dangling PRD #218 owner stamp, keyed under the #887 subsection encoding
+    // (`uzi-trackowner.<branch>.owner`, branch verbatim in the subsection).
+    gitIn(bare, ["config", "--local", "uzi-trackowner.uzi/self-improve.owner", "old-run"]);
+    // issue #887 collision regression: a DISTINCT branch literally named "uzi-self-improve"
+    // (hyphen, not slash). The old flatten-to-variable-name encoding mapped both this and
+    // "uzi/self-improve" to the same key; the subsection encoding does not, so clearing the
+    // slash branch's stamp below must leave this hyphen branch's stamp untouched.
+    gitIn(bare, ["config", "--local", "uzi-trackowner.uzi-self-improve.owner", "sibling-run"]);
     // An UNRELATED sibling tracking ref that must SURVIVE the clear.
     gitIn(bare, ["update-ref", "refs/uzi-runner/agent/issue-999", mainSha]);
 
@@ -1401,16 +1407,23 @@ describe("issue #887 — fetchAgentBranch clears a D/F-conflicting legacy ancest
       mainSha,
       "the deleted ancestor's tip must be archived under refs/uzi-archive/<sanitized>/<sha>",
     );
-    // The dangling owner-config key was cleared (--get now exits non-zero → gitIn throws).
+    // The cleared ancestor's own owner stamp is gone (--get now exits non-zero → gitIn throws).
     assert.throws(
-      () => gitIn(bare, ["config", "--local", "--get", "uzi-trackowner.uzi-self-improve"]),
-      "the dangling PRD #218 owner stamp must be unset",
+      () => gitIn(bare, ["config", "--local", "--get", "uzi-trackowner.uzi/self-improve.owner"]),
+      "the deleted ancestor's PRD #218 owner stamp must be unset",
     );
-    // The unrelated sibling tracking ref is untouched.
+    // issue #887 collision regression: the DISTINCT "uzi-self-improve" (hyphen) branch's
+    // stamp must SURVIVE — the old encoding collided both onto one key and cleared it here.
     assert.strictEqual(
-      refInBare(bare, "refs/uzi-runner/agent/issue-999"),
-      true,
-      "an unrelated sibling tracking ref must survive",
+      gitIn(bare, ["config", "--local", "--get", "uzi-trackowner.uzi-self-improve.owner"]),
+      "sibling-run",
+      "a distinct hyphen-named branch's owner stamp must not be collaterally cleared",
+    );
+    // The unrelated sibling tracking ref is untouched — its tip is unchanged, not merely present.
+    assert.strictEqual(
+      gitIn(bare, ["rev-parse", "refs/uzi-runner/agent/issue-999"]),
+      mainSha,
+      "an unrelated sibling tracking ref must remain unchanged",
     );
   });
 });

--- a/agent/test/git.test.ts
+++ b/agent/test/git.test.ts
@@ -1342,3 +1342,75 @@ describe("issue #781 — disjoint-ref seed guard + fetch --prune", () => {
     );
   });
 });
+
+// Issue #887 — a self_improve run's fetch-back writes the tracking ref
+// refs/uzi-runner/uzi/self-improve/<runId>. On a worker whose persistent bare still
+// carries the pre-#774 FLAT leaf ref refs/uzi-runner/uzi/self-improve, that leaf is a
+// strict path-prefix (directory ancestor) of the new dst, so the ref-store cannot create
+// the dst directory and the whole fetch aborts ("some local refs could not be updated").
+// fetchAgentBranch must clear the conflicting ancestor first (archiving its tip), land the
+// agent commit, and leave unrelated sibling tracking refs untouched.
+describe("issue #887 — fetchAgentBranch clears a D/F-conflicting legacy ancestor tracking ref", () => {
+  const IDENT = ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false"];
+  function refInBare(bare: string, ref: string): boolean {
+    try {
+      gitIn(bare, ["rev-parse", "--verify", "--quiet", ref]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it("archives + deletes the flat ancestor, fetches the self-improve branch, and spares siblings", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+
+    // Seed the legacy pre-#774 FLAT leaf ref at main's commit — the ancestor that
+    // path-blocks refs/uzi-runner/uzi/self-improve/<runId>.
+    const mainSha = gitIn(bare, ["rev-parse", "refs/remotes/origin/main"]);
+    gitIn(bare, ["update-ref", "refs/uzi-runner/uzi/self-improve", mainSha]);
+    // Its dangling PRD #218 owner stamp (sanitized branch "uzi-self-improve").
+    gitIn(bare, ["config", "--local", "uzi-trackowner.uzi-self-improve", "old-run"]);
+    // An UNRELATED sibling tracking ref that must SURVIVE the clear.
+    gitIn(bare, ["update-ref", "refs/uzi-runner/agent/issue-999", mainSha]);
+
+    const runId = "37702d9d-887d-49c9-b3cd-7974a3b2ecde";
+    const branch = `uzi/self-improve/${runId}`;
+    const rc = await git.runnerCloneForBranch(bare, branch, `self-improve-${runId}`, runId);
+
+    // The agent commits in the runner clone.
+    fs.writeFileSync(path.join(rc.path, "SI.txt"), "self-improve\n");
+    gitIn(rc.path, ["add", "SI.txt"]);
+    gitIn(rc.path, [...IDENT, "commit", "-m", "self-improve work"]);
+    const agentSha = gitIn(rc.path, ["rev-parse", "HEAD"]);
+
+    // Without the fix this THROWS ("some local refs could not be updated"); with it the
+    // ancestor is cleared first and the fetch lands.
+    const ref = await git.fetchAgentBranch(bare, rc.path, branch, runId);
+
+    assert.strictEqual(ref, `refs/uzi-runner/${branch}`);
+    assert.strictEqual(gitIn(bare, ["rev-parse", ref]), agentSha, "the self-improve commit landed in the worker bare");
+    // The flat ancestor is gone (it path-blocked dst).
+    assert.strictEqual(
+      refInBare(bare, "refs/uzi-runner/uzi/self-improve"),
+      false,
+      "the D/F-conflicting flat ancestor must be deleted",
+    );
+    // Its tip was archived first so a possibly-unmerged commit is never lost.
+    assert.strictEqual(
+      gitIn(bare, ["rev-parse", `refs/uzi-archive/uzi-self-improve/${mainSha}`]),
+      mainSha,
+      "the deleted ancestor's tip must be archived under refs/uzi-archive/<sanitized>/<sha>",
+    );
+    // The dangling owner-config key was cleared (--get now exits non-zero → gitIn throws).
+    assert.throws(
+      () => gitIn(bare, ["config", "--local", "--get", "uzi-trackowner.uzi-self-improve"]),
+      "the dangling PRD #218 owner stamp must be unset",
+    );
+    // The unrelated sibling tracking ref is untouched.
+    assert.strictEqual(
+      refInBare(bare, "refs/uzi-runner/agent/issue-999"),
+      true,
+      "an unrelated sibling tracking ref must survive",
+    );
+  });
+});


### PR DESCRIPTION
Implements issue #887.

Closes #887

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-887`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch fetching when legacy tracking references conflict with newer run-specific references.
  * Conflicting legacy references are safely archived and removed while preserving unrelated tracking data.
  * Branch ownership information is now preserved accurately, including for branches with similar or overlapping names.
  * Agent commits can now be fetched successfully in these conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->