### PR TITLE
bug(web): sidebar forecast-row rate-limit tooltip drops the "resets in …" countdown that safe rows show

### DIFF
--- a/web/src/components/RateLimitMeters.test.tsx
+++ b/web/src/components/RateLimitMeters.test.tsx
@@ -203,6 +203,30 @@ describe("SidebarRateLimits", () => {
     expect(screen.queryByLabelText("Claude rate limits")).toBeNull();
   });
 
+  // The forecast rows must carry the "resets in …" countdown, folded into
+  // MicroRow's valueText so it flows into RateLimitForecast's tooltip text. A 5h
+  // window at 90% with a near reset (elapsed ≈ 13000s on the 18000s window ⇒
+  // projected ≈ 125 ⇒ "over"): the wrapper's title is `${valueText} — projected …`,
+  // so after the fix it contains BOTH "resets in" (from valueText) and "projected".
+  it("carries the resets-in countdown into a forecast row's title", async () => {
+    const forecastReading: MyRateLimits = {
+      status: "ok",
+      five_hour: { pct: 90, resets_at: nowSecs + 5000 },
+      seven_day: { pct: 20, resets_at: nowSecs + 200_000 },
+      source: "usage_endpoint",
+      synced_at: new Date().toISOString(),
+      stale: false,
+    };
+    mockApi.getMyRateLimits.mockResolvedValue(tokens(forecastReading));
+    render(<SidebarRateLimits />);
+    await screen.findByLabelText("Claude rate limits");
+    const bar5h = screen.getByRole("progressbar", { name: "5h window" });
+    const titled = bar5h.closest("[title]") as HTMLElement;
+    const title = titled.getAttribute("title") ?? "";
+    expect(title).toMatch(/resets in/);
+    expect(title).toMatch(/projected/);
+  });
+
   it("dims both micro-bars on a stale reading", async () => {
     mockApi.getMyRateLimits.mockResolvedValue(tokens(staleReading));
     render(<SidebarRateLimits />);

--- a/web/src/components/RateLimitMeters.tsx
+++ b/web/src/components/RateLimitMeters.tsx
@@ -304,12 +304,15 @@ function MicroRow({
   win,
   dim,
   forecast,
+  now,
 }: {
   label: string;
   win: RateLimitWindow;
   dim: boolean;
   forecast: PaceForecast;
+  now: number;
 }) {
+  const countdown = formatCountdown(win.resets_at, now);
   return (
     <div className="grid grid-cols-[1.4rem_1fr_2.6rem] items-center gap-2 text-[11px]">
       <span className="font-mono text-faint">{label}</span>
@@ -317,7 +320,7 @@ function MicroRow({
         className="h-[5px]"
         label={`${label} window`}
         pct={win.pct}
-        valueText={`${win.pct}%`}
+        valueText={`${win.pct}%${countdown ? `, resets in ${countdown}` : ""}`}
         forecast={forecast}
         dim={dim}
       />
@@ -360,12 +363,14 @@ function TokenMicroMeters({
         win={limits.five_hour}
         dim={limits.stale}
         forecast={rowForecast(limits.stale, limits.five_hour.pct, limits.five_hour.resets_at, WINDOW_DURATION["5h"], now, limits.source)}
+        now={now}
       />
       <MicroRow
         label="7d"
         win={limits.seven_day}
         dim={limits.stale}
         forecast={rowForecast(limits.stale, limits.seven_day.pct, limits.seven_day.resets_at, WINDOW_DURATION["7d"], now, limits.source)}
+        now={now}
       />
     </div>
   );

--- a/web/src/components/RateLimitMeters.tsx
+++ b/web/src/components/RateLimitMeters.tsx
@@ -299,6 +299,8 @@ export function RateLimitAnnouncer() {
   );
 }
 
+// MicroRow is one window's 5px forecast bar, showing its percentage and folding
+// the "resets in <countdown>" text into the bar's forecast tooltip.
 function MicroRow({
   label,
   win,


### PR DESCRIPTION
Implements issue #859.

Closes #859

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-859`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Rate limit meters now include reset countdown information in their accessible labels and value descriptions.
  * Forecast tooltips display both projected utilization and the time remaining until reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->