### PR TITLE
bug(tui): selected floor-row title is invisible on light terminals

### DIFF
--- a/api/cmd/uzi/tui.go
+++ b/api/cmd/uzi/tui.go
@@ -225,17 +225,26 @@ func newTUIModel(ctx context.Context, c uzicli.Client, startRun string) tuiModel
 	return m
 }
 
-func (m tuiModel) Init() tea.Cmd {
+// initCmds is the pre-batch Cmd slice, extracted from Init so a test can inspect the
+// startup commands without executing any (some members block on tea.Tick).
+// tea.RequestBackgroundColor is the bare Cmd value (a func() Msg): issuing it from
+// startup makes the terminal report its background colour, which drives the
+// tea.BackgroundColorMsg handler in Update that flips m.dark and rebuilds the palette —
+// so a light terminal actually gets the light theme instead of the dark default.
+func (m tuiModel) initCmds() []tea.Cmd {
 	cmds := []tea.Cmd{m.fetchRunsCmd(m.board.admin), m.fetchSecretsCmd(),
-		m.fetchRateLimitsCmd(), m.fetchSettingsCmd(), tickCmd(), stripTickCmd()}
+		m.fetchRateLimitsCmd(), m.fetchSettingsCmd(), tickCmd(), stripTickCmd(),
+		tea.RequestBackgroundColor}
 	if m.skewCheck {
 		cmds = append(cmds, m.fetchBuildInfoCmd(), skewTickCmd())
 	}
 	if m.view == viewDetail {
 		cmds = append(cmds, m.loadDetailCmd(m.detail.runID), m.openStreamCmd(m.detail.runID))
 	}
-	return tea.Batch(cmds...)
+	return cmds
 }
+
+func (m tuiModel) Init() tea.Cmd { return tea.Batch(m.initCmds()...) }
 
 func tickCmd() tea.Cmd {
 	return tea.Tick(boardPollInterval, func(time.Time) tea.Msg { return boardTickMsg{} })

--- a/api/cmd/uzi/tui_all_lane_test.go
+++ b/api/cmd/uzi/tui_all_lane_test.go
@@ -120,3 +120,41 @@ func TestDetailAllLaneIconIsNeutral(t *testing.T) {
 		t.Errorf("the active stalled lane should still show ▲\n%s", rail)
 	}
 }
+
+// TestDetailSelectedCrewRoleHasExplicitForeground pins issue #938's crew-rail half: a SELECTED
+// crew lane's role carries the explicit tungsten foreground so it stays legible on the warm
+// selection bar (on a light terminal the default-ink role would otherwise wash into it), the
+// same treatment boardRow's selected floor title got. Unselected rows keep the default ink
+// (nil fg). Mutation that reddens this: reverting laneRow's selected role to paintSeg(nil,...).
+func TestDetailSelectedCrewRoleHasExplicitForeground(t *testing.T) {
+	now := time.Now()
+	// Two actors -> lanes [ALL, lead, coder]. Move selection ALL -> lead -> coder so a REAL
+	// lane (never the meta ALL row) is selected; coder never carries the lead's inline meter,
+	// so the role span is drawn exactly as laneRow builds it, with nothing appended after it.
+	m := loadDetail(t, "a44a44a4-4444", "ok", []apitypes.MessageDTO{
+		msgDTO(1, "text", "lead", "", "", "planning", now.Add(-time.Minute)),
+		msgDTO(2, "text", "coder", "toolu_a", "impl", "writing", now),
+	})
+	m = press(t, m, "j")
+	m = press(t, m, "j")
+	if sel, ok := m.detail.selectedLane(); !ok || sel.Role != "coder" {
+		t.Fatalf("expected the coder lane selected, got %+v (ok=%v)", sel, ok)
+	}
+	// Raw content (NOT ansi.Strip): the assertion is about the SGR the role span carries.
+	out := m.View().Content
+
+	// The selected role is painted with tungsten over the warm selection bar, exactly as
+	// laneRow draws it (leading space + capped role). This is the span that vanishes if the
+	// selected branch falls back to nil fg.
+	selRole := paintSeg(m.pal.tungsten, m.pal.selBg, false, " "+m.renderer.Plain("coder", 14))
+	if !strings.Contains(out, selRole) {
+		t.Errorf("selected crew role is not painted with the tungsten fg over the selection bar\nwant span %q\n%s", selRole, out)
+	}
+	// Control (non-vacuous): the UNSELECTED lead role must NOT carry the tungsten-over-selBg
+	// span — an unselected row has no selection bg and keeps the default ink. If this appeared,
+	// the assertion above could pass for the wrong reason (every role tungsten-painted).
+	unselRole := paintSeg(m.pal.tungsten, m.pal.selBg, false, " "+m.renderer.Plain("lead", 14))
+	if strings.Contains(out, unselRole) {
+		t.Errorf("unselected crew role must keep default ink, not tungsten over the selection bar\ngot span %q\n%s", unselRole, out)
+	}
+}

