### PR TITLE
controller: evicted zombie pod permanently badges a healthy hosted worker "Upgrade failed"

### DIFF
--- a/controller/internal/kube/rollhealth.go
+++ b/controller/internal/kube/rollhealth.go
@@ -234,12 +234,26 @@ func deriveRollHealth(pods []corev1.Pod, wantHash, replicaFailure string, now ti
 
 	// Prefer a pod matching what the deployment asks for. A pod carrying a different
 	// hash is the OLD one still terminating, which says nothing about the new one.
-	var current *corev1.Pod
+	var current, fallback *corev1.Pod
 	for i := range pods {
-		if pods[i].Annotations[AnnotationSpecHash] == wantHash {
-			current = &pods[i]
-			break
+		if pods[i].Annotations[AnnotationSpecHash] != wantHash {
+			continue
 		}
+		p := &pods[i]
+		// A terminal or terminating pod says nothing about the live rollout; remember
+		// one only so an all-terminal wantHash set keeps today's verdict rather than
+		// silently becoming `rolling`.
+		if p.Status.Phase == corev1.PodFailed || p.Status.Phase == corev1.PodSucceeded || p.DeletionTimestamp != nil {
+			if fallback == nil {
+				fallback = p
+			}
+			continue
+		}
+		current = p
+		break
+	}
+	if current == nil {
+		current = fallback // only terminal pods matched: preserve status quo, do not drop to rolling
 	}
 	if current == nil {
 		// Only stale pods: the new one is not up yet. Same state as the gap.

--- a/controller/internal/kube/rollhealth.go
+++ b/controller/internal/kube/rollhealth.go
@@ -242,9 +242,13 @@ func deriveRollHealth(pods []corev1.Pod, wantHash, replicaFailure string, now ti
 		p := &pods[i]
 		// A terminal or terminating pod says nothing about the live rollout; remember
 		// one only so an all-terminal wantHash set keeps today's verdict rather than
-		// silently becoming `rolling`.
+		// silently becoming `rolling`. Keep the OLDEST such pod (earliest creation), not
+		// the first seen, so the fallback verdict is order-independent: the age arm below
+		// keys on CreationTimestamp, so retaining a list-order-arbitrary terminal pod would
+		// make an all-terminal set read `rolling` or `stuck` depending on List() order.
+		// Oldest is also the honest proxy for "how long has this worker been down".
 		if p.Status.Phase == corev1.PodFailed || p.Status.Phase == corev1.PodSucceeded || p.DeletionTimestamp != nil {
-			if fallback == nil {
+			if fallback == nil || p.CreationTimestamp.Before(&fallback.CreationTimestamp) {
 				fallback = p
 			}
 			continue

--- a/controller/internal/kube/rollhealth_test.go
+++ b/controller/internal/kube/rollhealth_test.go
@@ -229,6 +229,51 @@ func TestDeriveRollHealth(t *testing.T) {
 				}
 			},
 		},
+		{
+			// The bug: two pods from one ReplicaSet share wantHash — a Failed/Evicted zombie
+			// stuck in PodInitializing and a Running+Ready replacement. Selecting the FIRST
+			// match picks the zombie (name-order List is deterministic), whose age then trips
+			// the stuck arm and never self-clears. Prefer-live must pick the Ready pod
+			// regardless of order, so the zombie is listed FIRST here.
+			name: "an evicted zombie sharing wantHash does not shadow the live Ready pod (order-independent)",
+			pods: func() []corev1.Pod {
+				zombie := waiting(workerPod("w1", want, stuckAge+27*time.Minute), "dind", "PodInitializing", 0, true)
+				zombie.Status.Phase = corev1.PodFailed
+				live := ready(workerPod("w1", want, time.Hour), testNow.Add(-5*time.Minute))
+				return []corev1.Pod{*zombie, *live}
+			}(),
+			wantPhase: protocol.PhaseSettled,
+			check: func(t *testing.T, h reconcile.RollHealth) {
+				if h.PodPhase != "Running" {
+					t.Errorf("PodPhase = %q, want \"Running\": the evicted zombie was selected instead of "+
+						"the live pod", h.PodPhase)
+				}
+				if h.BlockingContainer != "" {
+					t.Errorf("BlockingContainer = %q, want empty: the live pod is Ready with nothing to "+
+						"blame — a non-empty value means the zombie's dind init container was read", h.BlockingContainer)
+				}
+				if h.BlockingReason != "" {
+					t.Errorf("BlockingReason = %q, want empty: the live pod is Ready — a non-empty reason "+
+						"means the zombie's PodInitializing was read", h.BlockingReason)
+				}
+			},
+		},
+		{
+			// The fallback pin: when ONLY terminal pods match wantHash, keep today's verdict
+			// (stuck for an old PodFailed) rather than silently dropping to rolling.
+			name: "a lone old PodFailed pod matching wantHash stays stuck (status quo preserved, not silenced to rolling)",
+			pods: func() []corev1.Pod {
+				z := workerPod("w1", want, stuckAge+time.Minute)
+				z.Status.Phase = corev1.PodFailed
+				return []corev1.Pod{*z}
+			}(),
+			wantPhase: protocol.PhaseStuck,
+			check: func(t *testing.T, h reconcile.RollHealth) {
+				if h.BlockingContainer != "" {
+					t.Errorf("BlockingContainer = %q, want empty: no container to blame on a bare PodFailed", h.BlockingContainer)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/controller/internal/kube/rollhealth_test.go
+++ b/controller/internal/kube/rollhealth_test.go
@@ -274,6 +274,36 @@ func TestDeriveRollHealth(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Order-independence of the all-terminal fallback: two terminal pods share
+			// wantHash, one OLD (> stuckAge, would be stuck) and one RECENT (< stuckAge,
+			// would be rolling), with the RECENT one listed FIRST. Keeping the first-seen
+			// terminal pod would pick the recent one and report `rolling`; the fallback must
+			// pick the OLDEST and report `stuck`. Paired with the reversed order below, the
+			// verdict is identical for both permutations.
+			name: "all-terminal fallback picks the oldest, recent-listed-first -> stuck",
+			pods: func() []corev1.Pod {
+				recent := workerPod("w1", want, time.Minute)
+				recent.Status.Phase = corev1.PodFailed
+				old := workerPod("w1", want, stuckAge+30*time.Minute)
+				old.Status.Phase = corev1.PodFailed
+				return []corev1.Pod{*recent, *old}
+			}(),
+			wantPhase: protocol.PhaseStuck,
+		},
+		{
+			// The reversed order of the case above: old-listed-first. Same two pods, same
+			// verdict — proving the fallback does not depend on List() order.
+			name: "all-terminal fallback picks the oldest, old-listed-first -> stuck",
+			pods: func() []corev1.Pod {
+				old := workerPod("w1", want, stuckAge+30*time.Minute)
+				old.Status.Phase = corev1.PodFailed
+				recent := workerPod("w1", want, time.Minute)
+				recent.Status.Phase = corev1.PodFailed
+				return []corev1.Pod{*old, *recent}
+			}(),
+			wantPhase: protocol.PhaseStuck,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Implements issue #951.

Closes #951

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-951`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollout health reporting by ignoring pods with mismatched revisions and prioritizing active, non-terminating pods.
  * Preserved reliable fallback behavior by selecting the oldest matching pod when only terminal or terminating pods remain.
* **Tests**
  * Added regression coverage ensuring live Ready pods take precedence over failed pods and stuck rollouts consistently retain the oldest terminal pod.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->