### PR TITLE
uzi self-improvement

### DIFF
--- a/agent/src/judge-runner.ts
+++ b/agent/src/judge-runner.ts
@@ -661,7 +661,8 @@ export function calibrateReview(review: ReviewRequest, failureClass: string | nu
 // summary runner (PRD #362 M3a), which parses the same fenced/prose-wrapped JSON shape.
 export function extractJsonObject(text: string): unknown {
   const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
-  const candidate = fence ? fence[1] : sliceFirstObject(text);
+  const inner = fence ? fence[1]! : text;
+  const candidate = sliceFirstObject(inner);
   if (!candidate) throw new Error("no JSON object found in the model output");
   return JSON.parse(candidate);
 }

--- a/agent/test/judge-runner.test.ts
+++ b/agent/test/judge-runner.test.ts
@@ -366,6 +366,13 @@ describe("parseReview", () => {
     assert.equal(r.model, "haiku");
   });
 
+  it("parses a fenced block with prose before the object inside the fence", () => {
+    const text =
+      '```json\nNote: focused on correctness.\n{"verdict":"ok","summary":"s","recommendations":[]}\n```';
+    const r = parseReview(text, "haiku");
+    assert.equal(r.verdict, "ok");
+  });
+
   it("parses JSON embedded in prose and drops unknown categories", () => {
     const text =
       'Here is my assessment: {"verdict":"issues","summary":"s","recommendations":[' +


### PR DESCRIPTION
Autonomous self-improvement change (PRD #46). Picks one top improvement per cycle.

Tracking issue: #296

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
### Self-improvement run

**Test evidence** (run by the worker — this repo has no CI):

- ✅ api: go test ./... — passed (exit 0)
- ✅ web: npm test — passed (exit 0)
- ✅ web: npm run build — passed (exit 0)
- ✅ agent: npm run typecheck — passed (exit 0)
- ✅ agent: npm test — passed (exit 0)

The bot cannot merge to `main` (protected-branch merge rights are humans only). A human must review and merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured review results when JSON is enclosed in code fences or preceded by explanatory text.
  * Ensured valid verdicts are parsed consistently from both formatted and unformatted responses.

* **Tests**
  * Added coverage for fenced JSON containing preceding prose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->