--- a/api/cmd/uzi/tui_board.go
+++ b/api/cmd/uzi/tui_board.go
@@ -902,6 +902,14 @@ func (m tuiModel) boardRow(r apitypes.RunListItemDTO, sel bool, mc boardMarkerCo
 		titleC = m.pal.amber
 	case bandDone:
 		titleC = m.pal.faintC
+	default: // floor band
+		// Unselected floor rows keep nil (default ink, the intended quiet look). A SELECTED
+		// floor row needs an explicit foreground or its default-fg title vanishes into the
+		// warm selection bar on a light terminal (dark-on-dark). tungsten (ld(#7c5200,#c9a061))
+		// resolves dark-on-light-selBg and light-on-dark-selBg, matching the selected id ink.
+		if sel {
+			titleC = m.pal.tungsten
+		}
 	}
 	idC := m.pal.faintC
 	if sel {

--- a/api/cmd/uzi/tui_detail.go
+++ b/api/cmd/uzi/tui_detail.go
@@ -752,10 +752,16 @@ func (m tuiModel) laneRow(l agentLane, selected bool, st crewState, suffix strin
 		dot, dotC = "◉", m.pal.tungsten
 	}
 	cursor := paintSeg(nil, bg, false, " ")
+	var roleFg color.Color
 	if selected {
 		cursor = paintSeg(m.pal.tungsten, bg, true, "▸")
+		// A selected row needs an explicit role foreground or its default-ink title vanishes into
+		// the warm selection bar (issue #938, mirroring boardRow's selected floor title): tungsten
+		// (ld(#7c5200,#c9a061)) reads on both selBg variants and matches the ▸ cursor and selected
+		// id ink. Unselected rows keep nil (the intended quiet default ink).
+		roleFg = m.pal.tungsten
 	}
-	line := cursor + paintSeg(dotC, bg, false, dot) + paintSeg(nil, bg, false, " "+m.renderer.Plain(l.Role, 14))
+	line := cursor + paintSeg(dotC, bg, false, dot) + paintSeg(roleFg, bg, false, " "+m.renderer.Plain(l.Role, 14))
 	if suffix != "" {
 		// A ·N ordinal disambiguates two lanes of one role (laneSuffixes). It is DERIVED, not
 		// the opaque SDK invocation id, so the id tail never reaches the rail — a lone role

--- a/api/cmd/uzi/tui_model_test.go
+++ b/api/cmd/uzi/tui_model_test.go
@@ -810,7 +810,7 @@ func TestTUIViewsStripControlBytesFromUntrustedText(t *testing.T) {
 	// asserting on "safe" would pass via the title even if the rail never drew the label (vacuous).
 	// "credsafe" carries the same hostile control/bidi bytes but a tail that only the rail's
 	// account-label render can put into the frame.
-	detailCredLabel := "\x1b[2J\u202E\x07\x01credsafe" //nolint:gosec // G101: not a credential \u2014 a hostile control/bidi-byte sanitization fixture whose display label happens to contain "cred"; the test asserts it is stripped, never a secret.
+	detailCredLabel := "\x1b[2J\u202E\x07\x01credsafe" //nolint:gosec // G101: not a credential - a hostile control/bidi-byte sanitization fixture whose display label happens to contain "cred"; the test asserts it is stripped, never a secret.
 	next, _ = detail.Update(detailLoadedMsg{
 		// A hostile milestone title exercises renderMilestones' crew-rail draw (D7): the
 		// in-progress id makes the row render its title through renderer.Plain. The hostile

--- a/api/cmd/uzi/tui_model_test.go
+++ b/api/cmd/uzi/tui_model_test.go
@@ -810,7 +810,7 @@ func TestTUIViewsStripControlBytesFromUntrustedText(t *testing.T) {
 	// asserting on "safe" would pass via the title even if the rail never drew the label (vacuous).
 	// "credsafe" carries the same hostile control/bidi bytes but a tail that only the rail's
 	// account-label render can put into the frame.
-	detailCredLabel := "\x1b[2J\u202E\x07\x01credsafe"
+	detailCredLabel := "\x1b[2J\u202E\x07\x01credsafe" //nolint:gosec // G101: not a credential \u2014 a hostile control/bidi-byte sanitization fixture whose display label happens to contain "cred"; the test asserts it is stripped, never a secret.
 	next, _ = detail.Update(detailLoadedMsg{
 		// A hostile milestone title exercises renderMilestones' crew-rail draw (D7): the
 		// in-progress id makes the row render its title through renderer.Plain. The hostile

--- a/api/cmd/uzi/tui_model_test.go
+++ b/api/cmd/uzi/tui_model_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image/color"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -2284,6 +2285,87 @@ func TestDetailAddFrameTotalOnZeroValue(t *testing.T) {
 	d.addFrame(laneFrame{Seq: 1})
 	if len(d.frames) != 1 {
 		t.Errorf("dedup did not hold; seen map not initialized: got %d frames", len(d.frames))
+	}
+}
+
+// TestTUIBoardSelectedFloorTitleHasExplicitForeground pins issue #938 fix 2: a SELECTED
+// floor-band row's title carries the explicit tungsten foreground, so it stays legible on
+// the warm selection bar (on a light terminal the default-ink title would otherwise be
+// dark-on-dark). Unselected floor titles keep the default ink (nil fg). Mutation that
+// reddens this: reverting the floor-band `default` case to leave titleC nil.
+func TestTUIBoardSelectedFloorTitleHasExplicitForeground(t *testing.T) {
+	fake := &uzicli.FakeClient{Runs: []apitypes.RunListItemDTO{
+		{RunDTO: apitypes.RunDTO{ID: "aaaaaaaa-1", Kind: "issue", Status: "running", IssueTitle: "selectedtitle"}},
+		{RunDTO: apitypes.RunDTO{ID: "bbbbbbbb-2", Kind: "issue", Status: "running", IssueTitle: "othertitle"}},
+	}}
+	m := tuiTestModel(t, fake, "")
+	next, _ := m.Update(boardRunsMsg{runs: fake.Runs})
+	m = next.(tuiModel)
+	out := m.View().Content
+
+	// The selected (cursor-0) floor title is drawn exactly as boardRow draws it: the tungsten
+	// fg over the warm selection bg. Reconstruct that span and require it present — this is the
+	// span that disappears if the floor-band default case is dropped.
+	selTitle := paintSeg(m.pal.tungsten, m.pal.selBg, false, "selectedtitle")
+	if !strings.Contains(out, selTitle) {
+		t.Errorf("selected floor title is not painted with the tungsten fg over the selection bar\nwant span %q\n%s", selTitle, out)
+	}
+	// Control (non-vacuous): the UNSELECTED floor title must NOT carry the tungsten fg — it
+	// keeps the default ink (nil fg). If this span appeared, the assertion above could pass for
+	// the wrong reason (every floor title tungsten-painted regardless of selection).
+	otherTungsten := paintSeg(m.pal.tungsten, nil, false, "othertitle")
+	if strings.Contains(out, otherTungsten) {
+		t.Errorf("unselected floor title must keep default ink, not the tungsten fg\ngot span %q\n%s", otherTungsten, out)
+	}
+}
+
+// TestTUIInitRequestsBackgroundColor pins issue #938 fix 1: Init issues
+// tea.RequestBackgroundColor at startup so the terminal reports its background and the
+// BackgroundColorMsg path can flip the theme. We inspect initCmds without executing any Cmd
+// (the tick cmds block on tea.Tick), comparing function pointers.
+func TestTUIInitRequestsBackgroundColor(t *testing.T) {
+	fake := &uzicli.FakeClient{}
+	m := tuiTestModel(t, fake, "")
+	want := reflect.ValueOf(tea.RequestBackgroundColor).Pointer()
+	found := false
+	for _, c := range m.initCmds() {
+		if c != nil && reflect.ValueOf(c).Pointer() == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("initCmds does not include tea.RequestBackgroundColor; the theme probe will never fire")
+	}
+}
+
+// TestTUIBackgroundColorMsgFlipsPalette pins that the BackgroundColorMsg handler flips
+// m.dark and rebuilds the palette in BOTH directions — the path fix 1 makes actually fire.
+func TestTUIBackgroundColorMsgFlipsPalette(t *testing.T) {
+	fake := &uzicli.FakeClient{}
+	m := tuiTestModel(t, fake, "") // dark=true by default
+	darkSelBg := m.pal.selBg
+
+	// A light background reported by the terminal → light theme.
+	next, _ := m.Update(tea.BackgroundColorMsg{Color: lipgloss.Color("#ffffff")})
+	m = next.(tuiModel)
+	if m.dark {
+		t.Errorf("a light background must set m.dark=false")
+	}
+	if fgSGR(m.pal.selBg) == fgSGR(darkSelBg) {
+		t.Errorf("selBg did not change when flipping to the light theme")
+	}
+	if fgSGR(m.pal.selBg) != fgSGR(newPalette(false).selBg) {
+		t.Errorf("flipped selBg %v does not match newPalette(false).selBg %v", m.pal.selBg, newPalette(false).selBg)
+	}
+
+	// The converse: a dark background reported → dark theme again.
+	next, _ = m.Update(tea.BackgroundColorMsg{Color: lipgloss.Color("#000000")})
+	m = next.(tuiModel)
+	if !m.dark {
+		t.Errorf("a dark background must set m.dark=true")
+	}
+	if fgSGR(m.pal.selBg) != fgSGR(newPalette(true).selBg) {
+		t.Errorf("flipped-back selBg %v does not match newPalette(true).selBg %v", m.pal.selBg, newPalette(true).selBg)
 	}
 }
 


### PR DESCRIPTION
Implements issue #938.

Closes #938

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-938`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved floor-row title visibility when a row is selected.
  - Improved selected crew-role visibility in detail views.
  - The interface now adapts its color palette correctly when switching between light and dark terminal themes.
  - Terminal background detection is performed during startup for more accurate theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->