### PR TITLE
ci(devbox): fetch full history so the branch-clobber guard has a merge base (#912)

### DIFF
--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Checkout uzi
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
+          # Full history. The branch-clobber guard below diffs
+          # main...chore/devbox-toolchain-update (three-dot), which needs a merge base; a
+          # shallow checkout (default depth 1) has none, so that diff fails and the guard
+          # fail-closes on EVERY run once the branch exists, never updating it (observed on
+          # run 33485168333: "no merge base" -> stuck). fetch-depth 0 gives the merge base.
+          fetch-depth: 0
           # The PAT (if set) is what lets the bump PR trigger its own CI; else the
           # built-in token, which can still push and open a PR where the repo setting
           # allows it, and otherwise the issue fallback runs.


### PR DESCRIPTION
Third and final publish-path fix. Run [33485168333](https://github.com/vtmocanu/uzi/actions/runs/33485168333) produced a **real** toolchain bump and validated it (base-image build green), but no PR opened.

## Root cause
The clobber guard diffs `main...chore/devbox-toolchain-update` (three-dot), which needs a **merge base**. The checkout is **shallow** (default depth 1), so once the bot branch exists there is no common ancestor — `git diff` exits 128 (`no merge base`), the guard fail-closes (correctly not clobbering, but blocking the PR), and it recurs every run. (This is exactly the diff-failure case the guard's own fail-closed logic was hardened for in #913 — it fired for real.)

## Fix
`fetch-depth: 0` on the checkout. Full history gives the three-dot diff a merge base; the guard then correctly sees only the lock differs → lease-overwrites the branch → opens the PR (the Actions-create-PR setting is now on).

Bump mechanism (#930) and install (#926) are unchanged and working; this only unblocks the publish. Lint green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch safety checks in the development environment update workflow by ensuring complete repository history is available.
  * No other workflow behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->