### PR TITLE
Ephemeral workers should default to auto-select credential mode, not "Use my default token"

### DIFF
--- a/api/internal/handler/auto_eligible_livedb_test.go
+++ b/api/internal/handler/auto_eligible_livedb_test.go
@@ -65,18 +65,26 @@ func TestAutoEligibleToggleLiveDB(t *testing.T) {
 	owner := mkSecretUser(t, pool)
 	stranger := mkSecretUser(t, pool)
 
-	rec := h.createToken(t, owner, "default", "sk-ant-autoeligible-owner-0000000000", true)
+	// A user's FIRST/SOLE anthropic_token is born auto-eligible (issue #804), so seed a
+	// preceding first token to hold that role; the token under test here is the owner's
+	// SECOND, which is the opt-in default we exercise (born OUT, toggled IN, then OUT).
+	if rec := h.createToken(t, owner, "default", "sk-ant-autoeligible-owner-first-0000", true); rec.Code != http.StatusCreated {
+		t.Fatalf("create first token: code %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	rec := h.createToken(t, owner, "console-key", "sk-ant-autoeligible-owner-0000000000", false)
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create: code %d, body %s", rec.Code, rec.Body.String())
 	}
 	tok := decodeSecret(t, rec).Secret.ID
 
-	// --- A new token is OUT of the pool ------------------------------------
-	// D2's default, and the one that must never drift: a token that silently
-	// arrived in the pool would spend an account the user reserved for something
-	// else, which is the whole reason the pool is opt-in.
+	// --- A new NON-FIRST token is OUT of the pool --------------------------
+	// D2's default for the reserved token, and the one that must never drift: a
+	// second token that silently arrived in the pool would spend an account the user
+	// reserved for something else, which is the whole reason #2+ stays opt-in (issue
+	// #804 keeps only the FIRST/SOLE token auto-eligible).
 	if autoEligibleOf(t, h, owner, tok) {
-		t.Fatal("a newly created token is already in the pool; the D2 default must be OUT")
+		t.Fatal("a newly created non-first token is already in the pool; the opt-in default for token #2+ must be OUT")
 	}
 
 	// --- Toggling on, and the response reporting it ------------------------
@@ -183,6 +191,14 @@ func TestSelfRateLimitsAutoStatusLiveDB(t *testing.T) {
 	stale := mk("stale", false)
 	lowRoom := mk("low-room", false)
 	noGauge := mk("no-gauge", false)
+
+	// notPooled is the user's FIRST token, which issue #804 makes born auto-eligible;
+	// opt it back OUT so it genuinely models a token the owner never put in the pool —
+	// the case that must classify not_pooled even with a wide-open gauge reading. The
+	// count stays 5 and no throwaway token pollutes the listing below.
+	if rec := patchAutoEligible(t, h, owner, notPooled, `{"auto_eligible":false}`); rec.Code != http.StatusOK {
+		t.Fatalf("opt not-pooled OUT: code %d, body %s", rec.Code, rec.Body.String())
+	}
 
 	for _, id := range []string{fresh, stale, lowRoom, noGauge} {
 		if rec := patchAutoEligible(t, h, owner, id, `{"auto_eligible":true}`); rec.Code != http.StatusOK {

--- a/api/internal/handler/ephemeral_provisioner_livedb_test.go
+++ b/api/internal/handler/ephemeral_provisioner_livedb_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vtmocanu/uzi/api/internal/secretbox"
 	"github.com/vtmocanu/uzi/api/internal/settings"
 	"github.com/vtmocanu/uzi/api/internal/store"
+	"github.com/vtmocanu/uzi/api/internal/workersvc"
 )
 
 // The end-to-end live-DB proof of PRD #529 M2's provisioner: the real
@@ -518,4 +519,79 @@ func TestEphemeralProvisionPassSaturationPlainRunLiveDB(t *testing.T) {
 	if rows[0].template != "base" {
 		t.Errorf("template = %q, want base (plain run)", rows[0].template)
 	}
+}
+
+// TestEphemeralProvisionBindModeLiveDB pins issue #804 in the REAL provisioner path
+// (ProvisionPass → provisionOne against real Postgres): an auto-provisioned burst worker
+// defaults to anthropic_bind_mode 'auto' ONLY when its owner has a non-empty auto-select
+// pool (≥1 auto_eligible anthropic_token), and 'default' otherwise — so an auto worker
+// never parks its run in pool_wait on an empty pool. This is the CI-gating home for the
+// decision (run-store-it.sh sweeps `-run 'LiveDB$'` over the handler package); the
+// store-package LiveDB tests separately pin the UserHasAutoEligibleAnthropicToken read and
+// the CreateEphemeralHostedWorker persistence it composes.
+func TestEphemeralProvisionBindModeLiveDB(t *testing.T) {
+	insertToken := func(fx *ephemeralFixture, label string, first bool) uuid.UUID {
+		fx.t.Helper()
+		row, err := fx.q.InsertUserSecret(fx.ctx, store.InsertUserSecretParams{
+			UserID: fx.userID, Kind: store.KindAnthropicToken, Label: label, WantDefault: first,
+			Ciphertext: []byte("ct-" + label), SealedWith: store.SealedWithMaster,
+		})
+		if err != nil {
+			fx.t.Fatalf("insert token %s: %v", label, err)
+		}
+		return row.ID
+	}
+	// provisionAndReadMode drives a capability-gap provision for the fixture user (a docker
+	// run its base-only fleet cannot serve) and returns the created worker's persisted
+	// anthropic_bind_mode.
+	provisionAndReadMode := func(fx *ephemeralFixture) string {
+		fx.t.Helper()
+		fx.onlineWorker("base-only", false) // base fleet cannot satisfy docker
+		runID := fx.queuedRun([]string{"docker"})
+		if _, err := fx.provisioner(true, 2).ProvisionPass(fx.ctx); err != nil {
+			fx.t.Fatalf("ProvisionPass: %v", err)
+		}
+		var mode string
+		if err := fx.pool.QueryRow(fx.ctx,
+			`SELECT anthropic_bind_mode FROM workers WHERE ephemeral_run_id = $1 AND ephemeral`, runID).Scan(&mode); err != nil {
+			fx.t.Fatalf("read bind mode: %v", err)
+		}
+		return mode
+	}
+
+	// An owner with ≥1 auto_eligible token (here: a born-eligible first token plus a second
+	// opted-out token) → the pool is non-empty → auto.
+	t.Run("eligible_token_owner_auto", func(t *testing.T) {
+		fx := newEphemeralFixture(t, true)
+		insertToken(fx, "default", true)      // first token, born auto_eligible (issue #804)
+		insertToken(fx, "console-key", false) // a second, non-eligible token; pool still non-empty
+		if got := provisionAndReadMode(fx); got != workersvc.BindModeAuto {
+			t.Errorf("anthropic_bind_mode = %q, want %q (owner has ≥1 auto_eligible token)", got, workersvc.BindModeAuto)
+		}
+	})
+
+	// An owner whose ONLY token is not eligible (born eligible, then opted out) → empty pool
+	// → default, so the run is never parked in pool_wait.
+	t.Run("opted_out_only_owner_default", func(t *testing.T) {
+		fx := newEphemeralFixture(t, true)
+		tok := insertToken(fx, "default", true)
+		if _, err := fx.q.SetUserSecretAutoEligible(fx.ctx, store.SetUserSecretAutoEligibleParams{
+			ID: tok, UserID: fx.userID, Kind: store.KindAnthropicToken, AutoEligible: false,
+		}); err != nil {
+			t.Fatalf("opt token out: %v", err)
+		}
+		if got := provisionAndReadMode(fx); got != workersvc.BindModeDefault {
+			t.Errorf("anthropic_bind_mode = %q, want %q (empty auto-select pool must not select auto)", got, workersvc.BindModeDefault)
+		}
+	})
+
+	// A single-token owner, eligible purely via the born-eligible first-token insert (no
+	// toggle) → auto. This is the headline #804 case: single-token users get auto for free.
+	t.Run("single_token_owner_auto", func(t *testing.T) {
+		fx := newEphemeralFixture(t, true)
+		insertToken(fx, "default", true) // sole token, born auto_eligible via insert
+		if got := provisionAndReadMode(fx); got != workersvc.BindModeAuto {
+			t.Errorf("anthropic_bind_mode = %q, want %q (single born-eligible token)", got, workersvc.BindModeAuto)
+		}
+	})
 }

--- a/api/internal/hostedsvc/ephemeral.go
+++ b/api/internal/hostedsvc/ephemeral.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vtmocanu/uzi/api/internal/jointoken"
 	"github.com/vtmocanu/uzi/api/internal/secretbox"
 	"github.com/vtmocanu/uzi/api/internal/store"
+	"github.com/vtmocanu/uzi/api/internal/workersvc"
 )
 
 // ephemeralProvisionBatch bounds how many unplaceable runs one ProvisionPass tick
@@ -255,6 +256,22 @@ func (p *EphemeralProvisioner) provisionOne(ctx context.Context, userID, runID u
 		return false, err
 	}
 
+	// Bind mode (issue #804): default an auto-provisioned burst worker to `auto` ONLY when
+	// the owner has ≥1 auto_eligible anthropic_token, so the auto-select pool is non-empty
+	// and the worker never parks its run in pool_wait (autoselect.ReasonPoolEmpty); a
+	// pre-existing multi-token owner who never opted in gets `default`. Read via qtx for a
+	// snapshot consistent with the rest of the tx — holding the provision lock over this
+	// read buys no atomicity (the auto_eligible toggle runs under a different lock class),
+	// it just keeps the read in one transaction.
+	hasPool, err := qtx.UserHasAutoEligibleAnthropicToken(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	mode := workersvc.BindModeDefault
+	if hasPool {
+		mode = workersvc.BindModeAuto
+	}
+
 	wkr, err := qtx.CreateEphemeralHostedWorker(ctx, store.CreateEphemeralHostedWorkerParams{
 		UserID:           userID,
 		Name:             ephemeralWorkerName(runID),
@@ -263,8 +280,9 @@ func (p *EphemeralProvisioner) provisionOne(ctx context.Context, userID, runID u
 		HostedSize:       pgtype.Text{String: p.cfg.DefaultSize, Valid: true},
 		// Explicit true/false (Valid always), never NULL: on a hosted row a false is a
 		// real "no sidecar", matching CreateHostedWorker.
-		DockerEnabled:  pgtype.Bool{Bool: docker, Valid: true},
-		EphemeralRunID: runID,
+		DockerEnabled:     pgtype.Bool{Bool: docker, Valid: true},
+		EphemeralRunID:    runID,
+		AnthropicBindMode: mode,
 	})
 	if err != nil {
 		if isUniqueViolation(err) {

--- a/api/internal/store/auto_eligible_first_token_livedb_test.go
+++ b/api/internal/store/auto_eligible_first_token_livedb_test.go
@@ -1,0 +1,308 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// These tests pin issue #804 (PRD #111 D2) at the SQL layer against a REAL Postgres:
+//
+//   - InsertUserSecret / UpsertDefaultUserSecret born-auto-eligible ONLY for a user's
+//     first/sole anthropic_token, so a single-token owner has a non-empty auto-select
+//     pool and their auto-mode ephemeral workers never park in pool_wait, while token
+//     #2+ (the reserved-console-key hazard) stays opt-in false.
+//   - Rotation via UpsertDefaultUserSecret PRESERVES the existing opt-in/opt-out state.
+//   - CreateEphemeralHostedWorker persists the caller-supplied anthropic_bind_mode.
+//   - UserHasAutoEligibleAnthropicToken — the bit the ephemeral provisioner reads to
+//     choose `auto` vs `default`.
+//   - The 00182 backfill WHERE-clause: a user's SOLE token becomes eligible, a
+//     multi-token user's tokens are never touched.
+//
+// A fake store cannot exhibit any of these — the first-token subquery, the CHECK, and
+// the set-based backfill are all real-SQL behaviour. Every test is skipped unless
+// UZI_TEST_DATABASE_URL points at a throwaway Postgres (./e2e/run-store-it.sh provides
+// one and sweeps this package for the LiveDB suffix).
+
+// autoEligPool opens a migrated pool or skips when no throwaway DB is configured.
+func autoEligPool(t *testing.T) (context.Context, *store.Queries, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return ctx, store.New(pool), pool
+}
+
+// seedBareUser inserts a bare user and returns its id.
+func seedBareUser(ctx context.Context, t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	mustExec(ctx, t, pool, `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+		id, fmt.Sprintf("autoelig-%s@e2e", id))
+	return id
+}
+
+// TestInsertUserSecretFirstTokenAutoEligibleLiveDB: the first anthropic_token a user
+// stores is born auto_eligible=true; the second is false.
+func TestInsertUserSecretFirstTokenAutoEligibleLiveDB(t *testing.T) {
+	ctx, q, pool := autoEligPool(t)
+	user := seedBareUser(ctx, t, pool)
+
+	first, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken, Label: "subscription", WantDefault: true,
+		Ciphertext: []byte("ct1"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("insert first: %v", err)
+	}
+	if !first.AutoEligible {
+		t.Errorf("first anthropic_token auto_eligible = false, want true (a sole-token owner needs a non-empty auto-select pool)")
+	}
+
+	// With one eligible token, the provisioner's read must report a non-empty pool.
+	has, err := q.UserHasAutoEligibleAnthropicToken(ctx, user)
+	if err != nil {
+		t.Fatalf("UserHasAutoEligibleAnthropicToken: %v", err)
+	}
+	if !has {
+		t.Errorf("UserHasAutoEligibleAnthropicToken = false after a born-eligible first token, want true")
+	}
+
+	second, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken, Label: "console-key", WantDefault: false,
+		Ciphertext: []byte("ct2"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("insert second: %v", err)
+	}
+	if second.AutoEligible {
+		t.Errorf("second anthropic_token auto_eligible = true, want false (only the FIRST token opts in; #2 is the reserved-key hazard)")
+	}
+}
+
+// TestUpsertDefaultFirstTokenAutoEligibleLiveDB: the D14 alias's INSERT branch is
+// born-eligible only for a first token, and a rotation (its DO UPDATE branch) preserves
+// whatever opt-in/opt-out state the token already carried.
+func TestUpsertDefaultFirstTokenAutoEligibleLiveDB(t *testing.T) {
+	ctx, q, pool := autoEligPool(t)
+
+	// (a) First-token INSERT branch: born eligible.
+	userA := seedBareUser(ctx, t, pool)
+	a1, err := q.UpsertDefaultUserSecret(ctx, store.UpsertDefaultUserSecretParams{
+		UserID: userA, Kind: store.KindAnthropicToken, Ciphertext: []byte("a1"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("upsert first: %v", err)
+	}
+	if !a1.AutoEligible {
+		t.Errorf("UpsertDefaultUserSecret first-token auto_eligible = false, want true")
+	}
+
+	// (b) Rotation preserves an OPTED-OUT token as false. Insert a first token (born
+	// true), flip it off, then rotate via Upsert (hits DO UPDATE) — it must stay false.
+	userB := seedBareUser(ctx, t, pool)
+	b1, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: userB, Kind: store.KindAnthropicToken, Label: "default", WantDefault: true,
+		Ciphertext: []byte("b1"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("insert userB token: %v", err)
+	}
+	if _, err := q.SetUserSecretAutoEligible(ctx, store.SetUserSecretAutoEligibleParams{
+		ID: b1.ID, UserID: userB, Kind: store.KindAnthropicToken, AutoEligible: false,
+	}); err != nil {
+		t.Fatalf("opt userB token out: %v", err)
+	}
+	bRot, err := q.UpsertDefaultUserSecret(ctx, store.UpsertDefaultUserSecretParams{
+		UserID: userB, Kind: store.KindAnthropicToken, Ciphertext: []byte("b1-rot"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("rotate userB: %v", err)
+	}
+	if bRot.ID != b1.ID {
+		t.Fatalf("rotation created a new row (%s) instead of updating the default (%s)", bRot.ID, b1.ID)
+	}
+	if bRot.AutoEligible {
+		t.Errorf("rotation flipped an opted-OUT token back to eligible; auto_eligible = true, want false (rotation must preserve state)")
+	}
+
+	// (c) Rotation preserves an OPTED-IN token as true.
+	userC := seedBareUser(ctx, t, pool)
+	c1, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: userC, Kind: store.KindAnthropicToken, Label: "default", WantDefault: true,
+		Ciphertext: []byte("c1"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("insert userC token: %v", err)
+	}
+	if !c1.AutoEligible {
+		t.Fatalf("precondition: userC first token not born eligible")
+	}
+	cRot, err := q.UpsertDefaultUserSecret(ctx, store.UpsertDefaultUserSecretParams{
+		UserID: userC, Kind: store.KindAnthropicToken, Ciphertext: []byte("c1-rot"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("rotate userC: %v", err)
+	}
+	if !cRot.AutoEligible {
+		t.Errorf("rotation cleared an opted-IN token; auto_eligible = false, want true (rotation must preserve state)")
+	}
+}
+
+// TestUserHasAutoEligibleAnthropicTokenLiveDB pins the provisioner's decision input:
+// false with no token / only an opted-out token, true once a token is opted in.
+func TestUserHasAutoEligibleAnthropicTokenLiveDB(t *testing.T) {
+	ctx, q, pool := autoEligPool(t)
+
+	// No token at all → false.
+	empty := seedBareUser(ctx, t, pool)
+	if has, err := q.UserHasAutoEligibleAnthropicToken(ctx, empty); err != nil {
+		t.Fatalf("query (no token): %v", err)
+	} else if has {
+		t.Errorf("UserHasAutoEligibleAnthropicToken = true for a token-less user, want false")
+	}
+
+	// A single opted-OUT token → false. Insert (born true), then opt out.
+	user := seedBareUser(ctx, t, pool)
+	tok, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken, Label: "default", WantDefault: true,
+		Ciphertext: []byte("ct"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := q.SetUserSecretAutoEligible(ctx, store.SetUserSecretAutoEligibleParams{
+		ID: tok.ID, UserID: user, Kind: store.KindAnthropicToken, AutoEligible: false,
+	}); err != nil {
+		t.Fatalf("opt out: %v", err)
+	}
+	if has, err := q.UserHasAutoEligibleAnthropicToken(ctx, user); err != nil {
+		t.Fatalf("query (opted out): %v", err)
+	} else if has {
+		t.Errorf("UserHasAutoEligibleAnthropicToken = true with only an opted-out token, want false")
+	}
+
+	// Opt it back in → true.
+	if _, err := q.SetUserSecretAutoEligible(ctx, store.SetUserSecretAutoEligibleParams{
+		ID: tok.ID, UserID: user, Kind: store.KindAnthropicToken, AutoEligible: true,
+	}); err != nil {
+		t.Fatalf("opt in: %v", err)
+	}
+	if has, err := q.UserHasAutoEligibleAnthropicToken(ctx, user); err != nil {
+		t.Fatalf("query (opted in): %v", err)
+	} else if !has {
+		t.Errorf("UserHasAutoEligibleAnthropicToken = false with an opted-in token, want true")
+	}
+}
+
+// TestCreateEphemeralHostedWorkerPersistsBindModeLiveDB proves the caller-supplied
+// anthropic_bind_mode is written (issue #804): create with 'auto', read the column back.
+func TestCreateEphemeralHostedWorkerPersistsBindModeLiveDB(t *testing.T) {
+	fx := newFleetFixture(t)
+	runID := fx.queuedRun()
+
+	wkr, err := fx.q.CreateEphemeralHostedWorker(fx.ctx, store.CreateEphemeralHostedWorkerParams{
+		UserID:            fx.userID,
+		Name:              "ephemeral-" + runID.String(),
+		TokenHash:         tokenHash(),
+		TemplateDeclared:  pgtype.Text{String: "base", Valid: true},
+		HostedSize:        pgtype.Text{String: "m", Valid: true},
+		DockerEnabled:     pgtype.Bool{Bool: true, Valid: true},
+		EphemeralRunID:    runID,
+		AnthropicBindMode: "auto",
+	})
+	if err != nil {
+		t.Fatalf("CreateEphemeralHostedWorker: %v", err)
+	}
+	if wkr.AnthropicBindMode != "auto" {
+		t.Errorf("returned worker anthropic_bind_mode = %q, want \"auto\"", wkr.AnthropicBindMode)
+	}
+	var got string
+	if err := fx.pool.QueryRow(fx.ctx,
+		`SELECT anthropic_bind_mode FROM workers WHERE id = $1`, wkr.ID).Scan(&got); err != nil {
+		t.Fatalf("read back anthropic_bind_mode: %v", err)
+	}
+	if got != "auto" {
+		t.Errorf("persisted anthropic_bind_mode = %q, want \"auto\" (the caller-supplied mode must be stored)", got)
+	}
+}
+
+// TestBackfillSoleTokenAutoEligibleWhereClauseLiveDB reproduces migration 00182's exact
+// backfill WHERE-clause on seeded pre-migration-state rows (auto_eligible=false inserted
+// directly), which is the accepted alternative to asserting the migration itself — by the
+// time a test runs, 00182 has already applied to an empty table. A user's SOLE token is
+// made eligible; neither token of a two-token user is touched.
+func TestBackfillSoleTokenAutoEligibleWhereClauseLiveDB(t *testing.T) {
+	ctx, q, pool := autoEligPool(t)
+
+	sole := seedBareUser(ctx, t, pool)
+	multi := seedBareUser(ctx, t, pool)
+
+	// Seed rows in the PRE-backfill state (auto_eligible=false explicitly), bypassing
+	// InsertUserSecret's born-eligible logic so the backfill has something to do.
+	seedRaw := func(user uuid.UUID, label string) uuid.UUID {
+		id := uuid.New()
+		mustExec(ctx, t, pool,
+			`INSERT INTO user_secrets (id, user_id, kind, label, is_default, auto_eligible, ciphertext, sealed_with)
+			 VALUES ($1, $2, $3, $4, $5, false, $6, 'master')`,
+			id, user, store.KindAnthropicToken, label, label == "default", []byte("ct-"+label))
+		return id
+	}
+	soleTok := seedRaw(sole, "default")
+	multiA := seedRaw(multi, "default")
+	multiB := seedRaw(multi, "console-key")
+
+	// The 00182 Up statement, verbatim.
+	mustExec(ctx, t, pool, `
+UPDATE user_secrets s
+SET auto_eligible = true
+WHERE s.kind = 'anthropic_token'
+  AND NOT s.auto_eligible
+  AND NOT EXISTS (
+      SELECT 1 FROM user_secrets o
+      WHERE o.user_id = s.user_id AND o.kind = 'anthropic_token' AND o.id <> s.id
+  )`)
+
+	// The provisioner-facing read is the cleanest assertion of the outcome.
+	if has, err := q.UserHasAutoEligibleAnthropicToken(ctx, sole); err != nil {
+		t.Fatalf("read sole: %v", err)
+	} else if !has {
+		t.Errorf("sole-token user has no eligible token after backfill, want their token pooled")
+	}
+	if has, err := q.UserHasAutoEligibleAnthropicToken(ctx, multi); err != nil {
+		t.Fatalf("read multi: %v", err)
+	} else if has {
+		t.Errorf("a multi-token user's token was pooled by the backfill, want none touched (reserved-key hazard)")
+	}
+
+	// Column-level check too, so the assertion does not rest solely on the EXISTS query.
+	assertElig := func(id uuid.UUID, want bool) {
+		var got bool
+		if err := pool.QueryRow(ctx, `SELECT auto_eligible FROM user_secrets WHERE id = $1`, id).Scan(&got); err != nil {
+			t.Fatalf("read auto_eligible: %v", err)
+		}
+		if got != want {
+			t.Errorf("secret %s auto_eligible = %v, want %v", id, got, want)
+		}
+	}
+	assertElig(soleTok, true)
+	assertElig(multiA, false)
+	assertElig(multiB, false)
+}

--- a/api/internal/store/auto_eligible_first_token_livedb_test.go
+++ b/api/internal/store/auto_eligible_first_token_livedb_test.go
@@ -306,3 +306,60 @@ WHERE s.kind = 'anthropic_token'
 	assertElig(multiA, false)
 	assertElig(multiB, false)
 }
+
+// TestUpsertDefaultInsertBranchMultiTokenNotPooledLiveDB guards the D12 reserved-key-leak
+// path (issue #804 / PRD #111 D2). UpsertDefaultUserSecret's INSERT branch is reachable in
+// the D12 "tokens exist with no default" state (a user holds anthropic_tokens but none is
+// is_default), and an UNCONDITIONAL born-eligible there would pool a token for a user who
+// already holds other, possibly reserved, tokens. The NOT EXISTS first-token guard prevents
+// that: the row the upsert creates for a MULTI-token user must be born auto_eligible=false.
+//
+// Reaching the state precisely: InsertUserSecret forces the FIRST token to default, so seed
+// two tokens (neither labelled 'default', or the upsert's INSERT would collide with the
+// label-unique index — the mirror-image 500 the query header documents), then
+// ClearDefaultUserSecret to leave ≥2 tokens with zero is_default. The upsert then takes its
+// INSERT branch (no is_default row to conflict on) and creates a new 'default'-labelled row.
+func TestUpsertDefaultInsertBranchMultiTokenNotPooledLiveDB(t *testing.T) {
+	ctx, q, pool := autoEligPool(t)
+	user := seedBareUser(ctx, t, pool)
+
+	// Two tokens (labels are NOT 'default', to keep the upsert on its INSERT-success path
+	// rather than the label-collision 500). The first is forced default and born eligible.
+	if _, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken, Label: "subscription", WantDefault: true,
+		Ciphertext: []byte("t1"), SealedWith: store.SealedWithMaster,
+	}); err != nil {
+		t.Fatalf("insert first token: %v", err)
+	}
+	if _, err := q.InsertUserSecret(ctx, store.InsertUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken, Label: "console-key", WantDefault: false,
+		Ciphertext: []byte("t2"), SealedWith: store.SealedWithMaster,
+	}); err != nil {
+		t.Fatalf("insert second token: %v", err)
+	}
+
+	// Clear the default → the goal state: ≥2 anthropic_tokens, zero is_default.
+	if _, err := q.ClearDefaultUserSecret(ctx, store.ClearDefaultUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken,
+	}); err != nil {
+		t.Fatalf("clear default: %v", err)
+	}
+
+	// The upsert now fires its INSERT branch (no is_default row to conflict on), creating a
+	// new 'default'-labelled row.
+	row, err := q.UpsertDefaultUserSecret(ctx, store.UpsertDefaultUserSecretParams{
+		UserID: user, Kind: store.KindAnthropicToken, Ciphertext: []byte("t3"), SealedWith: store.SealedWithMaster,
+	})
+	if err != nil {
+		t.Fatalf("upsert default (INSERT branch): %v", err)
+	}
+
+	// The reserved-key-leak guard: a multi-token user's newly created row is NOT born pooled.
+	if row.AutoEligible {
+		t.Errorf("newly created default for a multi-token user is auto_eligible=true; the reserved-key-leak guard requires false")
+	}
+	// ...and it IS the new default (the upsert's intent).
+	if !row.IsDefault {
+		t.Errorf("newly created default is_default=false, want true (the upsert must create the default)")
+	}
+}

--- a/api/internal/store/ephemeral_provision_integration_test.go
+++ b/api/internal/store/ephemeral_provision_integration_test.go
@@ -123,13 +123,14 @@ func TestListUnplaceableQueuedRunsForEphemeralLiveDB(t *testing.T) {
 		runID := queuedRunWithCaps(fx2, []string{"docker"})
 		// Bind an ephemeral worker to it.
 		if _, err := fx2.q.CreateEphemeralHostedWorker(fx2.ctx, store.CreateEphemeralHostedWorkerParams{
-			UserID:           fx2.userID,
-			Name:             "ephemeral-" + runID.String(),
-			TokenHash:        tokenHash(),
-			TemplateDeclared: pgtype.Text{String: "base", Valid: true},
-			HostedSize:       pgtype.Text{String: "m", Valid: true},
-			DockerEnabled:    pgtype.Bool{Bool: true, Valid: true},
-			EphemeralRunID:   runID,
+			UserID:            fx2.userID,
+			Name:              "ephemeral-" + runID.String(),
+			TokenHash:         tokenHash(),
+			TemplateDeclared:  pgtype.Text{String: "base", Valid: true},
+			HostedSize:        pgtype.Text{String: "m", Valid: true},
+			DockerEnabled:     pgtype.Bool{Bool: true, Valid: true},
+			EphemeralRunID:    runID,
+			AnthropicBindMode: "default",
 		}); err != nil {
 			t.Fatalf("CreateEphemeralHostedWorker: %v", err)
 		}
@@ -161,13 +162,14 @@ func TestListUnplaceableQueuedRunsForEphemeralLiveDB(t *testing.T) {
 		atCap.worker("base-only", capOf(1), false)
 		boundRun := queuedRunWithCaps(atCap, []string{"docker"})
 		if _, err := atCap.q.CreateEphemeralHostedWorker(atCap.ctx, store.CreateEphemeralHostedWorkerParams{
-			UserID:           atCap.userID,
-			Name:             "ephemeral-" + boundRun.String(),
-			TokenHash:        tokenHash(),
-			TemplateDeclared: pgtype.Text{String: "base", Valid: true},
-			HostedSize:       pgtype.Text{String: "m", Valid: true},
-			DockerEnabled:    pgtype.Bool{Bool: true, Valid: true},
-			EphemeralRunID:   boundRun,
+			UserID:            atCap.userID,
+			Name:              "ephemeral-" + boundRun.String(),
+			TokenHash:         tokenHash(),
+			TemplateDeclared:  pgtype.Text{String: "base", Valid: true},
+			HostedSize:        pgtype.Text{String: "m", Valid: true},
+			DockerEnabled:     pgtype.Bool{Bool: true, Valid: true},
+			EphemeralRunID:    boundRun,
+			AnthropicBindMode: "default",
 		}); err != nil {
 			t.Fatalf("seed at-cap ephemeral worker: %v", err)
 		}
@@ -208,13 +210,14 @@ func TestEphemeralAndPersistentQuotaCountsAreSeparateLiveDB(t *testing.T) {
 		 VALUES ($1, 'persistent', $2, 'base', 'hosted', 'm', false)`, fx.userID, tokenHash())
 	// One ephemeral hosted worker bound to the run.
 	if _, err := fx.q.CreateEphemeralHostedWorker(fx.ctx, store.CreateEphemeralHostedWorkerParams{
-		UserID:           fx.userID,
-		Name:             "ephemeral-" + runID.String(),
-		TokenHash:        tokenHash(),
-		TemplateDeclared: pgtype.Text{String: "base", Valid: true},
-		HostedSize:       pgtype.Text{String: "m", Valid: true},
-		DockerEnabled:    pgtype.Bool{Bool: true, Valid: true},
-		EphemeralRunID:   runID,
+		UserID:            fx.userID,
+		Name:              "ephemeral-" + runID.String(),
+		TokenHash:         tokenHash(),
+		TemplateDeclared:  pgtype.Text{String: "base", Valid: true},
+		HostedSize:        pgtype.Text{String: "m", Valid: true},
+		DockerEnabled:     pgtype.Bool{Bool: true, Valid: true},
+		EphemeralRunID:    runID,
+		AnthropicBindMode: "default",
 	}); err != nil {
 		t.Fatalf("CreateEphemeralHostedWorker: %v", err)
 	}
@@ -243,13 +246,14 @@ func TestCreateEphemeralHostedWorkerOnePerRunLiveDB(t *testing.T) {
 
 	mk := func(name string) error {
 		_, err := fx.q.CreateEphemeralHostedWorker(fx.ctx, store.CreateEphemeralHostedWorkerParams{
-			UserID:           fx.userID,
-			Name:             name,
-			TokenHash:        tokenHash(),
-			TemplateDeclared: pgtype.Text{String: "base", Valid: true},
-			HostedSize:       pgtype.Text{String: "m", Valid: true},
-			DockerEnabled:    pgtype.Bool{Bool: true, Valid: true},
-			EphemeralRunID:   runID,
+			UserID:            fx.userID,
+			Name:              name,
+			TokenHash:         tokenHash(),
+			TemplateDeclared:  pgtype.Text{String: "base", Valid: true},
+			HostedSize:        pgtype.Text{String: "m", Valid: true},
+			DockerEnabled:     pgtype.Bool{Bool: true, Valid: true},
+			EphemeralRunID:    runID,
+			AnthropicBindMode: "default",
 		})
 		return err
 	}

--- a/api/internal/store/ephemeral_teardown_livedb_test.go
+++ b/api/internal/store/ephemeral_teardown_livedb_test.go
@@ -22,13 +22,14 @@ import (
 func seedEphemeralWorkerBound(fx *fleetFixture, runID uuid.UUID) uuid.UUID {
 	fx.t.Helper()
 	w, err := fx.q.CreateEphemeralHostedWorker(fx.ctx, store.CreateEphemeralHostedWorkerParams{
-		UserID:           fx.userID,
-		Name:             "ephemeral-" + runID.String(),
-		TokenHash:        tokenHash(),
-		TemplateDeclared: pgtype.Text{String: "base", Valid: true},
-		HostedSize:       pgtype.Text{String: "m", Valid: true},
-		DockerEnabled:    pgtype.Bool{Bool: true, Valid: true},
-		EphemeralRunID:   runID,
+		UserID:            fx.userID,
+		Name:              "ephemeral-" + runID.String(),
+		TokenHash:         tokenHash(),
+		TemplateDeclared:  pgtype.Text{String: "base", Valid: true},
+		HostedSize:        pgtype.Text{String: "m", Valid: true},
+		DockerEnabled:     pgtype.Bool{Bool: true, Valid: true},
+		EphemeralRunID:    runID,
+		AnthropicBindMode: "default",
 	})
 	if err != nil {
 		fx.t.Fatalf("CreateEphemeralHostedWorker: %v", err)

--- a/api/internal/store/hosted_workers.sql.go
+++ b/api/internal/store/hosted_workers.sql.go
@@ -102,19 +102,20 @@ func (q *Queries) CountHostedWorkersForUser(ctx context.Context, userID uuid.UUI
 }
 
 const createEphemeralHostedWorker = `-- name: CreateEphemeralHostedWorker :one
-INSERT INTO workers (user_id, name, token_hash, template_declared, kind, hosted_size, docker_enabled, ephemeral, ephemeral_run_id)
-VALUES ($1, $2, $3, $4, 'hosted', $5, $6, true, $7::uuid)
+INSERT INTO workers (user_id, name, token_hash, template_declared, kind, hosted_size, docker_enabled, ephemeral, ephemeral_run_id, anthropic_bind_mode)
+VALUES ($1, $2, $3, $4, 'hosted', $5, $6, true, $7::uuid, $8)
 RETURNING id, user_id, name, token_hash, status, last_heartbeat_at, version, created_at, updated_at, template_declared, template_reported, max_concurrent_runs, stats_cpu_pct, stats_mem_bytes, stats_mem_limit_bytes, stats_source, kind, hosted_size, hosted_generation, docker_enabled, anthropic_secret_id, anthropic_bind_mode, online_since, draining_since, capabilities, ephemeral, ephemeral_run_id
 `
 
 type CreateEphemeralHostedWorkerParams struct {
-	UserID           uuid.UUID   `json:"user_id"`
-	Name             string      `json:"name"`
-	TokenHash        []byte      `json:"token_hash"`
-	TemplateDeclared pgtype.Text `json:"template_declared"`
-	HostedSize       pgtype.Text `json:"hosted_size"`
-	DockerEnabled    pgtype.Bool `json:"docker_enabled"`
-	EphemeralRunID   uuid.UUID   `json:"ephemeral_run_id"`
+	UserID            uuid.UUID   `json:"user_id"`
+	Name              string      `json:"name"`
+	TokenHash         []byte      `json:"token_hash"`
+	TemplateDeclared  pgtype.Text `json:"template_declared"`
+	HostedSize        pgtype.Text `json:"hosted_size"`
+	DockerEnabled     pgtype.Bool `json:"docker_enabled"`
+	EphemeralRunID    uuid.UUID   `json:"ephemeral_run_id"`
+	AnthropicBindMode string      `json:"anthropic_bind_mode"`
 }
 
 // Insert a run-bound EPHEMERAL hosted worker (PRD #529 M2). It is CreateHostedWorker
@@ -132,6 +133,10 @@ type CreateEphemeralHostedWorkerParams struct {
 // requires template_declared/hosted_size NOT NULL on a hosted row, docker_enabled an
 // explicit true/false). ephemeral_run_id is cast to a non-null uuid so the param is a
 // plain uuid.UUID: the provisioner always has a concrete run to bind to.
+//
+// anthropic_bind_mode is now caller-supplied (issue #804): the provisioner passes `auto`
+// when the owner has ≥1 auto_eligible anthropic_token (a non-empty auto-select pool) and
+// `default` otherwise, so an auto worker never parks a run in pool_wait on an empty pool.
 func (q *Queries) CreateEphemeralHostedWorker(ctx context.Context, arg CreateEphemeralHostedWorkerParams) (Worker, error) {
 	row := q.db.QueryRow(ctx, createEphemeralHostedWorker,
 		arg.UserID,
@@ -141,6 +146,7 @@ func (q *Queries) CreateEphemeralHostedWorker(ctx context.Context, arg CreateEph
 		arg.HostedSize,
 		arg.DockerEnabled,
 		arg.EphemeralRunID,
+		arg.AnthropicBindMode,
 	)
 	var i Worker
 	err := row.Scan(

--- a/api/internal/store/migrations/00182_backfill_sole_token_auto_eligible.sql
+++ b/api/internal/store/migrations/00182_backfill_sole_token_auto_eligible.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- Backfill (issue #804): a user's SOLE anthropic_token becomes auto-select eligible, so
+-- their auto-mode ephemeral workers can spend it instead of parking in pool_wait. Scoped
+-- to users with EXACTLY ONE anthropic_token — the reserved-console-key hazard (00087) is
+-- inherently multi-token, so a multi-token user is never touched here (their opt-in stays
+-- explicit). Keyed on token COUNT, never on is_default: tying eligibility to the default
+-- pointer would silently pool a console key a user later promotes to default (PRD #111 D2).
+UPDATE user_secrets s
+SET auto_eligible = true
+WHERE s.kind = 'anthropic_token'
+  AND NOT s.auto_eligible
+  AND NOT EXISTS (
+      SELECT 1 FROM user_secrets o
+      WHERE o.user_id = s.user_id AND o.kind = 'anthropic_token' AND o.id <> s.id
+  );
+
+-- +goose Down
+-- No-op, deliberately and unavoidably: once applied, a backfilled row is indistinguishable
+-- from a genuine owner opt-in, so Down cannot restore false without clobbering real opt-ins.
+-- (Mirrors 00088's lossy-down precedent.)
+SELECT 1;

--- a/api/internal/store/queries/hosted_workers.sql
+++ b/api/internal/store/queries/hosted_workers.sql
@@ -113,8 +113,12 @@ SELECT count(*) FROM workers WHERE user_id = @user_id AND kind = 'hosted' AND ep
 -- requires template_declared/hosted_size NOT NULL on a hosted row, docker_enabled an
 -- explicit true/false). ephemeral_run_id is cast to a non-null uuid so the param is a
 -- plain uuid.UUID: the provisioner always has a concrete run to bind to.
-INSERT INTO workers (user_id, name, token_hash, template_declared, kind, hosted_size, docker_enabled, ephemeral, ephemeral_run_id)
-VALUES (@user_id, @name, @token_hash, @template_declared, 'hosted', @hosted_size, @docker_enabled, true, @ephemeral_run_id::uuid)
+--
+-- anthropic_bind_mode is now caller-supplied (issue #804): the provisioner passes `auto`
+-- when the owner has ≥1 auto_eligible anthropic_token (a non-empty auto-select pool) and
+-- `default` otherwise, so an auto worker never parks a run in pool_wait on an empty pool.
+INSERT INTO workers (user_id, name, token_hash, template_declared, kind, hosted_size, docker_enabled, ephemeral, ephemeral_run_id, anthropic_bind_mode)
+VALUES (@user_id, @name, @token_hash, @template_declared, 'hosted', @hosted_size, @docker_enabled, true, @ephemeral_run_id::uuid, @anthropic_bind_mode)
 RETURNING *;
 
 -- name: DeleteEphemeralWorkerForRun :execrows

--- a/api/internal/store/queries/user_secrets.sql
+++ b/api/internal/store/queries/user_secrets.sql
@@ -33,7 +33,7 @@
 -- This does NOT replace D12's transaction. It converts one silent failure into
 -- either the right answer or a loud one; serialising the set-default swap and the
 -- delete-default check is a different job, and still M2's.
-INSERT INTO user_secrets (user_id, kind, label, is_default, ciphertext, sealed_with)
+INSERT INTO user_secrets (user_id, kind, label, is_default, auto_eligible, ciphertext, sealed_with)
 VALUES (@user_id, @kind, @label,
         -- Scoped to (user_id, kind), never to user_id alone: the partial unique
         -- index this defends is per-(user_id, kind), and under D9's future
@@ -42,6 +42,15 @@ VALUES (@user_id, @kind, @label,
         -- invisible-token bug, one kind over.
         @want_default::boolean
             OR NOT EXISTS (SELECT 1 FROM user_secrets WHERE user_id = @user_id AND kind = @kind),
+        -- auto_eligible (PRD #111 D2 / issue #804): a user's FIRST/SOLE anthropic_token
+        -- is born opted INTO the auto-select pool, so a single-token owner's auto-mode
+        -- ephemeral workers have a non-empty pool to spend and never park in pool_wait.
+        -- Token #2+ stays opt-in false (the reserved-console-key hazard is multi-token).
+        -- Reuses the SAME first-token subquery as is_default just above; the
+        -- @kind = 'anthropic_token' guard keeps 00087's CHECK
+        -- (NOT auto_eligible OR kind = 'anthropic_token') satisfied for a future
+        -- non-anthropic first token.
+        (@kind = 'anthropic_token' AND NOT EXISTS (SELECT 1 FROM user_secrets WHERE user_id = @user_id AND kind = @kind)),
         @ciphertext, @sealed_with)
 RETURNING id, kind, label, is_default, auto_eligible, created_at, updated_at;
 
@@ -90,12 +99,25 @@ RETURNING id, kind, label, is_default, auto_eligible, created_at, updated_at;
 -- to make it unreachable again; until then this comment is the warning. (A
 -- no-default user whose rows are all labelled something else is fine: the insert
 -- simply creates a new default labelled 'default'.)
-INSERT INTO user_secrets (user_id, kind, label, is_default, ciphertext, sealed_with)
-VALUES ($1, $2, 'default', true, $3, $4)
+INSERT INTO user_secrets (user_id, kind, label, is_default, auto_eligible, ciphertext, sealed_with)
+VALUES ($1, $2, 'default', true,
+        -- auto_eligible (PRD #111 D2 / issue #804): born opted into the auto-select
+        -- pool ONLY when this is the user's first token of the kind — the SAME
+        -- first-token guard InsertUserSecret uses. The NOT EXISTS is load-bearing, not
+        -- belt-and-braces: the INSERT branch of this upsert is REACHABLE in the D12
+        -- "tokens exist with no default" state (see the header comment), so an
+        -- unconditional true would pool a token for a user who already holds other,
+        -- possibly reserved, tokens — a reserved-key leak. The $2 = 'anthropic_token'
+        -- guard keeps 00087's kind CHECK satisfied even though kind is always
+        -- 'anthropic_token' on this path in practice.
+        ($2 = 'anthropic_token' AND NOT EXISTS (SELECT 1 FROM user_secrets WHERE user_id = $1 AND kind = $2)),
+        $3, $4)
 ON CONFLICT (user_id, kind) WHERE is_default DO UPDATE
     SET ciphertext = EXCLUDED.ciphertext,
         sealed_with = EXCLUDED.sealed_with,
         updated_at = now()
+        -- NOT auto_eligible: rotation must PRESERVE the existing opt-in/opt-out state
+        -- the owner chose. Only the value moves on conflict (issue #804).
 RETURNING id, kind, label, is_default, auto_eligible, created_at, updated_at;
 
 -- name: GetUserSecretCiphertext :one
@@ -336,3 +358,13 @@ WHERE user_id = $1 AND sealed_with = 'master';
 UPDATE user_secrets
 SET ciphertext = @ciphertext, sealed_with = 'dek', updated_at = now()
 WHERE id = @id AND user_id = @user_id AND sealed_with = 'master';
+
+-- name: UserHasAutoEligibleAnthropicToken :one
+-- True iff the user has opted at least one Anthropic token into the auto-select pool
+-- (PRD #111 M2 D2). The ephemeral provisioner (issue #804) reads this to decide a
+-- burst worker's bind mode: `auto` when the pool is non-empty, else `default`, so an
+-- auto worker never parks a run in pool_wait on an empty pool (autoselect.ReasonPoolEmpty).
+SELECT EXISTS (
+    SELECT 1 FROM user_secrets
+    WHERE user_id = @user_id AND kind = 'anthropic_token' AND auto_eligible
+);

--- a/api/internal/store/user_secrets.sql.go
+++ b/api/internal/store/user_secrets.sql.go
@@ -330,7 +330,7 @@ func (q *Queries) GetUserSecretMetaByID(ctx context.Context, arg GetUserSecretMe
 }
 
 const insertUserSecret = `-- name: InsertUserSecret :one
-INSERT INTO user_secrets (user_id, kind, label, is_default, ciphertext, sealed_with)
+INSERT INTO user_secrets (user_id, kind, label, is_default, auto_eligible, ciphertext, sealed_with)
 VALUES ($1, $2, $3,
         -- Scoped to (user_id, kind), never to user_id alone: the partial unique
         -- index this defends is per-(user_id, kind), and under D9's future
@@ -339,6 +339,15 @@ VALUES ($1, $2, $3,
         -- invisible-token bug, one kind over.
         $4::boolean
             OR NOT EXISTS (SELECT 1 FROM user_secrets WHERE user_id = $1 AND kind = $2),
+        -- auto_eligible (PRD #111 D2 / issue #804): a user's FIRST/SOLE anthropic_token
+        -- is born opted INTO the auto-select pool, so a single-token owner's auto-mode
+        -- ephemeral workers have a non-empty pool to spend and never park in pool_wait.
+        -- Token #2+ stays opt-in false (the reserved-console-key hazard is multi-token).
+        -- Reuses the SAME first-token subquery as is_default just above; the
+        -- @kind = 'anthropic_token' guard keeps 00087's CHECK
+        -- (NOT auto_eligible OR kind = 'anthropic_token') satisfied for a future
+        -- non-anthropic first token.
+        ($2 = 'anthropic_token' AND NOT EXISTS (SELECT 1 FROM user_secrets WHERE user_id = $1 AND kind = $2)),
         $5, $6)
 RETURNING id, kind, label, is_default, auto_eligible, created_at, updated_at
 `
@@ -785,12 +794,25 @@ func (q *Queries) SetUserSecretDefault(ctx context.Context, arg SetUserSecretDef
 }
 
 const upsertDefaultUserSecret = `-- name: UpsertDefaultUserSecret :one
-INSERT INTO user_secrets (user_id, kind, label, is_default, ciphertext, sealed_with)
-VALUES ($1, $2, 'default', true, $3, $4)
+INSERT INTO user_secrets (user_id, kind, label, is_default, auto_eligible, ciphertext, sealed_with)
+VALUES ($1, $2, 'default', true,
+        -- auto_eligible (PRD #111 D2 / issue #804): born opted into the auto-select
+        -- pool ONLY when this is the user's first token of the kind — the SAME
+        -- first-token guard InsertUserSecret uses. The NOT EXISTS is load-bearing, not
+        -- belt-and-braces: the INSERT branch of this upsert is REACHABLE in the D12
+        -- "tokens exist with no default" state (see the header comment), so an
+        -- unconditional true would pool a token for a user who already holds other,
+        -- possibly reserved, tokens — a reserved-key leak. The $2 = 'anthropic_token'
+        -- guard keeps 00087's kind CHECK satisfied even though kind is always
+        -- 'anthropic_token' on this path in practice.
+        ($2 = 'anthropic_token' AND NOT EXISTS (SELECT 1 FROM user_secrets WHERE user_id = $1 AND kind = $2)),
+        $3, $4)
 ON CONFLICT (user_id, kind) WHERE is_default DO UPDATE
     SET ciphertext = EXCLUDED.ciphertext,
         sealed_with = EXCLUDED.sealed_with,
         updated_at = now()
+        -- NOT auto_eligible: rotation must PRESERVE the existing opt-in/opt-out state
+        -- the owner chose. Only the value moves on conflict (issue #804).
 RETURNING id, kind, label, is_default, auto_eligible, created_at, updated_at
 `
 
@@ -863,4 +885,22 @@ func (q *Queries) UpsertDefaultUserSecret(ctx context.Context, arg UpsertDefault
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const userHasAutoEligibleAnthropicToken = `-- name: UserHasAutoEligibleAnthropicToken :one
+SELECT EXISTS (
+    SELECT 1 FROM user_secrets
+    WHERE user_id = $1 AND kind = 'anthropic_token' AND auto_eligible
+)
+`
+
+// True iff the user has opted at least one Anthropic token into the auto-select pool
+// (PRD #111 M2 D2). The ephemeral provisioner (issue #804) reads this to decide a
+// burst worker's bind mode: `auto` when the pool is non-empty, else `default`, so an
+// auto worker never parks a run in pool_wait on an empty pool (autoselect.ReasonPoolEmpty).
+func (q *Queries) UserHasAutoEligibleAnthropicToken(ctx context.Context, userID uuid.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, userHasAutoEligibleAnthropicToken, userID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
 }

--- a/api/internal/uzidocs/embed/anthropic-token.md
+++ b/api/internal/uzidocs/embed/anthropic-token.md
@@ -101,11 +101,25 @@ its picker to **Auto-select from the pool** (or `uzi worker set-token
 <worker-id> --auto`) and each claim spends whichever of your **pooled**
 tokens has the most rate-limit headroom.
 
-It is opt-in **per token**, and the pool starts empty. On **Settings →
-Anthropic tokens**, tick **Auto-select from this token** on each one you are
-happy for uzi to spend; `uzi token pool <name> --on|--off` does the same. The
-pool is empty by default on purpose — one that helped itself to every
-credential would spend the one you reserved for something else.
+Your **first (or only) token starts in the pool automatically** — a
+single-token account gets auto-selection for free, nothing to opt in. That's
+safe by construction: with one token, the pool and your default are the same
+credential, so pooling it opens no new spend surface.
+
+**Every token after that starts opt-in**, and stays out until you say
+otherwise. On **Settings → Anthropic tokens**, tick **Auto-select from this
+token** on each one you are happy for uzi to spend; `uzi token pool <name>
+--on|--off` does the same. That's deliberate — a second token that helped
+itself into the pool would spend a credential you reserved for something
+else, which is the whole reason it starts out.
+
+> **A throwaway worker defaults to auto-select too.** A [worker uzi
+> auto-provisions for an unmet
+> capability](./scheduling.md#auto-provisioning-a-worker-for-an-unmet-capability)
+> comes up set to **Auto-select from the pool** as long as you have at least
+> one pooled token, so a burst of throwaway workers spreads across your pool
+> instead of leaning on one credential. If your pool is empty, it quietly
+> spends your default token instead, the same as any other worker.
 
 **Opting a token in does not guarantee it gets picked.** Beside the toggle,
 each pooled token shows whether auto-selection could pick it *right now*:

--- a/docs/anthropic-token.md
+++ b/docs/anthropic-token.md
@@ -101,11 +101,25 @@ its picker to **Auto-select from the pool** (or `uzi worker set-token
 <worker-id> --auto`) and each claim spends whichever of your **pooled**
 tokens has the most rate-limit headroom.
 
-It is opt-in **per token**, and the pool starts empty. On **Settings →
-Anthropic tokens**, tick **Auto-select from this token** on each one you are
-happy for uzi to spend; `uzi token pool <name> --on|--off` does the same. The
-pool is empty by default on purpose — one that helped itself to every
-credential would spend the one you reserved for something else.
+Your **first (or only) token starts in the pool automatically** — a
+single-token account gets auto-selection for free, nothing to opt in. That's
+safe by construction: with one token, the pool and your default are the same
+credential, so pooling it opens no new spend surface.
+
+**Every token after that starts opt-in**, and stays out until you say
+otherwise. On **Settings → Anthropic tokens**, tick **Auto-select from this
+token** on each one you are happy for uzi to spend; `uzi token pool <name>
+--on|--off` does the same. That's deliberate — a second token that helped
+itself into the pool would spend a credential you reserved for something
+else, which is the whole reason it starts out.
+
+> **A throwaway worker defaults to auto-select too.** A [worker uzi
+> auto-provisions for an unmet
+> capability](./scheduling.md#auto-provisioning-a-worker-for-an-unmet-capability)
+> comes up set to **Auto-select from the pool** as long as you have at least
+> one pooled token, so a burst of throwaway workers spreads across your pool
+> instead of leaning on one credential. If your pool is empty, it quietly
+> spends your default token instead, the same as any other worker.
 
 **Opting a token in does not guarantee it gets picked.** Beside the toggle,
 each pooled token shows whether auto-selection could pick it *right now*:

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -23468,3 +23468,33 @@ combining `user_id` / `auto_approve` / `schedule_id` / `resume_of_run_id` / `kin
   `manual`/`autopilot`.
 - **Surfaced end to end.** RunDTO (`trigger_source`), `uzi run get --json` / `--field`, the
   `uzi admin runs` table, and the web `interface Run` mirror.
+
+## 594. Issue #804 — auto-provisioned EPHEMERAL workers default to Anthropic bind-mode `auto`, but only when the owner's auto-select pool is non-empty; a sole anthropic_token is born pool-eligible
+
+Serves human: hosted ephemeral (burst) workers should use the owner's auto-select pool by default
+rather than their single default token, without regressing owners who never opted in. Terse contract
+here; issue #804 and the query/provisioner code comments carry the richer rationale.
+
+- **Ephemeral-only default flip, made CONDITIONAL.** `EphemeralProvisioner.provisionOne`
+  (`api/internal/hostedsvc/ephemeral.go`) sets `AnthropicBindMode = auto` for an auto-provisioned burst
+  worker **only when the owner has ≥1 `auto_eligible` anthropic_token** (queried via new
+  `UserHasAutoEligibleAnthropicToken`); otherwise it falls back to `default`. A blanket `auto` would
+  park the run in `pool_wait` (`autoselect.ReasonPoolEmpty`) for any owner with an empty pool — and,
+  since §581 (PRD #754) removed the owner-default fallback, there is no rescue — including a
+  pre-existing multi-token user who never opted in. The conditional avoids that stall/regression.
+- **A user's FIRST/SOLE anthropic_token is now born `auto_eligible = true`**, so a single-token owner's
+  pool is non-empty and their ephemeral run auto-selects their only token. Applied at insert on BOTH
+  write paths — `InsertUserSecret` and `UpsertDefaultUserSecret` — each guarded by the SAME
+  `@kind = 'anthropic_token' AND NOT EXISTS (… same user, same kind)` first-token subquery, so the
+  auto-eligibility is tied to *being the first anthropic_token*, never to the `is_default` pointer.
+- **Token #2+ stays opt-in `auto_eligible = false`**, preserving PRD #111 D2's reserved-console-key
+  protection: a later-added token is never silently pooled. The `kind = 'anthropic_token'` predicate on
+  the born-eligible clause also keeps migration 00087's `CHECK (NOT auto_eligible OR kind =
+  'anthropic_token')` satisfied and prevents a reserved-key leak on the upsert path.
+- **Migration `00182_backfill_sole_token_auto_eligible.sql`** backfills existing sole-anthropic_token
+  users to `auto_eligible = true`, so users created before this change get the same non-empty pool.
+- **Persistent hosted workers are deliberately unchanged** (still default to `default`). This is an
+  ephemeral/burst-worker default only.
+
+Cross-refs: PRD #754 pool-only auto lane + `pool_wait` (§581); PRD #111 D2 opt-in / reserved-console-key
+protection and D7's removed fallback (§581); migration 00087's `auto_eligible` CHECK.

--- a/web/src/mocks/mockApi.autoEligible.test.ts
+++ b/web/src/mocks/mockApi.autoEligible.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+
+// issue #804: the api now births a user's FIRST/SOLE anthropic_token with
+// auto_eligible=true, so a single-token user has a non-empty auto-select pool;
+// token #2+ stays opt-in (auto_eligible=false). Both mock creation paths —
+// createAnthropicToken (PRD #104 M2) and the putAnthropicToken D14 alias — must
+// mirror that first-token-only rule, or the mock teaches the wrong lesson. The
+// multi-token assertion is REQUIRED so the mock cannot silently diverge from the
+// server's first-token-ONLY behaviour by making every token eligible.
+//
+// Each test reloads the module against a fresh (empty) localStorage so the
+// in-memory store re-seeds, then clears the seeded anthropic tokens to drive the
+// first-token rule from an empty pool. The demo vault seeds UNLOCKED, so no
+// explicit unlock is needed before a create.
+
+const KEY = "uzi.mock.v3";
+
+function installStorage(initial: Record<string, string> = {}): void {
+  const m = new Map<string, string>(Object.entries(initial));
+  const storage = {
+    getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+    setItem: (k: string, v: string) => void m.set(k, String(v)),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+}
+
+async function reload() {
+  vi.resetModules();
+  return (await import("./mockApi")).mockApi;
+}
+
+// Remove every seeded anthropic token so the next create is genuinely the first.
+// The default cannot be deleted while siblings exist (D6), so drop the
+// non-defaults first, then the (now sole) default.
+async function clearAnthropicTokens(api: Awaited<ReturnType<typeof reload>>): Promise<void> {
+  const toks = (await api.listSecrets()).secrets.filter((s) => s.kind === "anthropic_token");
+  for (const s of toks.filter((t) => !t.is_default)) await api.deleteAnthropicTokenById(s.id);
+  for (const s of toks.filter((t) => t.is_default)) await api.deleteAnthropicTokenById(s.id);
+  const after = (await api.listSecrets()).secrets.filter((s) => s.kind === "anthropic_token");
+  expect(after).toHaveLength(0);
+}
+
+beforeEach(() => installStorage({ [KEY]: "" }));
+afterEach(() => vi.resetModules());
+
+describe("mockApi — anthropic_token auto_eligible birth rule (issue #804)", () => {
+  it("createAnthropicToken: the FIRST token is born eligible, the SECOND is opt-in", async () => {
+    const api = await reload();
+    await clearAnthropicTokens(api);
+
+    const { secret: first } = await api.createAnthropicToken("sk-ant-mock-first", "first-key", false);
+    expect(first.auto_eligible).toBe(true);
+
+    const { secret: second } = await api.createAnthropicToken("sk-ant-mock-second", "second-key", false);
+    expect(second.auto_eligible).toBe(false);
+  });
+
+  it("putAnthropicToken (D14 alias): the sole first token is born eligible", async () => {
+    const api = await reload();
+    await clearAnthropicTokens(api);
+
+    const { secret } = await api.putAnthropicToken("sk-ant-mock-default");
+    expect(secret.label).toBe("default");
+    expect(secret.auto_eligible).toBe(true);
+  });
+
+  it("putAnthropicToken then createAnthropicToken: the second token via the CRUD path is opt-in", async () => {
+    const api = await reload();
+    await clearAnthropicTokens(api);
+
+    const { secret: first } = await api.putAnthropicToken("sk-ant-mock-default");
+    expect(first.auto_eligible).toBe(true);
+
+    const { secret: second } = await api.createAnthropicToken("sk-ant-mock-next", "next-key", false);
+    expect(second.auto_eligible).toBe(false);
+  });
+});

--- a/web/src/mocks/mockApi.ts
+++ b/web/src/mocks/mockApi.ts
@@ -2450,9 +2450,11 @@ export const mockApi = {
       kind: "anthropic_token",
       label: "default",
       is_default: true,
-      // A new token is never pooled (PRD #111 D2) — mirror the server default or
-      // the mock teaches the wrong lesson.
-      auto_eligible: false,
+      // The user's FIRST/SOLE anthropic_token is born pooled (issue #804) so a
+      // single-token user has a non-empty auto-select pool; token #2+ stays
+      // opt-in. Compute it faithfully off the "no existing anthropic_token" rule,
+      // evaluated BEFORE pushing this row, or the mock teaches the wrong lesson.
+      auto_eligible: secrets.filter((s) => s.kind === "anthropic_token").length === 0,
       created_at: now,
       updated_at: now,
     };
@@ -2482,7 +2484,10 @@ export const mockApi = {
       kind: "anthropic_token",
       label: trimmed,
       is_default: wantDefault,
-      auto_eligible: false,
+      // The user's FIRST/SOLE anthropic_token is born pooled (issue #804); token
+      // #2+ stays opt-in (auto_eligible false). Mirror the server or the mock
+      // teaches the wrong lesson.
+      auto_eligible: first,
       created_at: now,
       updated_at: now,
     };


### PR DESCRIPTION
Implements issue #804.

Closes #804

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-804`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The first Anthropic token is now automatically included in token auto-selection.
  * Additional Anthropic tokens remain opt-in and preserve their existing eligibility during rotation.
  * Auto-provisioned ephemeral workers use pooled token selection when an eligible token is available; otherwise, they use the default token.
  * Existing sole-token accounts are updated to support automatic selection.

* **Documentation**
  * Updated token and hosted worker documentation to describe the new selection behavior.

* **Tests**
  * Added coverage for token eligibility, worker provisioning, migration behavior, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->