### PR TITLE
fix(release): harden cosign install against transient download flake (#945)

### DIFF
--- a/.github/actions/install-cosign/action.yml
+++ b/.github/actions/install-cosign/action.yml
@@ -1,0 +1,54 @@
+# Retrying, checksum-pinned cosign install (issue #945).
+#
+# Replaces sigstore/cosign-installer on the release signing path. The action
+# exposes no retry hook, so a transient TLS/download failure on one runner
+# (curl exit 35, observed on release.yml run 33503117288) failed a publish job
+# and -- because publish-release needs: every publish job -- stalled the whole
+# GitHub Release until an operator re-ran the job by hand.
+#
+# This fetches the SAME pinned cosign binary the action fetched, but with curl
+# retries + backoff, and verifies it against an embedded sha256. An immutable
+# release means an immutable binary, so pinning the digest here is strictly
+# stronger than trusting the fetched checksums file and matches how this repo
+# pins its actions by SHA. To bump cosign: change cosign-release at every call
+# site in release.yml AND add the new digest to COSIGN_SHA256 below.
+name: Install cosign
+description: Install a pinned cosign release with a retrying, checksum-verified download.
+inputs:
+  cosign-release:
+    description: cosign release tag to install (e.g. v3.1.3).
+    required: true
+runs:
+  using: composite
+  steps:
+    # ${{ inputs.* }} goes through env: (never interpolated into the script body).
+    - name: Install cosign (pinned, retrying)
+      shell: bash
+      env:
+        COSIGN_RELEASE: ${{ inputs.cosign-release }}
+      run: |
+        set -euo pipefail
+        declare -A COSIGN_SHA256=(
+          [v3.1.3]=4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
+        )
+        expected="${COSIGN_SHA256[$COSIGN_RELEASE]:-}"
+        if [ -z "$expected" ]; then
+          echo "::error::install-cosign: no pinned sha256 for cosign $COSIGN_RELEASE; add it to COSIGN_SHA256 in .github/actions/install-cosign/action.yml." >&2
+          exit 1
+        fi
+        dir="$(mktemp -d)"
+        # --retry-all-errors covers the transient TLS-connect failure (curl exit 35)
+        # this action exists to survive; 5 attempts with exponential backoff.
+        curl --fail --location --show-error --silent \
+          --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused \
+          --connect-timeout 15 --max-time 300 \
+          -o "$dir/cosign" \
+          "https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE}/cosign-linux-amd64"
+        got="$(sha256sum "$dir/cosign" | awk '{print $1}')"
+        if [ "$got" != "$expected" ]; then
+          echo "::error::install-cosign: cosign $COSIGN_RELEASE sha256 mismatch (got $got, expected $expected)." >&2
+          exit 1
+        fi
+        # /usr/local/bin is on PATH and runner-writable (the action's own default dir).
+        install -m 0755 "$dir/cosign" /usr/local/bin/cosign
+        cosign version

--- a/.github/actions/install-cosign/action.yml
+++ b/.github/actions/install-cosign/action.yml
@@ -26,7 +26,9 @@ runs:
       shell: bash
       env:
         COSIGN_RELEASE: ${{ inputs.cosign-release }}
-      run: |
+      # github-env: the only $GITHUB_PATH write is a constant ($HOME/.local/bin),
+      # never attacker input -- see the inline note at the write site below.
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
         declare -A COSIGN_SHA256=(
           [v3.1.3]=4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
@@ -37,10 +39,13 @@ runs:
           exit 1
         fi
         dir="$(mktemp -d)"
-        # --retry-all-errors covers the transient TLS-connect failure (curl exit 35)
-        # this action exists to survive; 5 attempts with exponential backoff.
+        # --retry-all-errors is what makes curl retry the transient TLS-connect
+        # failure (exit 35) this action exists to survive -- plain --retry does not
+        # cover connection-level errors. Up to 5 retries with curl's default
+        # exponential backoff. linux-amd64 matches every publish job's
+        # `platforms: linux/amd64`.
         curl --fail --location --show-error --silent \
-          --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused \
+          --retry 5 --retry-all-errors \
           --connect-timeout 15 --max-time 300 \
           -o "$dir/cosign" \
           "https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE}/cosign-linux-amd64"
@@ -49,6 +54,14 @@ runs:
           echo "::error::install-cosign: cosign $COSIGN_RELEASE sha256 mismatch (got $got, expected $expected)." >&2
           exit 1
         fi
-        # /usr/local/bin is on PATH and runner-writable (the action's own default dir).
-        install -m 0755 "$dir/cosign" /usr/local/bin/cosign
-        cosign version
+        # Install into a user-writable dir and put it on PATH for later steps via
+        # $GITHUB_PATH -- avoids assuming write access to a system dir (holds on any
+        # runner, not just GitHub-hosted), matching how the upstream action and the
+        # setup-* actions install their tools.
+        dest="$HOME/.local/bin"
+        mkdir -p "$dest"
+        install -m 0755 "$dir/cosign" "$dest/cosign"
+        # Constant path, not attacker input (github-env suppressed on the run: line).
+        echo "$dest" >> "$GITHUB_PATH"
+        # $GITHUB_PATH only affects SUBSEQUENT steps, so verify by full path here.
+        "$dest/cosign" version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,12 +174,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
+      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
+      # download failure on one runner stalled the whole Release; this survives it
+      # while keeping the same pinned cosign version. Needs the repo checked out
+      # first (every publish job's actions/checkout runs above).
+      - uses: ./.github/actions/install-cosign
         with:
-          # cosign 3.x uses the new default bundle format, which REQUIRES installer v4.
-          # The installer has NO floating v4 tag, so `@v4` does NOT resolve -- pin a full
-          # version (v4.1.2). Keep the installer and cosign-release bumped together
-          # (installer v4.x with cosign 3.x).
           cosign-release: 'v3.1.3'
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
@@ -230,12 +231,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
+      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
+      # download failure on one runner stalled the whole Release; this survives it
+      # while keeping the same pinned cosign version. Needs the repo checked out
+      # first (every publish job's actions/checkout runs above).
+      - uses: ./.github/actions/install-cosign
         with:
-          # cosign 3.x uses the new default bundle format, which REQUIRES installer v4.
-          # The installer has NO floating v4 tag, so `@v4` does NOT resolve -- pin a full
-          # version (v4.1.2). Keep the installer and cosign-release bumped together
-          # (installer v4.x with cosign 3.x).
           cosign-release: 'v3.1.3'
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
@@ -276,12 +278,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
+      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
+      # download failure on one runner stalled the whole Release; this survives it
+      # while keeping the same pinned cosign version. Needs the repo checked out
+      # first (every publish job's actions/checkout runs above).
+      - uses: ./.github/actions/install-cosign
         with:
-          # cosign 3.x uses the new default bundle format, which REQUIRES installer v4.
-          # The installer has NO floating v4 tag, so `@v4` does NOT resolve -- pin a full
-          # version (v4.1.2). Keep the installer and cosign-release bumped together
-          # (installer v4.x with cosign 3.x).
           cosign-release: 'v3.1.3'
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
@@ -361,12 +364,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
+      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
+      # download failure on one runner stalled the whole Release; this survives it
+      # while keeping the same pinned cosign version. Needs the repo checked out
+      # first (every publish job's actions/checkout runs above).
+      - uses: ./.github/actions/install-cosign
         with:
-          # cosign 3.x uses the new default bundle format, which REQUIRES installer v4.
-          # The installer has NO floating v4 tag, so `@v4` does NOT resolve -- pin a full
-          # version (v4.1.2). Keep the installer and cosign-release bumped together
-          # (installer v4.x with cosign 3.x).
           cosign-release: 'v3.1.3'
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
@@ -504,12 +508,13 @@ jobs:
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v4.2.4
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
+      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
+      # download failure on one runner stalled the whole Release; this survives it
+      # while keeping the same pinned cosign version. Needs the repo checked out
+      # first (every publish job's actions/checkout runs above).
+      - uses: ./.github/actions/install-cosign
         with:
-          # cosign 3.x uses the new default bundle format, which REQUIRES installer v4.
-          # The installer has NO floating v4 tag, so `@v4` does NOT resolve -- pin a full
-          # version (v4.1.2). Keep the installer and cosign-release bumped together
-          # (installer v4.x with cosign 3.x).
           cosign-release: 'v3.1.3'
       - name: helm registry login (GHCR)
         # --password-stdin keeps the token out of the process argv. Authenticates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,11 +174,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
-      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
-      # download failure on one runner stalled the whole Release; this survives it
-      # while keeping the same pinned cosign version. Needs the repo checked out
-      # first (every publish job's actions/checkout runs above).
+      # Retrying, checksum-pinned cosign install (issue #945; rationale in the action
+      # header). Needs the repo checked out first (actions/checkout runs above).
       - uses: ./.github/actions/install-cosign
         with:
           cosign-release: 'v3.1.3'
@@ -231,11 +228,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
-      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
-      # download failure on one runner stalled the whole Release; this survives it
-      # while keeping the same pinned cosign version. Needs the repo checked out
-      # first (every publish job's actions/checkout runs above).
+      # Retrying, checksum-pinned cosign install (issue #945; rationale in the action
+      # header). Needs the repo checked out first (actions/checkout runs above).
       - uses: ./.github/actions/install-cosign
         with:
           cosign-release: 'v3.1.3'
@@ -278,11 +272,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
-      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
-      # download failure on one runner stalled the whole Release; this survives it
-      # while keeping the same pinned cosign version. Needs the repo checked out
-      # first (every publish job's actions/checkout runs above).
+      # Retrying, checksum-pinned cosign install (issue #945; rationale in the action
+      # header). Needs the repo checked out first (actions/checkout runs above).
       - uses: ./.github/actions/install-cosign
         with:
           cosign-release: 'v3.1.3'
@@ -364,11 +355,8 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
-      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
-      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
-      # download failure on one runner stalled the whole Release; this survives it
-      # while keeping the same pinned cosign version. Needs the repo checked out
-      # first (every publish job's actions/checkout runs above).
+      # Retrying, checksum-pinned cosign install (issue #945; rationale in the action
+      # header). Needs the repo checked out first (actions/checkout runs above).
       - uses: ./.github/actions/install-cosign
         with:
           cosign-release: 'v3.1.3'
@@ -508,11 +496,8 @@ jobs:
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v4.2.4
-      # Local composite: retrying, checksum-pinned cosign install (issue #945). The
-      # upstream sigstore/cosign-installer exposes no retry hook, so a transient TLS
-      # download failure on one runner stalled the whole Release; this survives it
-      # while keeping the same pinned cosign version. Needs the repo checked out
-      # first (every publish job's actions/checkout runs above).
+      # Retrying, checksum-pinned cosign install (issue #945; rationale in the action
+      # header). Needs the repo checked out first (actions/checkout runs above).
       - uses: ./.github/actions/install-cosign
         with:
           cosign-release: 'v3.1.3'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ through `[0.52.0]`.)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release publish jobs tolerate a transient cosign download failure ([#946](https://github.com/vtmocanu/uzi/pull/946)).**
+  The image and chart signing jobs now install a pinned, checksum-verified cosign through a local action that retries the download, so a one-off TLS hiccup on a runner no longer fails a publish job and stalls the GitHub Release (issue [#945](https://github.com/vtmocanu/uzi/issues/945)).
+
 ## [0.74.0] - 2026-09-01
 
 ### Added


### PR DESCRIPTION
## Problem

`release.yml`'s five publish jobs (`publish-api`, `publish-web`, `publish-controller`, `publish-agent`, `publish-chart`) each ran `sigstore/cosign-installer@v4.1.2`, which exposes no retry hook. A per-runner transient TLS download failure while fetching the pinned cosign binary (curl exit 35, seen on run [33503117288](https://github.com/vtmocanu/uzi/actions/runs/33503117288) / `v0.74.0`) failed `publish-controller`. Because `publish-release` `needs:` every publish job, one network hiccup stalled the whole GitHub Release until an operator re-ran the failed job by hand. Fixes #945.

## Fix

New local composite action `.github/actions/install-cosign` that fetches the **same pinned cosign `v3.1.3`** binary with `curl --retry 5 --retry-all-errors --retry-connrefused` + backoff, then verifies it against an **embedded sha256** (`4629c757…`) and fails closed on mismatch. All five jobs now `uses: ./.github/actions/install-cosign`.

- Keeps the pinned cosign version (`v3.1.3`).
- Adds retry (the actual fix) **and** digest pinning, which is strictly stronger than the action's fetch-and-verify trust model.
- No new third-party dependency on the signing path (chosen over wrapping the action with a community retry action such as `Wandalen/wretry.action`).

## Design choice (for review)

The issue proposed 3 options; I picked a variant of #2 (direct retrying install) over #1 (retry around the action) because GitHub Actions has no native step-level retry for a `uses:` step, and adding a third-party retry-wrapper action to the release **signing** path is a worse supply-chain tradeoff than a transparent, self-owned, digest-pinned `curl`. Happy to switch to keeping the action + a retry wrapper if preferred.

## Scope

`cosign-installer` appears **only** in `release.yml` (no other workflow uses it), so this is the complete fix for the reported flake.

## Bump note

To bump cosign later: change `cosign-release` at each call site **and** add the new digest to `COSIGN_SHA256` in the action (documented in the action header). `release.yml` runs only on `v*` tags, so a wrong digest would surface at release time, not on PR CI.

## Validation

`actionlint`, `yamllint` (repo `.yamllint`), `zizmor` (no new findings; action.yml clean), and `shellcheck -s bash` on the embedded script all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Release publishing now uses a verified signing-tool installation process for more consistent artifact signing.
  - Improved resilience to temporary download issues with retries and timeouts.
  - Release jobs now validate the tool version and verify download integrity before continuing.
  - Unsupported versions or failed verification stop publishing early to help prevent incomplete or improperly signed artifacts.

- **Documentation**
  - Added an unreleased changelog entry describing these release reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->