### PR TITLE
PRD: web useAsyncData hook for the hand-rolled load/loading/error fetch cycle

### DIFF
--- a/prds/done/950-web-useasyncdata.md
+++ b/prds/done/950-web-useasyncdata.md
@@ -1,14 +1,16 @@
 # PRD #950: web useAsyncData hook for the hand-rolled load/loading/error fetch cycle
 
 **GitHub Issue**: [#950](https://github.com/vtmocanu/uzi/issues/950)
-**Status**: Draft (created 2026-09-01)
+**Status**: Implemented (created 2026-09-01; M1–M3 complete)
 **Priority**: Medium
 **Parent**: epic #915 (Batch 2, P8; finding W2). Depends on P3 (#919, merged in PR #935 — `errorMessage()` is a building block here).
 **Line refs**: re-derived at `5e343113`. Implementer re-derives at their base; anchors are identifiers, not offsets.
 
 ## Problem
 
-The load/loading/error fetch cycle is hand-rolled **33 times** (28 sites in 24 page files + 5 in components; the epic's "~23 pages" undercounted — `AdminSettings` holds 3 independent cycles, `Judge` and `RunsList` 2 each). The canonical shape, repeated near-verbatim:
+The load/loading/error fetch cycle is hand-rolled **34 times** (29 sites in 25 page files + 5 in components; the epic's "~23 pages" undercounted — `AdminSettings` holds 3 independent cycles, `Judge` and `RunsList` 2 each). The canonical shape, repeated near-verbatim:
+
+> **AI-synced 2026-09-01 (implementation).** The original draft counted **33** cycles / **26** migratable, missing `pages/RunDefaults.tsx` — a Tier-A cycle structurally identical to `Settings.tsx` (state `loading`/`error`, `Promise.all([listSecrets, getMySettings])`, `errorMessage(err, "Failed to load settings")`) present at the base commit but named in neither the migrate nor the exclude list. It was folded in as the 27th migratable site (wave 1); counts corrected throughout to **34** total / **27** migratable so Success Criterion 1 (the exclusion list is the complete remainder) holds.
 
 ```tsx
 const load = useCallback(async () => {
@@ -18,11 +20,11 @@ const load = useCallback(async () => {
 useEffect(() => { load() }, [load]);
 ```
 
-**Zero `AbortController` exists in `web/src`**, and of the 33 pattern-carrying cycles only `RunsList` (excluded here) guards its primary load against stale responses; none of the 26 migratable sites do — a hook that always guards is a strict improvement on every one of them.
+**Zero `AbortController` exists in `web/src`**, and of the 34 pattern-carrying cycles only `RunsList` (excluded here) guards its primary load against stale responses; none of the 27 migratable sites do — a hook that always guards is a strict improvement on every one of them.
 
 ## Solution
 
-One shared hook, then migrate 26 sites in two waves. The remaining 7 pattern-carrying sites are **deliberately excluded** (each needs a design decision or has no error/loading contract to preserve) and are enumerated below so the sweep has a checkable end state.
+One shared hook, then migrate 27 sites in two waves. The remaining 7 pattern-carrying sites are **deliberately excluded** (each needs a design decision or has no error/loading contract to preserve) and are enumerated below so the sweep has a checkable end state.
 
 ### The hook
 
@@ -39,7 +41,7 @@ Requirements (each traced to a migratable site that needs it):
 
 **Test-environment trap (measured):** `web/vite.config.ts` splits vitest into a "jsdom" project and a "node" project, and `src/lib/**` belongs to **node** — but a per-file `// @vitest-environment jsdom` docblock outranks the project setting (76 of 118 files carry one). `useAsyncData.test.tsx` needs that docblock or renderHook dies in the node environment.
 
-### Migration wave 1 — Tier A, mechanical (16 sites)
+### Migration wave 1 — Tier A, mechanical (17 sites)
 
 | File | State names | Cycle at 5e343113 | Variant |
 |---|---|---|---|
@@ -52,6 +54,7 @@ Requirements (each traced to a migratable site that needs it):
 | `pages/ForgeSettings.tsx` | `error`,`loading` | 98-137 | `Promise.all` ×2 |
 | `pages/IssueView.tsx` | `issue`,`runs`,`hasWorker`,`hasToken`,`loading`,`error` | 51-80 | deps `[repoId, iidNum]`; `Promise.all` ×4 |
 | `pages/Settings.tsx` | `secrets`,`sidebarTokenIds`,`loading`,`error` | 42-72 | `Promise.all` ×2 |
+| `pages/RunDefaults.tsx` | `secrets`,`loading`,`error` | ~190-219 | `Promise.all` ×2 feeding a settings form (like `Settings.tsx`); found during implementation (see AI-synced note above) |
 | `pages/Skills.tsx` | `skills`,`loading`,`error` | 47-67 | plain |
 | `pages/ToolAllowlist.tsx` | `entries`,`loading`,`error` | 15-36 | plain |
 | `pages/AdminSettings.tsx` (`UpdatesSettingsCard` :741) | `status`,`loading`,`error` | 743-767 | `skeleton: "always"` |
@@ -81,21 +84,21 @@ Requirements (each traced to a migratable site that needs it):
 
 ## Milestones
 
-- [ ] **M1 — the hook + its tests.** `web/src/lib/useAsyncData.ts` + `useAsyncData.test.tsx` (with the `@vitest-environment jsdom` docblock). Tests cover: success, error (message from fallback and from custom mapper), reload, `enabled` false→true, all three `skeleton` levels (initial / deps / always — each asserting when loading does AND does not re-arm), and the stale-response guard (two overlapping loads — the slower stale one must not clobber). Mutation-check the guard test: break the generation check and confirm the test fails. `task gate:web` green.
-- [ ] **M2 — wave 1 (16 Tier A sites).** Behavior-preserving per site: same state semantics, same error strings (each site's `errorMessage` fallback verbatim), nested best-effort fetches stay inside the fetcher. Existing page tests pass **unmodified** — if a migration seems to *require* a test edit, that is semantic drift: fix the code, never the test. Commit M2 complete before starting M3, so an M3 stall cannot lose M2. `task gate:web` green.
-- [ ] **M3 — wave 2 (10 Tier B/C sites).** Each wrinkle from the table preserved; poll paths composed, never absorbed. Existing page tests pass **unmodified** (same required-test-edit-means-drift rule) — `RunsList.test.tsx:1140`-style negative assertions on excluded pages must be untouched and still green. `task gate:web` green.
+- [x] **M1 — the hook + its tests.** `web/src/lib/useAsyncData.ts` + `useAsyncData.test.tsx` (with the `@vitest-environment jsdom` docblock). Tests cover: success, error (message from fallback and from custom mapper), reload, `enabled` false→true, all three `skeleton` levels (initial / deps / always — each asserting when loading does AND does not re-arm), and the stale-response guard (two overlapping loads — the slower stale one must not clobber). Mutation-check the guard test: break the generation check and confirm the test fails. `task gate:web` green. _(Done. `reload()` also returns a settle `Promise<void>` so migrated `await load()` call sites keep their await semantics.)_
+- [x] **M2 — wave 1 (17 Tier A sites, incl. `RunDefaults`).** Behavior-preserving per site: same state semantics, same error strings (each site's `errorMessage` fallback verbatim), nested best-effort fetches stay inside the fetcher. Existing page tests pass **unmodified** — if a migration seems to *require* a test edit, that is semantic drift: fix the code, never the test. Commit M2 complete before starting M3, so an M3 stall cannot lose M2. `task gate:web` green.
+- [x] **M3 — wave 2 (10 Tier B/C sites).** Each wrinkle from the table preserved; poll paths composed, never absorbed. Existing page tests pass **unmodified** (same required-test-edit-means-drift rule) — `RunsList.test.tsx:1140`-style negative assertions on excluded pages must be untouched and still green. `task gate:web` green.
 
 ## Success criteria
 
-1. All 26 named sites use `useAsyncData`; the exclusion list above is the complete remainder (verified by re-running the enumeration grep for the `try/catch(errorMessage)/finally(setLoading)` shape over `web/src/pages` + `web/src/components` and reading the hits — no post-filtering, per the repo's sweep rules).
+1. All 27 named sites use `useAsyncData`; the exclusion list above is the complete remainder (verified by re-running the enumeration grep for the `try/catch(errorMessage)/finally(setLoading)` shape over `web/src/pages` + `web/src/components` and reading the hits — no post-filtering, per the repo's sweep rules).
 2. **Zero page-test edits**: the loading→error→retry→loaded flows pinned by e.g. `AdminSettingsUpdates.test.tsx:227-239` and `Memory.test.tsx:38-71` pass byte-identical. (M1's new hook tests are the only test additions.)
-3. Every migrated site is now stale-response guarded (the hook's generation counter) — a strict improvement over the 16 Tier A sites that had no guard, with no regression to the excluded pages' stronger discipline.
+3. Every migrated site is now stale-response guarded (the hook's generation counter) — a strict improvement over the 17 Tier A sites that had no guard, with no regression to the excluded pages' stronger discipline. (Where a value is optimistically mutated outside the load — e.g. `IssueView.issue`, `Agents.allocations`, `Findings.backlog` — it stays local state set as a fetcher side effect, so its behavior is unchanged; the site's primary load is guarded.)
 4. `task gate:web` green (includes knip zero-tolerance — the hook's exports must all be consumed).
 5. No `.github/workflows/**` in the branch diff (implementation or validation).
 
 ## Decision Log
 
-- **D1 — string error state, not a rich error object.** Every migratable site stores the `errorMessage()` string today; returning the raw `unknown` would push mapping into 26 render paths and change nothing for the user.
+- **D1 — string error state, not a rich error object.** Every migratable site stores the `errorMessage()` string today; returning the raw `unknown` would push mapping into 27 render paths and change nothing for the user.
 - **D2 — generation counter over AbortController.** No fetch in `web/src` is abortable today (the api client has no signal plumbing); the counter delivers the same stale-response correctness without touching `lib/api.ts` (4093 lines, out of scope), and it is the pattern `Judge.tsx` already documents as superseding `alive` flags.
 - **D3 — polling stays outside the hook.** Four sites' tests and comments pin "poll failures never blank working data"; a hook that unified the paths would redden `RunsList.test.tsx:1140` and regress deliberate behavior. `usePollWhileVisible` + `reload` composes where wanted.
 - **D4 — the 7 entangled sites are excluded, not "done worse".** Migrating `Dashboard`/`Board`/`RunsList`/`Judge`/`Repos` means changing UX contracts (skeleton gating, toast diffing, threaded liveness); that is a design PRD, not a dedup.

--- a/web/src/components/CliTokens.tsx
+++ b/web/src/components/CliTokens.tsx
@@ -3,10 +3,11 @@
 // revoke, and the "Revoke all" panic button. The scope picker is offered ONLY to
 // admins (a non-admin can mint only a 'user' token). See PRD #64 M6.
 
-import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useAuth } from "../auth/AuthContext";
 import { api, type CliToken, type CliTokenScope } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { CLI_TOKEN_STALE_DAYS, isCliTokenStale } from "../lib/cliTokens";
 import { useDemoMode } from "../lib/demoMode";
 import { maskIp } from "../lib/demoMask";
@@ -20,8 +21,20 @@ export function CliTokens() {
   const { user } = useAuth();
   const isAdmin = user?.is_admin ?? false;
 
-  const [tokens, setTokens] = useState<CliToken[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    data,
+    loading,
+    error: loadError,
+    reload,
+  } = useAsyncData<{ tokens: CliToken[] }>(
+    async () => {
+      const { tokens } = await api.listCliTokens();
+      return { tokens };
+    },
+    [],
+    { fallback: "Failed to load CLI tokens" },
+  );
+  const tokens = data?.tokens ?? [];
   const [error, setError] = useState("");
 
   const [name, setName] = useState("");
@@ -42,21 +55,6 @@ export function CliTokens() {
   // the panic button and stops every CLI/CI job at once, so it asks first.
   const [confirmingAll, setConfirmingAll] = useState(false);
   const confirmRef = useRef<HTMLDivElement>(null);
-
-  const load = useCallback(async () => {
-    try {
-      const { tokens } = await api.listCliTokens();
-      setTokens(tokens);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load CLI tokens"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
 
   // Focus the warning when the confirm arms (not the destructive button — that is
   // how a confirmation becomes a formality), mirroring WorkersSettings.
@@ -83,7 +81,7 @@ export function CliTokens() {
       setCopied(false);
       setName("");
       setScope("user");
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to create CLI token"));
     } finally {
@@ -105,7 +103,7 @@ export function CliTokens() {
     setError("");
     try {
       await api.revokeCliToken(id);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to revoke token"));
     }
@@ -116,7 +114,7 @@ export function CliTokens() {
     setConfirmingAll(false);
     try {
       await api.revokeAllCliTokens();
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to revoke tokens"));
     }
@@ -136,7 +134,7 @@ export function CliTokens() {
         </p>
       </div>
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
 
       {/* Show-once mint result. Only its hash is stored, so this is the one and only
           time the value appears — the copy affordance + warning mirror the worker

--- a/web/src/components/Memory.tsx
+++ b/web/src/components/Memory.tsx
@@ -6,9 +6,10 @@
 // arms a confirm before it fires. The store is inert/advisory — memory is read back
 // into a future run as untrusted, nonce-fenced context, never as instructions.
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { api, type Memory, type MemoryBasis } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Badge, Button, Card, EmptyState, SectionTitle } from "./ui";
 import { ThoughtIcon } from "./icons";
 import { stripUnsafeChars } from "../lib/safeText";
@@ -50,30 +51,27 @@ function normalizeBasis(basis: Memory["basis"]): MemoryBasis {
 
 export function Memory() {
   const demo = useDemoMode();
-  const [entries, setEntries] = useState<Memory[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-
-  const load = useCallback(async () => {
-    try {
+  const {
+    data,
+    loading,
+    error: loadError,
+    reload,
+  } = useAsyncData<{ entries: Memory[] }>(
+    async () => {
       const { memories } = await api.listMemory();
-      setEntries(memories);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load memory"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return { entries: memories };
+    },
+    [],
+    { fallback: "Failed to load memory" },
+  );
+  const entries = data?.entries ?? [];
+  const [error, setError] = useState("");
 
   const remove = async (id: string) => {
     setError("");
     try {
       await api.deleteMemory(id);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to delete memory"));
     }
@@ -93,7 +91,7 @@ export function Memory() {
         </p>
       </div>
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
 
       {loading ? (
         <div className="space-y-2">

--- a/web/src/components/RateLimitMeters.tsx
+++ b/web/src/components/RateLimitMeters.tsx
@@ -3,10 +3,11 @@
 // token never leaves the api — the SPA only ever sees percentages) and reuse the
 // shared MeterTrack + toneFor thresholds. The admin table is a separate page.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { isShownInSidebar, onSidebarTokensChanged } from "../lib/sidebarTokens";
 import { api, type RateLimitWindow, type TokenRateLimits } from "../lib/api";
+import { useAsyncData } from "../lib/useAsyncData";
 import { usePollWhileVisible } from "../lib/usePollWhileVisible";
 import {
   formatAgo,
@@ -38,22 +39,16 @@ export function useMyRateLimits(intervalMs: number): {
   tokens: TokenRateLimits[] | null;
   loading: boolean;
 } {
-  const [tokens, setTokens] = useState<TokenRateLimits[] | null>(null);
-  const [loading, setLoading] = useState(true);
-  const load = useCallback(() => {
-    api
-      .getMyRateLimits()
-      .then((d) => {
-        setTokens(d.tokens);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, []);
-  useEffect(() => {
-    load();
-  }, [load]);
-  usePollWhileVisible(load, intervalMs);
-  return { tokens, loading };
+  // Reimplemented over useAsyncData (PRD #950 M3, Tier C) with the exact old
+  // contract: `data` null-initial matches the old `tokens` null, and NO error is
+  // ever surfaced (the old catch only cleared loading) — so `error` is not
+  // destructured. The poll is composed on the hook's reload, not absorbed.
+  const { data, loading, reload } = useAsyncData(
+    async () => (await api.getMyRateLimits()).tokens,
+    [],
+  );
+  usePollWhileVisible(reload, intervalMs);
+  return { tokens: data, loading };
 }
 
 const CARD_BLURB =

--- a/web/src/components/SkillAllocationPanel.tsx
+++ b/web/src/components/SkillAllocationPanel.tsx
@@ -8,9 +8,10 @@
 // edit — a non-admin sends my_skill_ids only, so the shared half is left
 // untouched (nil = untouched, server-side).
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { api, type Skill, type TemplateSkills } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { scopeBadgeTone, SCOPE_LABEL } from "../lib/skills";
 import { Alert, Badge, Button, Card, Spinner } from "./ui";
 
@@ -26,7 +27,6 @@ export function SkillAllocationPanel({
   const [allSkills, setAllSkills] = useState<Skill[]>([]);
   const [shared, setShared] = useState<Set<string>>(new Set());
   const [mine, setMine] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState("");
@@ -35,22 +35,9 @@ export function SkillAllocationPanel({
   const [baseShared, setBaseShared] = useState<Set<string>>(new Set());
   const [baseMine, setBaseMine] = useState<Set<string>>(new Set());
 
-  const load = useCallback(async () => {
-    setError("");
-    try {
-      const [{ skills }, { allocations }] = await Promise.all([
-        api.listSkills(),
-        api.getTemplateSkills(templateId),
-      ]);
-      setAllSkills(skills);
-      applyAllocations(allocations);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load skill allocations"));
-    } finally {
-      setLoading(false);
-    }
-  }, [templateId]);
-
+  // applyAllocations seeds shared/mine and their baselines from a GET/PUT response.
+  // Declared ABOVE the useAsyncData call because the fetcher closes over it; it only
+  // writes setters, so hoisting it above the load changes nothing else.
   const applyAllocations = (a: TemplateSkills) => {
     const s = new Set(a.shared.map((x) => x.skill_id));
     const m = new Set(a.mine.map((x) => x.skill_id));
@@ -60,9 +47,22 @@ export function SkillAllocationPanel({
     setBaseMine(new Set(m));
   };
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  // allSkills is set only here, so it is seeded as a fetcher side effect; shared/mine
+  // and their baselines are also written by the edit toggles and Save, so
+  // applyAllocations seeds them as a side effect too. The hook owns loading and the
+  // load error (surfaced as loadError, unioned with the save error at the Alert below).
+  const { loading, error: loadError } = useAsyncData(
+    async () => {
+      const [{ skills }, { allocations }] = await Promise.all([
+        api.listSkills(),
+        api.getTemplateSkills(templateId),
+      ]);
+      setAllSkills(skills);
+      applyAllocations(allocations);
+    },
+    [templateId],
+    { fallback: "Failed to load skill allocations" },
+  );
 
   const byId = useMemo(() => new Map(allSkills.map((s) => [s.id, s])), [allSkills]);
 
@@ -139,7 +139,7 @@ export function SkillAllocationPanel({
         </p>
       </div>
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {notice && <Alert message={notice} tone="success" />}
 
       <div>

--- a/web/src/components/SlackNotifications.tsx
+++ b/web/src/components/SlackNotifications.tsx
@@ -4,9 +4,10 @@
 // auto-match misses, and a self-test DM. All writes are self-scoped — a user can
 // only ever touch their own mapping.
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { api, type SlackLink } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Badge, type BadgeTone, Button, Card, Field, Input, SectionTitle, Skeleton } from "./ui";
 import { DocLink } from "./DocLink";
 import { DOC_SLACK } from "../lib/doclinks";
@@ -31,27 +32,23 @@ const WORKSPACE_ALERT: Record<Exclude<SlackLink["workspace"], "connected">, stri
 
 export function SlackNotifications() {
   const [link, setLink] = useState<SlackLink | null>(null);
-  const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [override, setOverride] = useState("");
-  const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
 
-  const load = useCallback(async () => {
-    try {
+  // `link` is also written by the mutation handlers below (a save reflects the new
+  // state without a refetch), so it stays local state and the fetcher sets it as a
+  // side effect rather than being bundled into the hook's `data`.
+  const { loading, error: loadError } = useAsyncData(
+    async () => {
       const { slack } = await api.getMySlack();
       setLink(slack);
       setOverride(slack.member_id ?? "");
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load notification settings"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+    },
+    [],
+    { fallback: "Failed to load notification settings" },
+  );
+  const [error, setError] = useState("");
 
   const toggleNotify = async (notify: boolean) => {
     setError("");
@@ -119,7 +116,7 @@ export function SlackNotifications() {
         </p>
       </div>
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {notice && <Alert tone="success" message={notice} />}
 
       {loading || link === null ? (

--- a/web/src/lib/useAsyncData.test.tsx
+++ b/web/src/lib/useAsyncData.test.tsx
@@ -82,8 +82,23 @@ describe("useAsyncData", () => {
       useAsyncData(() => Promise.resolve(++n), []),
     );
     await waitFor(() => expect(result.current.data).toBe(1));
-    act(() => result.current.reload());
+    act(() => { void result.current.reload(); });
     await waitFor(() => expect(result.current.data).toBe(2));
+  });
+
+  it("reload() returns a promise that settles AFTER data updates (await reload())", async () => {
+    // Migrated mutation handlers do `await reload()` before clearing a busy spinner,
+    // so the returned promise must not resolve until the refetch's state is applied.
+    let n = 0;
+    const { result } = renderHook(() =>
+      useAsyncData(() => Promise.resolve(++n), []),
+    );
+    await waitFor(() => expect(result.current.data).toBe(1));
+    await act(async () => {
+      await result.current.reload();
+    });
+    // Immediately after the awaited reload resolves, the new data is already applied.
+    expect(result.current.data).toBe(2);
   });
 
   it("enabled:false never fetches; flipping to true fetches with loading armed first", async () => {
@@ -131,7 +146,7 @@ describe("useAsyncData", () => {
     expect(result.current.loading).toBe(false);
 
     // Manual reload(): does NOT re-arm either.
-    act(() => result.current.reload());
+    act(() => { void result.current.reload(); });
     expect(result.current.loading).toBe(false);
     await act(async () => {
       calls[2].resolve("c");
@@ -161,7 +176,7 @@ describe("useAsyncData", () => {
     expect(result.current.data).toBe("b");
 
     // Manual reload() does NOT re-arm.
-    act(() => result.current.reload());
+    act(() => { void result.current.reload(); });
     expect(result.current.loading).toBe(false);
     await act(async () => {
       calls[2].resolve("c");
@@ -180,7 +195,7 @@ describe("useAsyncData", () => {
     });
     expect(result.current.loading).toBe(false);
 
-    act(() => result.current.reload());
+    act(() => { void result.current.reload(); });
     expect(result.current.loading).toBe(true);
     await act(async () => {
       calls[1].resolve("b");

--- a/web/src/lib/useAsyncData.test.tsx
+++ b/web/src/lib/useAsyncData.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useAsyncData } from "./useAsyncData";
+import { ApiError, errorMessage } from "./apiError";
+
+afterEach(() => {
+  cleanup();
+});
+
+// A promise whose resolution we control, so overlapping loads can be ordered.
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+}
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// A fetcher that hands back a fresh controllable deferred per call, so a test can
+// resolve calls in any order and observe loading between them.
+function makeController() {
+  const calls: Array<Deferred<string>> = [];
+  const fetcher = vi.fn(() => {
+    const d = deferred<string>();
+    calls.push(d);
+    return d.promise;
+  });
+  return { fetcher, calls };
+}
+
+describe("useAsyncData", () => {
+  it("success sets data, clears loading and leaves error empty", async () => {
+    const { result } = renderHook(() =>
+      useAsyncData(() => Promise.resolve("hi"), []),
+    );
+    await waitFor(() => expect(result.current.data).toBe("hi"));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe("");
+  });
+
+  it("maps error via fallback and keeps data null", async () => {
+    const err = new Error("network"); // not an ApiError -> errorMessage returns the fallback
+    const fallback = "Failed to load widgets";
+    const { result } = renderHook(() =>
+      useAsyncData(() => Promise.reject(err), [], { fallback }),
+    );
+    await waitFor(() => expect(result.current.error).toBe(fallback));
+    expect(result.current.error).toBe(errorMessage(err, fallback));
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("uses a custom mapError over the fallback path", async () => {
+    // Give an ApiError so the fallback path would yield the server message; the
+    // custom mapper must win and produce a different string.
+    const err = new ApiError(404, "server-said-not-found");
+    const fallback = "generic-fallback";
+    const mapped = "custom-mapped-message";
+    const { result } = renderHook(() =>
+      useAsyncData(() => Promise.reject(err), [], {
+        fallback,
+        mapError: () => mapped,
+      }),
+    );
+    await waitFor(() => expect(result.current.error).toBe(mapped));
+    // Distinct from what either fallback branch would have produced.
+    expect(result.current.error).not.toBe(errorMessage(err, fallback));
+    expect(result.current.error).not.toBe(fallback);
+  });
+
+  it("reload() refetches and updates data", async () => {
+    let n = 0;
+    const { result } = renderHook(() =>
+      useAsyncData(() => Promise.resolve(++n), []),
+    );
+    await waitFor(() => expect(result.current.data).toBe(1));
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.data).toBe(2));
+  });
+
+  it("enabled:false never fetches; flipping to true fetches with loading armed first", async () => {
+    const fetcher = vi.fn(() => Promise.resolve("data"));
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncData(fetcher, [], { enabled }),
+      { initialProps: { enabled: false } },
+    );
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+
+    rerender({ enabled: true });
+    // No blank/loaded frame: loading is already true and data still null before
+    // the fetch resolves.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => expect(result.current.data).toBe("data"));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("skeleton 'initial': first mount arms loading; a deps change and reload do NOT re-arm", async () => {
+    const { fetcher, calls } = makeController();
+    const { result, rerender } = renderHook(
+      ({ dep }) => useAsyncData(fetcher, [dep], { skeleton: "initial" }),
+      { initialProps: { dep: 1 } },
+    );
+    // First mount: loading armed until the first fetch lands.
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      calls[0].resolve("a");
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBe("a");
+
+    // Deps change: does NOT re-arm; stale data stays visible while the refetch runs.
+    rerender({ dep: 2 });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBe("a");
+    await act(async () => {
+      calls[1].resolve("b");
+    });
+    expect(result.current.data).toBe("b");
+    expect(result.current.loading).toBe(false);
+
+    // Manual reload(): does NOT re-arm either.
+    act(() => result.current.reload());
+    expect(result.current.loading).toBe(false);
+    await act(async () => {
+      calls[2].resolve("c");
+    });
+    expect(result.current.data).toBe("c");
+  });
+
+  it("skeleton 'deps': a deps change re-arms loading; reload does NOT", async () => {
+    const { fetcher, calls } = makeController();
+    const { result, rerender } = renderHook(
+      ({ dep }) => useAsyncData(fetcher, [dep], { skeleton: "deps" }),
+      { initialProps: { dep: 1 } },
+    );
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      calls[0].resolve("a");
+    });
+    expect(result.current.loading).toBe(false);
+
+    // Deps-driven refetch re-arms the skeleton.
+    rerender({ dep: 2 });
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      calls[1].resolve("b");
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBe("b");
+
+    // Manual reload() does NOT re-arm.
+    act(() => result.current.reload());
+    expect(result.current.loading).toBe(false);
+    await act(async () => {
+      calls[2].resolve("c");
+    });
+    expect(result.current.data).toBe("c");
+  });
+
+  it("skeleton 'always': reload() re-arms loading", async () => {
+    const { fetcher, calls } = makeController();
+    const { result } = renderHook(() =>
+      useAsyncData(fetcher, [], { skeleton: "always" }),
+    );
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      calls[0].resolve("a");
+    });
+    expect(result.current.loading).toBe(false);
+
+    act(() => result.current.reload());
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      calls[1].resolve("b");
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBe("b");
+  });
+
+  it("stale-response guard: an older fetch resolving LAST does not clobber a newer one", async () => {
+    // MUTATION CHECK: this test exercises the `gen === genRef.current` guard in
+    // useAsyncData. If that check is removed, the older fetch (calls[0], issued
+    // first and resolved LAST here) would setData("old") after the newer result,
+    // overwriting "new" with "old" — the two values are deliberately different so
+    // the final expect(...).toBe("new") would then fail.
+    const { fetcher, calls } = makeController();
+    const { result, rerender } = renderHook(
+      ({ dep }) => useAsyncData(fetcher, [dep], { skeleton: "initial" }),
+      { initialProps: { dep: 1 } },
+    );
+    // Older load in flight.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Deps change starts a newer load; the effect cleanup bumps the generation so
+    // the older load is now stale.
+    rerender({ dep: 2 });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // Resolve the NEWER load first — it wins.
+    await act(async () => {
+      calls[1].resolve("new");
+    });
+    expect(result.current.data).toBe("new");
+
+    // Now resolve the OLDER load LAST — the guard must drop it.
+    await act(async () => {
+      calls[0].resolve("old");
+    });
+    expect(result.current.data).toBe("new");
+  });
+});

--- a/web/src/lib/useAsyncData.ts
+++ b/web/src/lib/useAsyncData.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { errorMessage } from "./apiError";
+
+// useAsyncData centralizes the hand-rolled load/loading/error/reload cycle that
+// web/src repeats ~33 times (PRD #950). `data` starts null; `error` is the
+// errorMessage() string every site stores today (D1), "" when none. On success
+// it sets data and clears error; on failure it sets error and KEEPS the last
+// data (a blip never blanks working data). Every fetch is stale-response guarded
+// by a monotonic generation counter — the Judge.tsx pattern that superseded the
+// `alive` flag — so an older overlapping load can never clobber a newer one, and
+// a fetch in flight at a deps change / unmount never lands.
+//
+// It does NOT poll: polling is composed on top by callers via usePollWhileVisible
+// calling `reload`, so a swallowed poll path stays the caller's concern (D3).
+export function useAsyncData<T>(
+  fetcher: () => Promise<T>,
+  deps: unknown[],
+  opts?: {
+    enabled?: boolean; // default true; when false the fetcher is never called
+    skeleton?: "initial" | "deps" | "always"; // when loading re-arms; default "initial"
+    fallback?: string; // errorMessage(err, fallback) when no mapError
+    mapError?: (err: unknown) => string; // overrides fallback when provided
+  },
+): { data: T | null; loading: boolean; error: string; reload: () => void } {
+  const enabled = opts?.enabled ?? true;
+  const skeleton = opts?.skeleton ?? "initial";
+
+  const [data, setData] = useState<T | null>(null);
+  // Initialize loading to `enabled` so an enabled:false->true flip shows no blank
+  // frame: the fetch effect re-arms it true before the first fetch resolves.
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState("");
+
+  // Stash the caller's fetcher and error-mapper in refs (the usePollWhileVisible
+  // cbRef idiom) so the fetch effect keys off `deps`/`enabled`, not off a closure
+  // recreated every render — callers need not useCallback their fetcher.
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  const mapErrRef = useRef<(err: unknown) => string>(() => "");
+  mapErrRef.current =
+    opts?.mapError ?? ((err) => errorMessage(err, opts?.fallback ?? ""));
+
+  // Monotonic invalidation counter. A fetch applies its result only if its stamp
+  // is still the latest issued; the effect cleanup bumps it to invalidate any
+  // in-flight fetch. `firstRef` decides skeleton arming on the very first fetch.
+  const genRef = useRef(0);
+  const firstRef = useRef(true);
+
+  const runFetch = useCallback(
+    (trigger: "deps" | "reload") => {
+      const first = firstRef.current;
+      firstRef.current = false;
+      // Arm the skeleton (set loading true before awaiting) per the level:
+      //   "always"  -> every fetch, including reload()
+      //   "deps"    -> the first fetch and every deps-driven refetch, not reload()
+      //   "initial" -> only the very first fetch
+      const arm =
+        skeleton === "always" ||
+        (skeleton === "deps" && trigger === "deps") ||
+        first;
+      const gen = ++genRef.current;
+      if (arm) setLoading(true);
+      fetcherRef.current().then(
+        (result) => {
+          if (gen !== genRef.current) return; // a newer fetch superseded this one
+          setData(result);
+          setError("");
+          setLoading(false);
+        },
+        (err) => {
+          if (gen !== genRef.current) return; // superseded: drop this stale error too
+          setError(mapErrRef.current(err)); // keep the last data on failure (D1)
+          setLoading(false);
+        },
+      );
+    },
+    [skeleton],
+  );
+
+  const reload = useCallback(() => runFetch("reload"), [runFetch]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false); // disabled: never fetch, and loading resolves false
+      return;
+    }
+    // Alias the generation ref to a local so the cleanup does not read `genRef`
+    // directly (react-hooks/exhaustive-deps, as in Judge.tsx): this ref is a
+    // monotonic invalidation counter, not a DOM node, so reading its live value
+    // in cleanup is intentional, not the stale-node hazard the rule guards.
+    const genCounter = genRef;
+    runFetch("deps");
+    // Bump the generation so a fetch in flight when deps change / the component
+    // unmounts never applies its result.
+    return () => {
+      genCounter.current++;
+    };
+    // The `deps` spread is the whole point of a generic fetch hook; the rule
+    // cannot statically check a caller-supplied array, so it is disabled here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, runFetch, ...deps]);
+
+  return { data, loading, error, reload };
+}

--- a/web/src/lib/useAsyncData.ts
+++ b/web/src/lib/useAsyncData.ts
@@ -21,7 +21,7 @@ export function useAsyncData<T>(
     fallback?: string; // errorMessage(err, fallback) when no mapError
     mapError?: (err: unknown) => string; // overrides fallback when provided
   },
-): { data: T | null; loading: boolean; error: string; reload: () => void } {
+): { data: T | null; loading: boolean; error: string; reload: () => Promise<void> } {
   const enabled = opts?.enabled ?? true;
   const skeleton = opts?.skeleton ?? "initial";
 
@@ -47,7 +47,7 @@ export function useAsyncData<T>(
   const firstRef = useRef(true);
 
   const runFetch = useCallback(
-    (trigger: "deps" | "reload") => {
+    (trigger: "deps" | "reload"): Promise<void> => {
       const first = firstRef.current;
       firstRef.current = false;
       // Arm the skeleton (set loading true before awaiting) per the level:
@@ -60,7 +60,10 @@ export function useAsyncData<T>(
         first;
       const gen = ++genRef.current;
       if (arm) setLoading(true);
-      fetcherRef.current().then(
+      // Return the settle promise so a caller can `await reload()` — the migrated
+      // mutation handlers await their refetch before clearing a row's busy spinner,
+      // exactly as they awaited the inline `load()` today.
+      return fetcherRef.current().then(
         (result) => {
           if (gen !== genRef.current) return; // a newer fetch superseded this one
           setData(result);
@@ -77,7 +80,7 @@ export function useAsyncData<T>(
     [skeleton],
   );
 
-  const reload = useCallback(() => runFetch("reload"), [runFetch]);
+  const reload = useCallback((): Promise<void> => runFetch("reload"), [runFetch]);
 
   useEffect(() => {
     if (!enabled) {
@@ -89,7 +92,7 @@ export function useAsyncData<T>(
     // monotonic invalidation counter, not a DOM node, so reading its live value
     // in cleanup is intentional, not the stale-node hazard the rule guards.
     const genCounter = genRef;
-    runFetch("deps");
+    void runFetch("deps"); // deps-driven fetch; its settle promise is only awaited via reload()
     // Bump the generation so a fetch in flight when deps change / the component
     // unmounts never applies its result.
     return () => {

--- a/web/src/pages/AdminBlockedRepos.tsx
+++ b/web/src/pages/AdminBlockedRepos.tsx
@@ -5,9 +5,10 @@
 // Repos page uses inline. Backed by the STORED privilege report, so it inherits R1's
 // caveat: if privilege checks were never run, an empty list is "unknown", not "none".
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { api, type BlockedRepo } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Badge, Button, Card, EmptyState, ListSkeleton, Textarea } from "../components/ui";
 import { AdminShell } from "../components/AdminShell";
 import { Modal } from "../components/Modal";
@@ -24,9 +25,20 @@ function daysSince(iso: string): number {
 
 export function AdminBlockedRepos() {
   const demo = useDemoMode();
-  const [repos, setRepos] = useState<BlockedRepo[]>([]);
-  const [checksUnknown, setChecksUnknown] = useState(false);
-  const [loading, setLoading] = useState(true);
+  // repos + checksUnknown are set only by the load, so they ride in the hook's data
+  // bundle and are read below with the same initial values the old useState had.
+  const { data, loading, error: loadError, reload } = useAsyncData(
+    async () => {
+      const res = await api.adminListBlockedRepos();
+      return { repos: res.repos, checksUnknown: res.checks_unknown };
+    },
+    [],
+    { fallback: "Failed to load blocked repos" },
+  );
+  const repos = data?.repos ?? [];
+  const checksUnknown = data?.checksUnknown ?? false;
+  // Kept local: the Allow-anyway / Revoke handlers below still set the page error, so
+  // it is merged with the hook's load error at the one page-level Alert.
   const [error, setError] = useState("");
   // The repo whose Allow-anyway modal is open, plus the reason and in-flight POST.
   const [allowRepo, setAllowRepo] = useState<BlockedRepo | null>(null);
@@ -36,22 +48,6 @@ export function AdminBlockedRepos() {
   // Alert would sit behind the backdrop, unseen). Distinct from the page `error`.
   const [allowError, setAllowError] = useState("");
   const [revokeBusyId, setRevokeBusyId] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    try {
-      const res = await api.adminListBlockedRepos();
-      setRepos(res.repos);
-      setChecksUnknown(res.checks_unknown);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load blocked repos"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
 
   const openAllow = (repo: BlockedRepo) => {
     setError("");
@@ -78,7 +74,7 @@ export function AdminBlockedRepos() {
       await api.setRepoGuardrailOverride(allowRepo.id, reason);
       setAllowRepo(null);
       setAllowReason("");
-      await load();
+      await reload();
     } catch (err) {
       setAllowError(errorMessage(err, "Failed to allow the repo"));
     } finally {
@@ -91,7 +87,7 @@ export function AdminBlockedRepos() {
     setRevokeBusyId(repo.id);
     try {
       await api.clearRepoGuardrailOverride(repo.id);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to revoke the override"));
     } finally {
@@ -102,7 +98,7 @@ export function AdminBlockedRepos() {
   return (
     <AdminShell description="Every user's repos the push/merge guardrail refuses right now, plus any an admin has explicitly allowed. Fixing branch protection on the forge clears the block on the next sync; an override persists until revoked.">
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
 
       {/* R1 caveat: never let a never-checked connection read as clean. */}
       {checksUnknown && (

--- a/web/src/pages/AdminBranding.tsx
+++ b/web/src/pages/AdminBranding.tsx
@@ -12,7 +12,6 @@
 
 import {
   useCallback,
-  useEffect,
   useRef,
   useState,
   type FormEvent,
@@ -24,6 +23,7 @@ import {
   type UpdateSettingsPayload,
 } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import {
   Alert,
   Button,
@@ -70,8 +70,9 @@ export function AdminBranding() {
   // Bumped after every upload/delete so the preview <img> re-fetches past the cache.
   const [logoRev, setLogoRev] = useState(0);
 
-  const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
+  // Kept local: the save / upload / clear handlers below still set this, so it is
+  // merged with the hook's load error at the one page-level Alert.
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
 
@@ -86,22 +87,19 @@ export function AdminBranding() {
     setBrandPlaque(settings.brand_plaque === "true");
   }, []);
 
-  const load = useCallback(async () => {
-    try {
+  // Every loaded value is editable/derived form state the handlers below also write,
+  // so the fetcher seeds them as side effects exactly as the old load did; the hook
+  // only owns loading + the load error.
+  const { loading, error: loadError } = useAsyncData(
+    async () => {
       const [resp, brand] = await Promise.all([api.getSettings(), api.branding()]);
       applySettings(resp.settings);
       setAppPresent(brand.app_logo_present);
       setBrandPresent(brand.brand_logo_present);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load branding"));
-    } finally {
-      setLoading(false);
-    }
-  }, [applySettings]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+    },
+    [applySettings],
+    { fallback: "Failed to load branding" },
+  );
 
   const dirty =
     saved !== null &&
@@ -285,7 +283,7 @@ export function AdminBranding() {
         </Card>
       ) : (
         <form onSubmit={save} className="space-y-6">
-          {error && <Alert message={error} />}
+          {(error || loadError) && <Alert message={error || loadError} />}
           {notice && <Alert message={notice} tone="success" />}
 
           <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">

--- a/web/src/pages/AdminRateLimits.tsx
+++ b/web/src/pages/AdminRateLimits.tsx
@@ -3,9 +3,8 @@
 // the capacity view leads with who is near a wall. Same table conventions as
 // Admin → Users; the meters reuse the shared MeterTrack + toneFor thresholds.
 
-import { useCallback, useEffect, useState } from "react";
 import { api, type AdminRateLimitUser, type MyRateLimits, type TokenRateLimits } from "../lib/api";
-import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { usePollWhileVisible } from "../lib/usePollWhileVisible";
 import {
   formatAgo,
@@ -131,28 +130,19 @@ function UserCell({
 }
 
 export function AdminRateLimits() {
-  const [users, setUsers] = useState<AdminRateLimitUser[]>([]);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(true);
+  // The poll reuses the hook's reload, so a poll failure surfaces the same error
+  // the initial load would (PRD #950 M3, Tier C). skeleton stays "initial" (the
+  // hook default), so the 60s poll's reload never re-shows the ListSkeleton — as
+  // today's poll never set loading true.
+  const { data, loading, error, reload } = useAsyncData(
+    async () => (await api.getAdminRateLimits()).users,
+    [],
+    { fallback: "Failed to load rate limits" },
+  );
+  const users = data ?? [];
   const now = useNow();
 
-  const load = useCallback(() => {
-    api
-      .getAdminRateLimits()
-      .then(({ users }) => {
-        setUsers(users);
-        setLoading(false);
-      })
-      .catch((err) => {
-        setError(errorMessage(err, "Failed to load rate limits"));
-        setLoading(false);
-      });
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-  usePollWhileVisible(load, 60_000);
+  usePollWhileVisible(reload, 60_000);
 
   const rows = sortAdminRows(users);
 

--- a/web/src/pages/AdminSettings.tsx
+++ b/web/src/pages/AdminSettings.tsx
@@ -19,6 +19,7 @@ import {
   type UpdateSettingsPayload,
 } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { useAuth } from "../auth/AuthContext";
 import {
   Alert,
@@ -739,32 +740,29 @@ function releaseExcerpt(body: string | undefined, max = 300): string {
 // unreachable) / "never" (no check yet) status in words. It renders NO release
 // markdown as HTML — the excerpt is a plain React text node.
 function UpdatesSettingsCard() {
+  // status is seeded by the load but ALSO updated by checkNow / saveToggle, so it
+  // stays local and the fetcher seeds it as a side effect.
   const [status, setStatus] = useState<ReleaseCheckStatus | null>(null);
-  const [loading, setLoading] = useState(true);
   const [checking, setChecking] = useState(false);
   // Which toggle is mid-save; null when idle. A save disables BOTH toggle inputs
   // (deliberate concurrent-write protection — see the `disabled` guards below), while
   // this value still records which of the two rows is the one being saved.
   const [savingToggle, setSavingToggle] = useState<"enabled" | "banner" | null>(null);
   const [copied, setCopied] = useState(false);
+  // Kept local: checkNow / saveToggle set this on failure, so it is merged with the
+  // hook's load error at the one Alert below.
   const [error, setError] = useState("");
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError("");
-    try {
+  // skeleton: "always" mirrors the old load's setLoading(true) on every call, so a
+  // Retry (reload) re-arms the skeleton exactly as it did before.
+  const { loading, error: loadError, reload } = useAsyncData(
+    async () => {
       const { release_check } = await api.getReleaseCheck();
       setStatus(release_check);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load release-check status"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
+    },
+    [],
+    { fallback: "Failed to load release-check status", skeleton: "always" },
+  );
 
   const checkNow = async () => {
     setError("");
@@ -846,7 +844,7 @@ function UpdatesSettingsCard() {
         )}
       </div>
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
 
       {loading ? (
         <Skeleton className="h-24 w-full" />
@@ -855,8 +853,8 @@ function UpdatesSettingsCard() {
         // above) plus a retry path instead of a permanent skeleton — the "Check
         // now" button is gated on `status`, so this is the only way back.
         <div className="space-y-3">
-          {!error && <Alert message="Failed to load release-check status." />}
-          <Button variant="secondary" size="sm" onClick={() => void load()} disabled={loading}>
+          {!error && !loadError && <Alert message="Failed to load release-check status." />}
+          <Button variant="secondary" size="sm" onClick={() => void reload()} disabled={loading}>
             Retry
           </Button>
         </div>
@@ -1265,8 +1263,9 @@ const SKILLS_PRESET_URL = "https://github.com/vtmocanu/skills";
 const SKILLS_PRESET_FOLDER = "product-agents/";
 
 function AgentSourceSettingsCard() {
+  // view is seeded by the load's resetForm but ALSO updated by refreshView / syncNow /
+  // checkForUpdates, so it stays local and the fetcher seeds it as a side effect.
   const [view, setView] = useState<AgentSourceView | null>(null);
-  const [loading, setLoading] = useState(true);
   const [url, setUrl] = useState("");
   const [ref, setRef] = useState("");
   // Repo-relative subfolder role files are read from (PRD #702 M1). The server
@@ -1301,6 +1300,8 @@ function AgentSourceSettingsCard() {
   const [updateMsg, setUpdateMsg] = useState<{ tone: "success" | "warning" | "danger"; text: string } | null>(
     null,
   );
+  // Kept local: the save / sync / approve / preset / check / bump handlers below all
+  // set this, so it is merged with the hook's load error at the one Alert below.
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
 
@@ -1324,20 +1325,17 @@ function AgentSourceSettingsCard() {
     setView(agent_source);
   }, []);
 
-  const load = useCallback(async () => {
-    try {
+  // The initial load resets the form (resetForm) — as does an explicit Save via
+  // reload() below — while refreshView (used by Sync/Approve/Bump) deliberately does
+  // NOT, preserving unsaved edits. The hook owns loading + the load error only.
+  const { loading, error: loadError, reload } = useAsyncData(
+    async () => {
       const { agent_source } = await api.getAgentSource();
       resetForm(agent_source);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load agent-source settings"));
-    } finally {
-      setLoading(false);
-    }
-  }, [resetForm]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
+    },
+    [resetForm],
+    { fallback: "Failed to load agent-source settings" },
+  );
 
   // Preset: fill the URL + folder for uzi's canonical roster and resolve its latest tag
   // at click time (PRD #702 M3). The URL/folder are filled IMMEDIATELY so a resolve
@@ -1410,7 +1408,7 @@ function AgentSourceSettingsCard() {
       setCredential("");
       // updateSettings returns the settings envelope, not the agent-source view —
       // re-read so the status/credential-configured/staged panels reflect the save.
-      await load();
+      await reload();
       setNotice("Agent-source settings saved.");
     } catch (err) {
       setError(errorMessage(err, "Failed to save agent-source settings"));
@@ -1577,7 +1575,7 @@ function AgentSourceSettingsCard() {
         </p>
       </div>
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {notice && <Alert tone="success" message={notice} />}
 
       {loading ? (

--- a/web/src/pages/AdminSettings.tsx
+++ b/web/src/pages/AdminSettings.tsx
@@ -117,7 +117,6 @@ export function AdminSettings() {
   const [uziLabel, setUziLabel] = useState("");
   const [autopilotLabel, setAutopilotLabel] = useState("");
   const [defaultTheme, setDefaultTheme] = useState("");
-  const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
@@ -142,24 +141,26 @@ export function AdminSettings() {
     setDefaultTheme(settings.default_theme);
   }, []);
 
-  const load = useCallback(async () => {
-    try {
-      applyResponse(await api.getSettings());
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load settings"));
-    } finally {
-      setLoading(false);
-    }
-    // Best-effort, independent of the settings load (PRD #32).
-    api
-      .vaultMigration()
-      .then(({ master_sealed }) => setMasterSealed(master_sealed))
-      .catch(() => setMasterSealed(null));
-  }, [applyResponse]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+  // The settings form fields are seeded by applyResponse as a fetcher side effect
+  // (they are editable and also written by the save handler). The vaultMigration probe
+  // runs in a `finally` so it fires regardless of the settings-load outcome, exactly as
+  // the old load ran it after its own try/catch/finally (PRD #32). The hook owns
+  // loading and the load error (surfaced as loadError, unioned with the save error at
+  // the Alert below); masterSealed stays local, set as a side effect.
+  const { loading, error: loadError } = useAsyncData(
+    async () => {
+      try {
+        applyResponse(await api.getSettings());
+      } finally {
+        api
+          .vaultMigration()
+          .then(({ master_sealed }) => setMasterSealed(master_sealed))
+          .catch(() => setMasterSealed(null));
+      }
+    },
+    [applyResponse],
+    { fallback: "Failed to load settings" },
+  );
 
   // Poll only the live Slack connection state so the chip reflects connecting →
   // connected without a manual reload. Uses the dedicated status endpoint (not the
@@ -270,7 +271,7 @@ export function AdminSettings() {
         </nav>
       )}
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {notice && <Alert tone="success" message={notice} />}
 
       {masterSealed !== null && masterSealed > 0 && (

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useAuth } from "../auth/AuthContext";
 import { api, type User } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Badge, Button, Card, ListSkeleton } from "../components/ui";
 import { AdminShell } from "../components/AdminShell";
 import { useDemoMode } from "../lib/demoMode";
@@ -10,12 +11,16 @@ import { maskEmail, maskName } from "../lib/demoMask";
 export function AdminUsers() {
   const demo = useDemoMode();
   const { user: me } = useAuth();
+  // users is seeded by the load but ALSO updated optimistically by the toggle
+  // handlers below (setUsers(prev => …)), so it stays a local state and the fetcher
+  // seeds it as a side effect rather than riding in the hook's data bundle.
   const [users, setUsers] = useState<User[]>([]);
+  // Kept local: the toggle handlers below still set this on failure, so it is merged
+  // with the hook's load error at the one page-level Alert.
   const [error, setError] = useState("");
   const [busyId, setBusyId] = useState<string | null>(null);
   const [judgeBusyId, setJudgeBusyId] = useState<string | null>(null);
   const [ciAutofixBusyId, setCiAutofixBusyId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
   // Whether the admin has ENFORCED the judge instance-wide (PRD #69 M4). Under
   // enforced mode the per-user judge flag is bypassed at enqueue (Decision 3), so the
   // per-user toggle in this table is INERT — greyed and annotated, not removed. Read
@@ -23,12 +28,13 @@ export function AdminUsers() {
   // it false so the toggle stays live rather than falsely claiming to be inert.
   const [judgeEnforceAll, setJudgeEnforceAll] = useState(false);
 
-  const load = useCallback(async () => {
-    try {
-      // The user list is the page; a failure here is fatal. The settings read is
-      // best-effort per the judgeEnforceAll comment above: it only decides whether the
-      // per-user toggle is annotated inert, so a settings-endpoint blip must NOT blank
-      // the whole table. Keep it OUT of the fatal path — leave enforce=false on error.
+  const { loading, error: loadError } = useAsyncData(
+    async () => {
+      // The user list is the page; a failure here is fatal (the fetcher rethrows and
+      // the hook turns it into loadError). The settings read is best-effort per the
+      // judgeEnforceAll comment above: it only decides whether the per-user toggle is
+      // annotated inert, so a settings-endpoint blip must NOT blank the whole table.
+      // Keep it OUT of the fatal path — leave enforce=false on error.
       const { users } = await api.listUsers();
       setUsers(users);
       try {
@@ -37,16 +43,10 @@ export function AdminUsers() {
       } catch {
         setJudgeEnforceAll(false);
       }
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load users"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+    },
+    [],
+    { fallback: "Failed to load users" },
+  );
 
   const toggle = async (u: User) => {
     setError("");
@@ -95,7 +95,7 @@ export function AdminUsers() {
 
   return (
     <AdminShell description="Deactivating a user blocks their login and immediately ends every active session.">
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {loading ? (
         <ListSkeleton rows={4} />
       ) : (

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import {
@@ -9,6 +9,7 @@ import {
   type BuiltinDefinition,
 } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import {
   driftedColumns,
   provenanceBadgeKind,
@@ -55,8 +56,6 @@ export function AgentDetail() {
   const isAdmin = !!user?.is_admin;
 
   const [template, setTemplate] = useState<AgentTemplate | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const [formError, setFormError] = useState("");
   const [notice, setNotice] = useState("");
   const [busy, setBusy] = useState(false);
@@ -65,8 +64,8 @@ export function AgentDetail() {
   // is a ref rather than lifted state.
   const editorRef = useRef<AgentTemplateEditorHandle>(null);
 
-  const load = useCallback(async () => {
-    try {
+  const { loading, error } = useAsyncData(
+    async () => {
       const { template } = await api.getAgentTemplate(id);
       setTemplate(template);
       // Only a caller who could actually press Reset has any use for the shipped
@@ -91,16 +90,10 @@ export function AgentDetail() {
           );
         }
       }
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load template"));
-    } finally {
-      setLoading(false);
-    }
-  }, [id, isAdmin]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+    },
+    [id, isAdmin],
+    { fallback: "Failed to load template" },
+  );
 
   const save = async (input: AgentTemplateInput) => {
     setFormError("");

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -4,11 +4,12 @@
 // admins additionally toggle which builtin/global templates are global defaults.
 // Anyone can author a private ("Mine") agent; admins can also publish globals.
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { api, type AgentTemplate, type TemplateAllocation } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import {
   isLeadTemplateName,
   provenanceBadgeKind,
@@ -33,35 +34,32 @@ const SHADOWED_HINT =
 export function Agents() {
   const { user } = useAuth();
   const isAdmin = !!user?.is_admin;
-  const [templates, setTemplates] = useState<AgentTemplate[]>([]);
+  // `allocations` is also written by the toggle handlers (setMyOverride /
+  // setGlobalDefault), so it stays local and the fetcher sets it as a side effect
+  // rather than routing through the hook's read-only `data`.
   const [allocations, setAllocations] = useState<TemplateAllocation[]>([]);
+  // `error` is the load error (from the hook, as `loadError`) OR a toggle-handler
+  // error kept here — the two share one Alert slot below.
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
-  const [loading, setLoading] = useState(true);
   // A single global busy flag disables ALL toggles during any in-flight
   // allocation PUT: each PUT replace-sets the whole half, so two rapid toggles
   // must not fire from stale state and drop one (reviewer M7 ride-along).
   const [busy, setBusy] = useState(false);
 
-  const load = useCallback(async () => {
-    setError("");
-    try {
+  const { data, loading, error: loadError } = useAsyncData(
+    async () => {
       const [{ templates }, { templates: alloc }] = await Promise.all([
         api.listAgentTemplates(),
         api.getTemplateAllocations(),
       ]);
-      setTemplates(templates);
       setAllocations(alloc);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load templates"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return { templates };
+    },
+    [],
+    { fallback: "Failed to load templates" },
+  );
+  const templates = useMemo(() => data?.templates ?? [], [data]);
 
   const allocById = useMemo(() => new Map(allocations.map((a) => [a.id, a])), [allocations]);
 
@@ -133,7 +131,7 @@ export function Agents() {
         }
       />
 
-      {error && <Alert message={error} />}
+      {(loadError || error) && <Alert message={loadError || error} />}
       {notice && <Alert message={notice} tone="success" />}
 
       {loading ? (

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { api, isTerminalRun, type Chat as ChatDTO, type Run, type Worker } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import {
   CHAT_MAX_TURNS,
   chatFromRun,
@@ -66,29 +67,23 @@ function ChatStatusBadge({ status }: { status: string }) {
 
 export function ChatList() {
   const navigate = useNavigate();
-  const [chats, setChats] = useState<ChatDTO[]>([]);
-  const [workers, setWorkers] = useState<Worker[]>([]);
-  const [loading, setLoading] = useState(true);
+  // `error` is the load error (from the hook, as `loadError`) OR a start/continue
+  // handler error kept here (startChat, and ConversationRow via onError) — the two
+  // share the one Alert slot below.
   const [error, setError] = useState("");
   const [prompt, setPrompt] = useState("");
   const [starting, setStarting] = useState(false);
 
-  const load = useCallback(async () => {
-    setError("");
-    try {
+  const { data, loading, error: loadError } = useAsyncData(
+    async () => {
       const [chatRes, { workers }] = await Promise.all([api.listChats(), api.listWorkers()]);
-      setChats(sortConversations(chatRes.chats));
-      setWorkers(workers);
-    } catch (e) {
-      setError(errorMessage(e, "Failed to load chats"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return { chats: sortConversations(chatRes.chats), workers };
+    },
+    [],
+    { fallback: "Failed to load chats" },
+  );
+  const chats = data?.chats ?? [];
+  const workers = data?.workers ?? [];
 
   const startChat = async () => {
     const p = prompt.trim();
@@ -117,7 +112,7 @@ export function ChatList() {
         description="Talk to uzi about itself, your runs, and ideas. It answers on your worker, from your token — and can draft issues you confirm."
       />
 
-      {error && <Alert message={error} />}
+      {(loadError || error) && <Alert message={loadError || error} />}
       {!loading && !online && <WorkerOfflineBanner />}
 
       <Card className="space-y-3">

--- a/web/src/pages/CliAuth.tsx
+++ b/web/src/pages/CliAuth.tsx
@@ -6,7 +6,7 @@
 // property: the server withholds the code precisely so this page cannot auto-fill
 // it and the human must confirm the tab belongs to their own invocation.
 
-import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import { Navigate, useLocation, useSearchParams } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import {
@@ -17,6 +17,7 @@ import {
   type CliTokenScope,
 } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Button, Card, Field, Input, Skeleton } from "../components/ui";
 import { ScopePicker } from "../components/ScopePicker";
 import { useDemoMode } from "../lib/demoMode";
@@ -31,16 +32,17 @@ const TERMINAL_STATUS_MESSAGE: Record<Exclude<CliAuthStatus, "pending">, string>
   expired: "This login request has expired. Run uzi login again in your terminal to start a new one.",
 };
 
+// The fetcher throws this sentinel when the page was opened without a ?request=
+// id — the hook only produces an error from a throw, and mapError maps it to the
+// missing-link message.
+const MISSING_REQUEST = Symbol("missing-request");
+
 export function CliAuth() {
   const demo = useDemoMode();
   const { user, loading: authLoading } = useAuth();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const requestId = searchParams.get("request");
-
-  const [meta, setMeta] = useState<CliAuthRequestMeta | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState("");
 
   const [code, setCode] = useState("");
   const [scope, setScope] = useState<CliTokenScope>("user");
@@ -52,35 +54,32 @@ export function CliAuth() {
 
   const isAdmin = user?.is_admin ?? false;
 
-  const load = useCallback(async () => {
-    if (!requestId) {
-      setLoadError("This link is missing its login request. Run uzi login again in your terminal.");
-      setLoading(false);
-      return;
-    }
-    try {
+  // Load only once the auth state is known and the user is signed in — otherwise
+  // the Navigate below sends them to log in first (the read is cookie-only).
+  const {
+    data: meta,
+    loading,
+    error: loadError,
+  } = useAsyncData<CliAuthRequestMeta>(
+    async () => {
+      if (!requestId) throw MISSING_REQUEST;
       const m = await api.getCliAuthRequest(requestId);
-      setMeta(m);
       if (m.status !== "pending") {
         setOutcome({ tone: "info", message: TERMINAL_STATUS_MESSAGE[m.status] });
       }
-    } catch (err) {
-      setLoadError(
-        err instanceof ApiError && err.status === 404
-          ? "This login request was not found. It may have already been used or expired."
-          : errorMessage(err, "Failed to load the login request."),
-      );
-    } finally {
-      setLoading(false);
-    }
-  }, [requestId]);
-
-  // Load only once the auth state is known and the user is signed in — otherwise
-  // the Navigate below sends them to log in first (the read is cookie-only).
-  useEffect(() => {
-    if (authLoading || !user) return;
-    load();
-  }, [authLoading, user, load]);
+      return m;
+    },
+    [requestId],
+    {
+      enabled: !authLoading && !!user,
+      mapError: (err) =>
+        err === MISSING_REQUEST
+          ? "This link is missing its login request. Run uzi login again in your terminal."
+          : err instanceof ApiError && err.status === 404
+            ? "This login request was not found. It may have already been used or expired."
+            : errorMessage(err, "Failed to load the login request."),
+    },
+  );
 
   // Not signed in → send to login, preserving the full URL so the consent page is
   // returned to after authenticating (password OR OIDC). The request id rides the

--- a/web/src/pages/Findings.tsx
+++ b/web/src/pages/Findings.tsx
@@ -24,6 +24,7 @@ import {
   type Repo,
 } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { stripUnsafeChars } from "../lib/safeText";
 import { useDemoMode } from "../lib/demoMode";
 import { maskRepoPath } from "../lib/demoMask";
@@ -64,8 +65,6 @@ export function Findings() {
 
   const [backlog, setBacklog] = useState<IncidentalFindingBacklog | null>(null);
   const [repos, setRepos] = useState<Repo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const [actionErr, setActionErr] = useState("");
   // Per-coordinate created-with-warning note from the just-clicked File (the forge issue WAS
   // created but its local disposition could not settle): kept so the filed row can surface the
@@ -75,28 +74,35 @@ export function Findings() {
   // backlog is the source of truth, so the row shows a friendly note and a reload reconciles.
   const [resolvedIds, setResolvedIds] = useState<Set<string>>(new Set());
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError("");
-    try {
-      const data = await api.listFindings(
-        bucket as IncidentalFindingBucket,
-        repoFilter || undefined,
-        runAnchor || undefined,
+  // backlog is ALSO written by patchRow (the optimistic File/Dismiss row update), so it
+  // stays local and is set as a side effect here rather than bundled into the hook's data.
+  // skeleton:"always" reproduces the old load's own setLoading(true), which fired on every
+  // call including the 409 handlers' reload. error is load-only (mutations use actionErr).
+  const {
+    loading,
+    error,
+    reload: load,
+  } = useAsyncData(
+    async () => {
+      setBacklog(
+        await api.listFindings(
+          bucket as IncidentalFindingBucket,
+          repoFilter || undefined,
+          runAnchor || undefined,
+        ),
       );
-      setBacklog(data);
-    } catch (e) {
-      setError(errorMessage(e, "Failed to load the findings backlog"));
-    } finally {
-      setLoading(false);
-    }
-  }, [bucket, repoFilter, runAnchor]);
+    },
+    [bucket, repoFilter, runAnchor],
+    { skeleton: "always", fallback: "Failed to load the findings backlog" },
+  );
 
+  // These resets are tied to a deps change (bucket/repo/run filter), NOT to a reload():
+  // the 409 File/Dismiss handlers call load() without clearing them, so they must stay in
+  // their own effect keyed on the same deps as the load, preserving that exact behavior.
   useEffect(() => {
     setFiledWarnings({});
     setResolvedIds(new Set());
-    load();
-  }, [load]);
+  }, [bucket, repoFilter, runAnchor]);
 
   // The repo scope selector's options. Best-effort (a failure leaves All-repos as the only
   // option, and the backlog still renders); the selector defaults to All-repos-grouped.

--- a/web/src/pages/ForgeSettings.tsx
+++ b/web/src/pages/ForgeSettings.tsx
@@ -3,9 +3,10 @@
 // on-demand "Check privileges" action). Inside SettingsShell; per-row busy
 // state instead of one page-wide busy flag.
 
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { Fragment, useState } from "react";
 import { api, ApiError, type ForgeConnection, type PrivilegeReport } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { privilegeBadge } from "../lib/privilege";
 import { forgePlatform } from "../lib/forgeNoun";
 import { inferForgeType, defaultUrlForType } from "../lib/forgeInfer";
@@ -81,14 +82,11 @@ function connectHints(forgeType: string): ConnectHints {
 
 export function ForgeSettings() {
   const demo = useDemoMode();
+  // `connections` is also patched in place by the privilege `check` handler, so it
+  // stays local and the fetcher below sets it as a side effect rather than routing
+  // through the hook's read-only `data`.
   const [connections, setConnections] = useState<ForgeConnection[]>([]);
-  const [allowedUrls, setAllowedUrls] = useState<string[]>([]);
   const [baseUrl, setBaseUrl] = useState("");
-  // The advertised forge types (PRD #65 D11). The picker below is shown only when
-  // more than one is advertised; while the API advertises just ["gitlab"] (today,
-  // until M6b), it stays hidden and forgeType defaults to that single value, so the
-  // connect form behaves exactly as before — the milestone lands dark.
-  const [forgeTypes, setForgeTypes] = useState<string[]>([]);
   const [forgeType, setForgeType] = useState("gitlab");
   // Cosmetic auto-change highlight (PRD #337 D9): when a sync handler moves the
   // *other* field, mark it so a CSS keyframe flashes it, making the coupling
@@ -105,18 +103,15 @@ export function ForgeSettings() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [checkingId, setCheckingId] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
   // Per-connection draft of the user's own forge username (PRD #19 M3). Seeded from
   // the stored value on load; keyed by connection id so multiple connections edit
   // independently.
   const [usernameDrafts, setUsernameDrafts] = useState<Record<string, string>>({});
 
-  const load = useCallback(async () => {
-    try {
+  const { data, loading, error: loadError, reload } = useAsyncData(
+    async () => {
       const [cfg, conns] = await Promise.all([api.forgeConfig(), api.listConnections()]);
-      setAllowedUrls(cfg.allowed_base_urls);
       setBaseUrl((prev) => prev || cfg.allowed_base_urls[0] || "");
-      setForgeTypes(cfg.forge_types);
       // The selection defaults to gitlab (the useState seed above), so a single-type
       // config sends forge_type: "gitlab" exactly as the form does now. Once the user
       // opens the picker (only shown when >1 type is advertised) their choice wins.
@@ -125,16 +120,17 @@ export function ForgeSettings() {
       setUsernameDrafts(
         Object.fromEntries(conns.connections.map((c) => [c.id, c.human_username ?? ""])),
       );
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load forge settings"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return { allowedUrls: cfg.allowed_base_urls, forgeTypes: cfg.forge_types };
+    },
+    [],
+    { fallback: "Failed to load forge settings" },
+  );
+  // The advertised forge types (PRD #65 D11). The picker below is shown only when
+  // more than one is advertised; while the API advertises just ["gitlab"] (today,
+  // until M6b), it stays hidden and forgeType defaults to that single value, so the
+  // connect form behaves exactly as before — the milestone lands dark.
+  const allowedUrls = data?.allowedUrls ?? [];
+  const forgeTypes = data?.forgeTypes ?? [];
 
   const resetMessages = () => {
     setError("");
@@ -151,7 +147,7 @@ export function ForgeSettings() {
       const { connection } = await api.createConnection(baseUrl, token, forgeType);
       setToken("");
       setNotice(`Connected as ${maskUsername(connection.bot_username, "bot", demo)}.`);
-      await load();
+      await reload();
     } catch (err) {
       if (err instanceof ApiError && err.status === 422) {
         const body = err.body as { violations?: string[] } | null;
@@ -171,7 +167,7 @@ export function ForgeSettings() {
     try {
       const { connection } = await api.verifyConnection(id);
       setNotice(`Verified ${maskUsername(connection.bot_username, "bot", demo)}.`);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Verify failed"));
     } finally {
@@ -206,7 +202,7 @@ export function ForgeSettings() {
     setBusyId(id);
     try {
       await api.deleteConnection(id);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Delete failed"));
     } finally {
@@ -230,7 +226,7 @@ export function ForgeSettings() {
             : "Forge username cleared.",
         );
       }
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Save failed"));
     } finally {
@@ -273,7 +269,7 @@ export function ForgeSettings() {
 
   return (
     <SettingsShell description="Connect the bot account uzi acts through.">
-      {error && <Alert message={error} />}
+      {(loadError || error) && <Alert message={loadError || error} />}
       {connectViolations && (
         <Card className="border-danger/40 bg-danger/5">
           <p className="text-sm font-medium text-danger">The token was not saved — it is over-privileged:</p>

--- a/web/src/pages/IssueView.tsx
+++ b/web/src/pages/IssueView.tsx
@@ -113,12 +113,19 @@ export function IssueView() {
           }
         }
         // Declined (or forced retry failed): clear starting, no toast on decline.
+        // The original load() began with setError(""), so a forced-retry failure
+        // toast never persisted (issue #856, spec: keep as-is); reload() does not
+        // clear it, so preserve that wipe explicitly here.
         setStarting(false);
+        setError("");
         reload();
         return;
       }
       setError(errorMessage(err, "Could not start run"));
       setStarting(false);
+      // As above: the old load() wiped this just-set message on entry so the toast
+      // never persisted; reproduce that clear now that reload() does not (issue #856).
+      setError("");
       reload();
     }
   };

--- a/web/src/pages/IssueView.tsx
+++ b/web/src/pages/IssueView.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { api, ApiError, isHttpsUrl, isOpenMRConflict, openMRConflictMRIID, preferForgeUrl, type IssueDetail, type RunListItem } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { hasAnthropicToken } from "../lib/hasToken";
 import { startRunGate } from "../lib/runStream";
 import { activeRunInHistory, effectiveRunStatus, isStoppedRun, mrChipState, runStatusTone } from "../lib/runBadge";
@@ -44,20 +45,20 @@ export function IssueView() {
   const navigate = useNavigate();
   const { uziLabel, autopilotLabel } = useAuth();
 
+  // `issue` is also written by the `promote` handler (setIssue at :promote), so it
+  // stays local and the fetcher sets it as a side effect rather than routing through
+  // the hook's read-only `data`.
   const [issue, setIssue] = useState<IssueDetail | null>(null);
-  const [runs, setRuns] = useState<RunListItem[]>([]);
-  const [hasWorker, setHasWorker] = useState(false);
-  const [hasToken, setHasToken] = useState(false);
-  const [loading, setLoading] = useState(true);
+  // `error` is the load error (from the hook, as `loadError`) OR a startRun/promote
+  // handler error kept here — the two share the one Alert slot below.
   const [error, setError] = useState("");
   const [starting, setStarting] = useState(false);
   const [promoting, setPromoting] = useState(false);
   // PRD #241: the "Schedule…" entry point, pre-pinned to this issue.
   const [scheduling, setScheduling] = useState(false);
 
-  const load = useCallback(async () => {
-    setError("");
-    try {
+  const { data, loading, error: loadError, reload } = useAsyncData(
+    async () => {
       const [{ issue }, { runs }, { workers }, { secrets }] = await Promise.all([
         api.getIssue(repoId, iidNum),
         api.listRuns({ repoId, issueIid: iidNum }),
@@ -65,19 +66,18 @@ export function IssueView() {
         api.listSecrets(),
       ]);
       setIssue(issue);
-      setRuns(runs);
-      setHasWorker(workers.length > 0);
-      setHasToken(hasAnthropicToken(secrets));
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load the issue"));
-    } finally {
-      setLoading(false);
-    }
-  }, [repoId, iidNum]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return {
+        runs,
+        hasWorker: workers.length > 0,
+        hasToken: hasAnthropicToken(secrets),
+      };
+    },
+    [repoId, iidNum],
+    { fallback: "Failed to load the issue" },
+  );
+  const runs = data?.runs ?? [];
+  const hasWorker = data?.hasWorker ?? false;
+  const hasToken = data?.hasToken ?? false;
 
   const startRun = async () => {
     if (!issue) return;
@@ -114,12 +114,12 @@ export function IssueView() {
         }
         // Declined (or forced retry failed): clear starting, no toast on decline.
         setStarting(false);
-        load();
+        reload();
         return;
       }
       setError(errorMessage(err, "Could not start run"));
       setStarting(false);
-      load();
+      reload();
     }
   };
 
@@ -166,7 +166,7 @@ export function IssueView() {
         <span className="text-muted">#{iid}</span>
       </nav>
 
-      {error && <Alert message={error} />}
+      {(loadError || error) && <Alert message={loadError || error} />}
       {loading && <p className="text-faint">Loading issue…</p>}
 
       {issue && (

--- a/web/src/pages/Notifications.tsx
+++ b/web/src/pages/Notifications.tsx
@@ -5,7 +5,7 @@
 // Marking read is own-row only; the bell badge in AppShell refreshes via the shared
 // change event.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { api, type Notification } from "../lib/api";
@@ -21,6 +21,7 @@ import {
   notificationTitle,
 } from "../lib/notifications";
 import { useJudgeTodo } from "../components/JudgeTodoContext";
+import { useAsyncData } from "../lib/useAsyncData";
 import { stripUnsafeChars } from "../lib/safeText";
 import { useDemoMode } from "../lib/demoMode";
 import { maskEmail, maskName, maskRepoPath } from "../lib/demoMask";
@@ -234,8 +235,9 @@ export function Notifications() {
   const [items, setItems] = useState<Notification[]>([]);
   const [unread, setUnread] = useState(0);
   const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  // error carries loadMore's failure; the primary load's failure comes from the
+  // hook below. The union of the two is rendered (see displayError).
   const [error, setError] = useState("");
 
   // The API paginates (offset/limit); the page walks it with a Load-more button
@@ -252,24 +254,22 @@ export function Notifications() {
     [scope],
   );
 
-  const load = useCallback(async () => {
-    setError("");
-    try {
+  // Primary load. items/unread/total are ALSO written by loadMore/markRead, so they
+  // stay local and are set as side effects here (never bundled into the hook's data).
+  // skeleton:"deps" reproduces the old setLoading(true) that lived in the EFFECT — it
+  // fired on every scope switch (a deps-driven refetch) but not on a manual reload.
+  const { loading, error: loadError } = useAsyncData(
+    async () => {
       const res = await fetchPage(0);
       setItems(res.notifications);
       setUnread(res.unread);
       setTotal(res.total);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load notifications"));
-    } finally {
-      setLoading(false);
-    }
-  }, [fetchPage]);
+    },
+    [fetchPage],
+    { skeleton: "deps", fallback: "Failed to load notifications" },
+  );
 
-  useEffect(() => {
-    setLoading(true);
-    load();
-  }, [load]);
+  const displayError = error || loadError;
 
   const loadMore = async () => {
     setLoadingMore(true);
@@ -339,10 +339,10 @@ export function Notifications() {
         }
       />
 
-      {error && <Alert message={error} />}
+      {displayError && <Alert message={displayError} />}
       {loading && <ListSkeleton rows={4} />}
 
-      {!loading && !error && (
+      {!loading && !displayError && (
         <>
           {items.length === 0 ? (
             <EmptyState

--- a/web/src/pages/RunDefaults.tsx
+++ b/web/src/pages/RunDefaults.tsx
@@ -5,10 +5,11 @@
 // in one scroll; the discriminator is that everything here shapes future runs,
 // while everything on Account is who you are and what you hold.
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useAuth } from "../auth/AuthContext";
-import { api, type SecretMeta } from "../lib/api";
+import { api } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Button, Card, Field, SectionTitle, Select, Skeleton } from "../components/ui";
 import { ModelSelect } from "../components/ModelSelect";
 import { EffortSelect } from "../components/EffortSelect";
@@ -17,8 +18,8 @@ import { SettingsShell } from "../components/SettingsShell";
 
 export function RunDefaults() {
   const { user, refresh, judgeEnforcedByAdmin, effectiveJudgeModel } = useAuth();
-  const [secrets, setSecrets] = useState<SecretMeta[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Kept local: the save handlers below still set this on failure, so it is merged
+  // with the hook's load error at the one page-level Alert.
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
   const [autopilotBusy, setAutopilotBusy] = useState(false);
@@ -187,13 +188,15 @@ export function RunDefaults() {
   const [effortBusy, setEffortBusy] = useState(false);
 
   // secrets feed the judge token picker; settings carry the saved worker model.
-  const load = useCallback(async () => {
-    try {
+  // secrets is read-only display, set only here, so it rides in the hook's data
+  // bundle. The settings fields seed editable form state the Save handlers also
+  // write, so they stay local and are seeded as side effects exactly as before.
+  const { data, loading, error: loadError } = useAsyncData(
+    async () => {
       const [{ secrets: rows }, { settings }] = await Promise.all([
         api.listSecrets(),
         api.getMySettings(),
       ]);
-      setSecrets(rows.filter((s) => s.kind === "anthropic_token"));
       const model = settings.default_model ?? "";
       setDefaultModel(model);
       setSavedModel(model);
@@ -207,16 +210,12 @@ export function RunDefaults() {
       setDefaultEffort(eff);
       setSavedEffort(eff);
       setMrReworkEnabled(settings.mr_rework_enabled ?? null);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load settings"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return { secrets: rows.filter((s) => s.kind === "anthropic_token") };
+    },
+    [],
+    { fallback: "Failed to load settings" },
+  );
+  const secrets = data?.secrets ?? [];
 
   const modelWarning = modelFieldWarning(defaultModel);
   const modelDirty = defaultModel.trim() !== savedModel;
@@ -323,7 +322,7 @@ export function RunDefaults() {
 
   return (
     <SettingsShell description="How your runs behave: autopilot, usage limits, the judge, CI fixes, the model, and reasoning effort.">
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {notice && <Alert tone="success" message={notice} />}
 
       <Card className="space-y-4">

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -35,6 +35,7 @@ import { canToggleWaitOnLimit, formatCountdown, runWindowLabel } from "../lib/li
 import { canToggleMrRework, effectiveMrRework } from "../lib/mrRework";
 import { stripUnsafeChars } from "../lib/safeText";
 import { useNow } from "../lib/useNow";
+import { useAsyncData } from "../lib/useAsyncData";
 import { effectiveWorkerCaps } from "../lib/workerCaps";
 import { AgentPicker, selectionLabel, type OwnTemplate } from "../components/AgentPicker";
 import {
@@ -2214,8 +2215,6 @@ export function JudgePanel({
   pollMaxTries?: number;
 }) {
   const [review, setReview] = useState<RunReview | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadErr, setLoadErr] = useState("");
   const [actionErr, setActionErr] = useState("");
   const [rerunning, setRerunning] = useState(false);
   const [queued, setQueued] = useState(false);
@@ -2240,8 +2239,18 @@ export function JudgePanel({
 
   const eligible = JUDGE_ELIGIBLE_KINDS.has(run.kind);
 
-  const fetchReview = useCallback(async () => {
-    try {
+  // The mount load, via useAsyncData: enabled:eligible reproduces the old effect's
+  // `if (!eligible) { setLoading(false); return; }` (eligible is derived from run.kind,
+  // stable per mount). review/pendingJudge/baselineUpdatedAt are ALSO written by the poll
+  // and the 409 re-fetch, so they stay local and are set as side effects here (never
+  // bundled into the hook's data). The hook clears its error on success, so no explicit
+  // clear is needed; the old catch's fallback becomes `fallback`.
+  const {
+    loading,
+    error: loadErr,
+    reload: fetchReview,
+  } = useAsyncData(
+    async () => {
       const { review, pending_judge } = await api.getRunReview(run.id);
       setReview(review);
       // Seed the poll's baseline to the verdict this fetch just put on screen (see the
@@ -2256,21 +2265,10 @@ export function JudgePanel({
       // the whole app over a missing optional field. (api/internal/uzicli/client.go
       // handles the same skew on the CLI side.)
       setPendingJudge(pending_judge ?? null);
-      setLoadErr("");
-    } catch (e) {
-      setLoadErr(errorMessage(e, "Failed to load the review"));
-    } finally {
-      setLoading(false);
-    }
-  }, [run.id]);
-
-  useEffect(() => {
-    if (!eligible) {
-      setLoading(false);
-      return;
-    }
-    fetchReview();
-  }, [eligible, fetchReview]);
+    },
+    [run.id],
+    { enabled: eligible, fallback: "Failed to load the review" },
+  );
 
   // The file-issue picker lists every repo the caller has connected (PRD #68 Decision 4).
   // Best-effort: a failure (or a bare test double) just leaves the picker empty.

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -5,7 +5,7 @@
 // a fired `once` row shows as terminal; a status='error' (parked) row is called out
 // distinctly. The "New schedule" button and the per-row ✎ open the shared modal.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   api,
   ApiError,
@@ -15,6 +15,7 @@ import {
   type ScheduleCatalog,
 } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { relativeFromNow, ScheduleModal } from "../components/ScheduleModal";
 import { browserTimezone } from "../lib/timezone";
 import { useDemoMode } from "../lib/demoMode";
@@ -101,8 +102,17 @@ export function Schedules() {
     tabRefs.current[target]?.focus();
   };
 
-  const load = useCallback(async () => {
-    try {
+  // schedules/catalog/repos are seeded here as fetcher side effects because all three
+  // are read AND written outside the load — the optimistic enable toggle rewrites
+  // schedules — so they stay local state rather than being derived from the hook's
+  // data. The hook owns the load error (surfaced as loadError, unioned with the
+  // mutation error below) and keeps the last-good rows on a reload failure, matching
+  // the old catch's `cur ?? []` (which kept the existing rows). No loading flag: the
+  // null schedules/catalog still gate the skeleton exactly as before, and on a
+  // first-load failure the fetcher throws before seeding so both stay null, which
+  // renders the skeleton the same as the old code did with catalog still null.
+  const { error: loadError, reload } = useAsyncData(
+    async () => {
       const [rows, cat, repoList] = await Promise.all([
         api.listSchedules(),
         api.listScheduleCatalog(),
@@ -111,16 +121,10 @@ export function Schedules() {
       setSchedules(rows);
       setCatalog(cat);
       setRepos(repoList);
-      setError("");
-    } catch (err) {
-      setError(errorMessage(err, "Could not load schedules"));
-      setSchedules((cur) => cur ?? []);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+    },
+    [],
+    { fallback: "Could not load schedules" },
+  );
 
   const toggleEnabled = async (s: Schedule) => {
     setBusyId(s.id);
@@ -133,7 +137,7 @@ export function Schedules() {
       const updated = await api.updateSchedule(s.id, { enabled: !s.enabled });
       setSchedules((rows) => (rows ? rows.map((r) => (r.id === s.id ? updated : r)) : rows));
       // Keep the catalog view's enablement pause-flags in sync.
-      load();
+      reload();
     } catch (err) {
       setError(errorMessage(err, "Could not update the schedule"));
       // Revert on failure.
@@ -156,7 +160,7 @@ export function Schedules() {
           ? `Started ${created} run${created === 1 ? "" : "s"} from this schedule.`
           : "Nothing fired — a matching run is already active (skipped by dedup).",
       );
-      load();
+      reload();
     } catch (err) {
       setError(errorMessage(err, "Could not run the schedule now"));
     } finally {
@@ -194,7 +198,7 @@ export function Schedules() {
           `Enabled “${entry.name}” on ${ok} repo${ok === 1 ? "" : "s"} → ${ok} schedule${ok === 1 ? "" : "s"}.`,
         );
       }
-      await load();
+      await reload();
     } finally {
       setBusyId("");
     }
@@ -207,7 +211,7 @@ export function Schedules() {
     try {
       await api.resetSchedule(s.id);
       setNotice("Reset to the catalog default.");
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Could not reset the schedule"));
     } finally {
@@ -225,7 +229,7 @@ export function Schedules() {
       const clone = await api.cloneSchedule(s.id);
       const label = s.origin === "default" && s.catalog_slug ? catalogName(catalog, s.catalog_slug) : "a schedule";
       setClonedFrom((m) => ({ ...m, [clone.id]: label }));
-      await load();
+      await reload();
       setEditing(clone);
       setTab("mine");
     } catch (err) {
@@ -240,7 +244,7 @@ export function Schedules() {
     setError("");
     try {
       await api.deleteSchedule(s.id);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Could not remove the schedule"));
     } finally {
@@ -268,7 +272,7 @@ export function Schedules() {
     try {
       const sibling = await api.addScheduleRepo(source.id, repoId);
       setNotice("Added on another repo.");
-      await load();
+      await reload();
       if (sibling.sibling_group_id) {
         setExpandedGroups((s) => new Set(s).add(sibling.sibling_group_id as string));
       }
@@ -286,7 +290,7 @@ export function Schedules() {
   const onSaved = () => {
     setCreating(false);
     setEditing(null);
-    load();
+    reload();
   };
 
   // My schedules holds the owner-authored (and cloned) rows; catalog defaults live in
@@ -364,7 +368,7 @@ export function Schedules() {
             onRemove={removeSchedule}
             onEdit={setEditing}
             notice={notice}
-            error={error}
+            error={error || loadError}
           />
         </div>
       ) : (
@@ -374,7 +378,7 @@ export function Schedules() {
           id={panelId("mine")}
           aria-labelledby={tabId("mine")}
         >
-          {error && <Alert message={error} />}
+          {(error || loadError) && <Alert message={error || loadError} />}
           {notice && <Alert message={notice} tone="info" />}
           <p className="text-sm text-muted">
             {total === 0

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -7,10 +7,11 @@
 // model) moved to the Run defaults tab (RunDefaults.tsx): this tab is who you
 // are and what you hold, that one is how your runs behave.
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useAuth } from "../auth/AuthContext";
 import { api, type SecretMeta } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Button, Card, Field, SectionTitle, Select, Toggle } from "../components/ui";
 import { AnthropicTokens } from "../components/AnthropicTokens";
 import { SettingsShell } from "../components/SettingsShell";
@@ -39,11 +40,11 @@ export function Settings() {
     prefs.set(ROTATE_NOTICE_KEY, true);
     setRotateDismissed(true);
   };
-  const [secrets, setSecrets] = useState<SecretMeta[]>([]);
-  const [loading, setLoading] = useState(true);
   // busy is the page-level guard the token card also respects, so two token
   // mutations cannot race each other's reloads.
   const [busy] = useState(false);
+  // `error` is the load error (from the hook, as `loadError`) OR an error set by a
+  // mutation handler / the token card here — the two share the one Alert slot below.
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
 
@@ -52,24 +53,19 @@ export function Settings() {
   // load and reload together.
   const [sidebarTokenIds, setSidebarTokenIds] = useState<string[]>([]);
 
-  const load = useCallback(async () => {
-    try {
+  const { data, loading, error: loadError, reload } = useAsyncData(
+    async () => {
       const [{ secrets: rows }, { settings }] = await Promise.all([
         api.listSecrets(),
         api.getMySettings(),
       ]);
-      setSecrets(rows.filter((s) => s.kind === "anthropic_token"));
       setSidebarTokenIds(settings.sidebar_token_ids ?? []);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load settings"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      return { secrets: rows.filter((s) => s.kind === "anthropic_token") };
+    },
+    [],
+    { fallback: "Failed to load settings" },
+  );
+  const secrets: SecretMeta[] = data?.secrets ?? [];
 
   // Whole-set replace over PUT /me/settings, then tell the sidebar rail (a
   // separate mount) to refetch now rather than on its next poll.
@@ -117,14 +113,14 @@ export function Settings() {
 
   return (
     <SettingsShell description="Your Anthropic tokens, vault, appearance, and account.">
-      {error && <Alert message={error} />}
+      {(loadError || error) && <Alert message={loadError || error} />}
       {notice && <Alert tone="success" message={notice} />}
 
       <AnthropicTokens
         secrets={secrets}
         loading={loading}
         busy={busy}
-        reload={load}
+        reload={reload}
         onError={setError}
         onNotice={setNotice}
         judgeSecretId={user?.judge_anthropic_secret_id ?? null}

--- a/web/src/pages/Skills.tsx
+++ b/web/src/pages/Skills.tsx
@@ -3,10 +3,11 @@
 // read returns them; admins see all scopes). Everyone can author their own
 // "Mine" skills; only admins create Global or edit/reset Builtin & Global.
 
-import { useCallback, useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
+import { useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { useAuth } from "../auth/AuthContext";
 import { api, type Skill, type SkillScope } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import {
   bodyError,
   byteLength,
@@ -43,28 +44,25 @@ type ConfirmState = { id: string; action: "reset" | "delete" } | null;
 export function Skills() {
   const { user } = useAuth();
   const isAdmin = !!user?.is_admin;
-  const [skills, setSkills] = useState<Skill[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    data,
+    loading,
+    error: loadError,
+    reload,
+  } = useAsyncData<{ skills: Skill[] }>(
+    async () => {
+      const { skills } = await api.listSkills();
+      return { skills };
+    },
+    [],
+    { fallback: "Failed to load skills" },
+  );
+  const skills = useMemo(() => data?.skills ?? [], [data]);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
   const [edit, setEdit] = useState<EditState>(null);
   const [confirm, setConfirm] = useState<ConfirmState>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    try {
-      const { skills } = await api.listSkills();
-      setSkills(skills);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load skills"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
 
   const groups = useMemo(() => {
     const builtin: Skill[] = [];
@@ -83,7 +81,7 @@ export function Skills() {
   const afterSave = (msg: string) => {
     setEdit(null);
     setNotice(msg);
-    load();
+    reload();
   };
 
   const runReset = async (id: string) => {
@@ -93,7 +91,7 @@ export function Skills() {
     try {
       await api.resetSkill(id);
       setNotice("Reset to the shipped default.");
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to reset"));
     } finally {
@@ -108,7 +106,7 @@ export function Skills() {
     try {
       await api.deleteSkill(id);
       setNotice("Skill deleted.");
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to delete"));
     } finally {
@@ -164,7 +162,7 @@ export function Skills() {
         }
       />
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
       {notice && <Alert message={notice} tone="success" />}
 
       {loading ? (

--- a/web/src/pages/ToolAllowlist.tsx
+++ b/web/src/pages/ToolAllowlist.tsx
@@ -2,9 +2,10 @@
 // tool profile. Admin-only page (gated by AdminRoute). The version policy is
 // optional: leave "Pinned version" blank to allow any version.
 
-import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import { api, type ToolAllowlistEntry } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
+import { useAsyncData } from "../lib/useAsyncData";
 import { Alert, Button, Card, EmptyState, Field, Input, ListSkeleton } from "../components/ui";
 import { AdminShell } from "../components/AdminShell";
 import { DocLink } from "../components/DocLink";
@@ -12,28 +13,25 @@ import { DOC_WORKER_TOOLS } from "../lib/doclinks";
 import { PackageIcon } from "../components/icons";
 
 export function ToolAllowlist() {
-  const [entries, setEntries] = useState<ToolAllowlistEntry[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    data,
+    loading,
+    error: loadError,
+    reload,
+  } = useAsyncData<{ entries: ToolAllowlistEntry[] }>(
+    async () => {
+      const { allowlist } = await api.listToolAllowlist();
+      return { entries: allowlist };
+    },
+    [],
+    { fallback: "Failed to load the allowlist" },
+  );
+  const entries = data?.entries ?? [];
   const [error, setError] = useState("");
   const [name, setName] = useState("");
   const [pinned, setPinned] = useState("");
   const [note, setNote] = useState("");
   const [busy, setBusy] = useState(false);
-
-  const load = useCallback(async () => {
-    try {
-      const { allowlist } = await api.listToolAllowlist();
-      setEntries(allowlist);
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load the allowlist"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
 
   const add = async (e: FormEvent) => {
     e.preventDefault();
@@ -48,7 +46,7 @@ export function ToolAllowlist() {
       setName("");
       setPinned("");
       setNote("");
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to add the package"));
     } finally {
@@ -60,7 +58,7 @@ export function ToolAllowlist() {
     setError("");
     try {
       await api.deleteToolAllowlistEntry(id);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to remove the package"));
     }
@@ -77,7 +75,7 @@ export function ToolAllowlist() {
       }
     >
 
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
 
       <Card className="space-y-4">
         <form onSubmit={add} className="flex flex-wrap items-end gap-3">

--- a/web/src/pages/WorkersSettings.tsx
+++ b/web/src/pages/WorkersSettings.tsx
@@ -6,7 +6,7 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
 
-import { api, type BindMode, type SecretMeta, type Worker } from "../lib/api";
+import { api, type BindMode, type Worker } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
 import { Alert, Badge, Button, Card, EmptyState, Field, Input, PageHeader, SectionTitle, Select, Skeleton } from "../components/ui";
 import { FleetUpgradePanel, WorkerUpgradeBadge, WorkerUpgradeDetail } from "../components/WorkerUpgradeBadge";
@@ -18,6 +18,7 @@ import { WorkerRunBadge } from "../components/WorkerRunBadge";
 import { WorkerCordonBadge } from "../components/WorkerCordonBadge";
 import { WorkerStatGauges, formatBytes } from "../components/WorkerStats";
 import { usePollWhileVisible } from "../lib/usePollWhileVisible";
+import { useAsyncData } from "../lib/useAsyncData";
 import { stripUnsafeChars } from "../lib/safeText";
 import { formatUptimeSince } from "../lib/formatUptimeSince";
 import { DocLink } from "../components/DocLink";
@@ -44,9 +45,22 @@ export function WorkersSettings() {
   // The control plane's own release, from the same memoised GET /api/version the footer
   // uses — one coordinate, so the panel and the footer cannot disagree.
   const cpVersion = useAppVersion();
-  // The user's named tokens, for the per-worker picker (PRD #104 M3/M6). Read
-  // alongside the workers so a rebind can offer labels without a second round trip.
-  const [tokens, setTokens] = useState<SecretMeta[]>([]);
+  // The primary load reads workers + the user's named tokens together (PRD #104
+  // M3/M6) so a rebind can offer labels without a second round trip. Migrated to
+  // useAsyncData (PRD #950 M3, Tier C): `workers` is ALSO written by the separate
+  // 10s poll and by the mutation handlers, so it stays local state and the fetcher
+  // seeds it as a side effect; `tokens` is written only by this load, so it rides
+  // the hook's data bundle. The separate error-swallowing poll below is unchanged.
+  const { data, loading, error: loadError, reload } = useAsyncData(
+    async () => {
+      const [{ workers }, { secrets }] = await Promise.all([api.listWorkers(), api.listSecrets()]);
+      setWorkers(workers);
+      return secrets.filter((s) => s.kind === "anthropic_token");
+    },
+    [],
+    { fallback: "Failed to load workers" },
+  );
+  const tokens = data ?? [];
   // How many of them are opted into the auto-selection pool (web-ux F18). An `auto`
   // worker with ZERO pooled tokens HOLDS every claim in pool_wait (spending nothing,
   // #754) rather than falling back to the owner's default, so the page must not say it
@@ -54,7 +68,6 @@ export function WorkersSettings() {
   const pooledCount = tokens.filter((t) => t.auto_eligible).length;
   // Which worker's rebind is in flight, so only that row's picker disables.
   const [tokenBusy, setTokenBusy] = useState("");
-  const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
   // The declared worker template (PRD #18): what image the user says this worker
   // will run. Defaults to the base image; the worker later self-reports its
@@ -96,18 +109,6 @@ export function WorkersSettings() {
   const noticeRef = useRef<HTMLDivElement>(null);
   const announce = useCallback((text: string, tone: "success" | "warning" = "success") => {
     setNotice({ text, tone });
-  }, []);
-
-  const load = useCallback(async () => {
-    try {
-      const [{ workers }, { secrets }] = await Promise.all([api.listWorkers(), api.listSecrets()]);
-      setWorkers(workers);
-      setTokens(secrets.filter((s) => s.kind === "anthropic_token"));
-    } catch (err) {
-      setError(errorMessage(err, "Failed to load workers"));
-    } finally {
-      setLoading(false);
-    }
   }, []);
 
   // rebind points one worker at a named token, or clears the binding when the
@@ -177,10 +178,6 @@ export function WorkersSettings() {
     [pooledCount, announce],
   );
 
-  useEffect(() => {
-    load();
-  }, [load]);
-
   // Liveness (PRD #49): re-fetch the fleet every 10s while the tab is visible — the
   // same rhythm the Dashboard uses — so live CPU/memory gauges refresh without a
   // reload (heartbeat cadence 15s × this 10s poll). A poll error keeps the last-good
@@ -205,7 +202,7 @@ export function WorkersSettings() {
       setCopied(false);
       setName("");
       setTemplate(DEFAULT_WORKER_TEMPLATE);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to create worker"));
     } finally {
@@ -225,7 +222,7 @@ export function WorkersSettings() {
       // clicks and takes nothing back from the asymmetry the confirmation buys. A row
       // that silently vanishes is poor feedback whichever kind it was.
       announce(`Deleted ${stripUnsafeChars(name ?? "worker")}.`);
-      await load();
+      await reload();
     } catch (err) {
       setError(errorMessage(err, "Failed to delete worker"));
     }
@@ -302,7 +299,7 @@ export function WorkersSettings() {
           </>
         }
       />
-      {error && <Alert message={error} />}
+      {(error || loadError) && <Alert message={error || loadError} />}
 
       {newToken && (
         <Card className="space-y-3 border-ok/40">
@@ -391,7 +388,7 @@ export function WorkersSettings() {
         hostedCount={workers.filter((w) => w.kind === "hosted").length}
         onProvisioned={async (worker) => {
           announce(`Provisioned ${worker.name} — it appears in your workers below.`);
-          await load();
+          await reload();
         }}
       />
 


### PR DESCRIPTION
Implements issue #950.

Closes #950

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-950`. Please review and merge manually — the agent never merges.