### PR TITLE
docs(rules): prds.md gains the push-protection class; PVC recovery corrects the unrecoverable claim

### DIFF
--- a/.claude/rules/prds.md
+++ b/.claude/rules/prds.md
@@ -17,8 +17,11 @@ is by design, not a bug to "fix" by widening the token. GitHub enforces the scop
 at the **push**, and the push is **atomic**: if the branch diff touches even one
 file under `.github/workflows/`, the *entire* push is rejected (`refusing to allow
 a Personal Access Token to create or update workflow … without workflow scope`) and
-**every commit on the branch is lost and unrecoverable** — the worker container is
-gone and nothing lands on the remote. Issue #377 makes that failure *graceful* (it
+**nothing lands on the remote**. On a hosted (k8s) worker the commits are NOT lost:
+they survive in the worker PVC at `refs/uzi-runner/agent/issue-N` and are recoverable
+per the `uzi-watcher` skill's *Recovering a failed run's work from the worker PVC*
+(measured twice: #422 on 2026-08-20, #954 on 2026-09-01; this sentence said "lost
+and unrecoverable" until the second one). Issue #377 makes that failure *graceful* (it
 detects the case pre-push, fails early with a typed reason, and preserves the diff
 for a human to land) but does **not** remove it.
 
@@ -61,3 +64,43 @@ rebase fallback) before pushing — no PRD authoring change needed for it. See
 [ADR-456](../../adr/0456-rebase-before-finalize-push.md). It still fails cleanly
 with the diff preserved if the realignment itself conflicts, so a PRD is never
 silently corrupted by it either way.
+
+## 🔴 A PRD whose tests need secret-SHAPED strings must assemble them at runtime, and its gate must include `task scan:secrets`
+
+The **second** push-rejection class, same shape as the workflow-scope one above and
+found the same way (a finished run that could not push). **GitHub Push Protection**
+scans **every commit in a push** against provider token patterns (GitLab `glpat-` +
+20 chars, GitHub `ghp_`/`github_pat_`, Slack `xox…`, and so on) and refuses the whole
+push with `GH013 … Push cannot contain secrets`. Two properties make it a PRD
+authoring concern rather than a worker bug:
+
+- **The worker's gate cannot see it.** A PRD names its component gate (`task
+  gate:api`); the secret scan (`task scan:secrets`, gitleaks over every tracked file
+  with a canary) lives in **`gate:repo`**, so a run can be gate-green through every
+  milestone and still be unpushable at finalize.
+- **A fix on top does not help.** Because every commit in the range is scanned, a
+  later commit that removes the literal still ships the commit that introduced it.
+  The literal must never be committed: fold the fix into the introducing commit
+  before the first push (a `--soft` reset and re-commit; nothing was on the remote).
+
+Measured 2026-09-01, PRD #954: M1 widened the `secretscrub` GitLab pattern to a
+`{16,}` body, which forced the slacksvc fixtures from `glpat-x` to a 20-character
+token — exactly the shape gitleaks' `gitlab-pat` rule and GitHub's scanner match.
+`task scan:secrets` reported 4 findings (`redact_test.go:43,:45`,
+`replier_test.go:587,:592`), the push was refused after all three milestones were
+done and reviewed, and the work was recovered from the PVC and landed as PR #968.
+
+So, when a PRD touches `secretscrub`, `snapshotSecretPatterns`, a redaction test, or
+any test that feeds a credential-shaped value through a scrubber:
+
+1. **Build the fixture from parts**, never as one literal: `const fake = "glpat-" +
+   "notAReal" + "0123456789"` (or `strings.Repeat`). The scrub sees the joined value
+   at runtime; the source never carries a token shape. Say why in a comment beside
+   it.
+2. **Put `task scan:secrets` in the PRD's per-milestone gate line**, next to the
+   component gate, and require the canaries-detected line in the run's evidence.
+3. **`//gitleaks:allow` with a written justification** is the in-repo precedent for a
+   literal that must stay literal (`slacksvc/chatactions_test.go`), and it silences
+   only gitleaks. GitHub Push Protection has no in-file allow directive (only an
+   out-of-band bypass URL), so for any shape GitHub recognises, runtime assembly is
+   the only form that satisfies both scanners.


### PR DESCRIPTION
Docs only (`.claude/rules/prds.md`, +45/−2). Opened as a PR rather than direct-to-main so CodeRabbit reviews the wording.

**New section** — a PRD whose tests need secret-shaped strings must assemble them at runtime, and its gate must include `task scan:secrets`. GitHub Push Protection scans every commit in a push (so a fix on top does not help), and the worker's component gate cannot see it because `scan:secrets` lives in `gate:repo`. Measured 2026-09-01 on PRD #954: the widened `{16,}` GitLab scrub body forced 20-character `glpat-` fixtures, gitleaks reported 4 findings, the push was refused after all three milestones, and the work was recovered from the worker PVC as #968.

**Fix-the-doc** — the workflow-scope section claimed a refused push leaves the work "lost and unrecoverable". Two PVC recoveries (#422 on 2026-08-20, #954 on 2026-09-01) disproved it; the sentence now says the commits survive at `refs/uzi-runner/agent/issue-N` and points at the `uzi-watcher` skill's recovery section, with the correction dated.

Related: #954, #968, epic #915.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product guidance to clarify that workflow-scope push failures preserve hosted-worker commits for recovery.
  * Added testing guidance for secret-shaped fixtures, including runtime assembly, secret scanning milestone gates, and documented exceptions for unavoidable literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->