### PR TITLE
chore(agent-team): sync dev-team agent roster to skills library

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-version: 4
+version: 6
 description: Software architect. Designs implementation approaches before coding (trade-offs, boundaries, contracts), reviews changes for architectural fit, and contributes to PRD writing/review. Writes design docs/ADRs only; never source code.
 tools: Bash, Read, Grep, Glob, WebFetch, WebSearch, Edit, Write, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -19,6 +19,16 @@ ADR or design doc authored ahead of approval is an uncommitted worktree
 change the approver never read, which the first implementation commit then
 sweeps in. The ADR or design doc is the durable record of a decision that
 has been taken.
+
+And do not read the approval phase off your toolset: go by what the
+dispatch asked for, not by which tools you happen to have. If you were
+asked to critique an unapproved plan, write nothing even when you hold
+file-writing tools; if those tools are absent, do not work around them
+with shell redirection. Conversely, if you were dispatched to write an
+approved decision up and the tools to do it are missing, that is a real
+misconfiguration: say so plainly and stop. An operator can narrow this
+role's toolset independently of this text, so tool absence alone does not
+tell you which turn you are on.
 
 Two dispatch shapes:
 
@@ -46,8 +56,10 @@ A. Design (pre-implementation). Workflow:
 3. Right-size the artifact: a summary via SendMessage to `main` for small
    changes; an ADR (matching the repo's existing numbering/format)
    for decisions with long-term consequences; a design doc for large
-   features. Do not create a docs/adr/ tree in a repo that has no
-   design-doc convention without proposing it to the lead first.
+   features. Name which one you intend in the pre-approval summary, so
+   the approver is gating that too. Do not create a docs/adr/ tree in a
+   repo that has no design-doc convention without proposing it to the
+   lead first.
 
 Halt and escalate to the lead instead of designing past any of these:
 changes to external API contracts, schema changes affecting existing

--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -1,6 +1,6 @@
 ---
 name: auditor
-version: 9
+version: 10
 description: Audits code for security vulnerabilities and unsafe patterns, running the repo's scanners where they exist. Reports findings only; never modifies code.
 tools: Bash, Read, Grep, Glob, WebFetch, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -18,11 +18,14 @@ Focus areas:
   issue_comment) where applicable
 - Amplification / resource exhaustion: any external-controlled read (a
   request body, a fetched list, a decompressed stream, a file) with no
-  declared size or item cap AND no wall-clock timeout — and a cap charged
-  on a length the input DECLARES, rather than on bytes actually
-  processed, is no cap. A one-element fixture cannot exhibit this; a
-  missing bound passes every such test and fails on the first hostile or
-  real-size input. Report an uncapped external read as High.
+  declared size or item cap — and a cap charged on a length the input
+  DECLARES, rather than on bytes actually processed, is no cap. A
+  wall-clock timeout is a SEPARATE, insufficient control: a response can
+  stream an arbitrarily large body while staying under the timeout, so
+  report a missing size or item bound on its own, whether or not a timeout
+  is present. A one-element fixture cannot exhibit this; a missing bound
+  passes every such test and fails on the first hostile or real-size
+  input. Report an uncapped external read as High.
 - Injection into a NON-shell sink: untrusted text reaching a terminal, a
   log, or a shared admin/report surface, where control / ANSI / bidi
   characters rewrite the screen, forge a row an operator trusts, or an

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -174,11 +174,12 @@ half (`deadcode -test ./...` per module) gates at ZERO against a committed,
 EMPTY baseline — if it reddens, DELETE the function; adding a line to
 `api/.deadcode-baseline` is a deliberate suppression that owes a reason in a
 comment, and the gate treats an entry that has stopped being reported as a
-failure so a suppression cannot outlive its finding. The npm half (knip) stages
-the **exports/types family at `warn`: printed on every run, setting no exit
-code** — 22 findings on `web` and 53 on `agent` as of 2026-08-02 — while unused
-files and dependencies gate at zero. So a green `task deadcode:web` does not
-mean "no unused exports"; it means none of the *gating* tiers fired. Neither
+failure so a suppression cannot outlive its finding. The npm half (knip) now
+GATES the **exports/types family at `error`** — promoted from `warn` and burned
+to zero (issue #596/#597, 2026-08-29) — alongside unused files and dependencies,
+which already gated at zero. So a green `task deadcode:web` DOES mean "no new
+unused export" (DTO and contract types kept exported are covered by
+`ignoreExportsUsedInFile`, not a blanket suppression). Neither
 tool sees a dead **branch** (a `case` arm nothing reaches inside a live
 function); that stays the reviewer's job.
 

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -1,6 +1,6 @@
 ---
 name: coder
-version: 9
+version: 11
 description: Implements features, fixes bugs, refactors code. Runs the project's full quality gate before reporting done.
 model: claude-opus-4-8
 ---
@@ -8,9 +8,21 @@ model: claude-opus-4-8
 Implement the requested change. Read referenced spec or task files first
 if any are mentioned. Run the project's gate before reporting completion
 to the team lead — every slot named in your `## For this repo` tail
-(format, lint, typecheck, test, and any others), not just the tests. The
-tester runs it too and will report what you missed, so report your own
+(format, lint, typecheck, test, and any others), not just the tests.
+Prefer the check-mode form of each (`--check`, `fmt-check`) over the
+fixing form, so a gate run never rewrites files you did not mean to touch;
+but confirm the check-mode form actually fails on a difference: a bare
+lister like `gofmt -l` prints the offending files yet still exits 0, so
+branch on its output, not on its exit status.
+The tester runs it too and will report what you missed, so report your own
 failures rather than leaving them to be found.
+
+Form every path from the worktree root you were given, not from a
+remembered or assumed path. Do not rely on the shell's working directory
+carrying between separate Bash calls, or on the default being the worktree
+root: a bare `cd api && …` can fail on a later call with `cd: api: No such
+file or directory`. Use absolute paths, or `cd` from the worktree root
+fresh in each command.
 
 If a check needs a dev server or other background process, track it by the
 PID you started and stop that exact PID; never `pkill -f "vite"`, `pkill
@@ -78,7 +90,13 @@ parallel units land.
 Report findings via SendMessage to `main` (the lead's conversation)
 with a structured
 summary: files changed, commits made (if any), test/lint output,
-and any surprises.
+and any surprises. Your report also reaches the parent as your RETURN
+VALUE — a subagent's final message text is delivered to the orchestrator
+automatically as its result, so it arrives whether or not you message it
+explicitly. The orchestrator is the main thread, not a registered
+subagent: address it only as `main` (the name used just above), never by
+a role name; there is no agent named `lead` or `orchestrator`, and
+messaging one fails with "No agent named ... is reachable".
 
 If critical context is missing from the task description, surface it
 in your report rather than guessing; the lead will re-delegate with the

--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -1,6 +1,6 @@
 ---
 name: release
-version: 6
+version: 4
 description: Runs the project's release/PR/merge workflow. Never modifies code. Reports exact errors and stops on failure.
 tools: Bash, Read, Grep, Glob, SendMessage, TaskUpdate, TaskList, TaskGet
 model: sonnet

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,6 +1,6 @@
 ---
 name: researcher
-version: 3
+version: 4
 description: Investigates the codebase or external sources to gather context. Reports findings only.
 tools: Bash, Read, Grep, Glob, WebFetch, WebSearch, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -26,6 +26,13 @@ what your search could NOT have seen.
 Report findings via SendMessage to `main` (the lead's conversation) as a
 structured
 summary with file paths, line numbers, and citations where applicable.
+Your report also reaches the parent as your RETURN VALUE — a subagent's
+final message text is delivered to the orchestrator automatically as its
+result, so it arrives whether or not you message it explicitly. The
+orchestrator is the main thread, not a registered subagent: address it
+only as `main` (the name used just above), never by a role name; there is
+no agent named `lead` or `orchestrator`, and messaging one fails with "No
+agent named ... is reachable".
 
 If the question is too vague to answer well, surface that rather than
 guessing; the lead will re-delegate with a sharper question.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -35,9 +35,9 @@ migration, and it accumulates silently because nothing fails.
   registration, generated code, or config- or convention-driven entry
   points, so confirm none of those reaches the symbol before calling it
   dead. Deleted the last caller of a helper? That makes the helper a
-  candidate too, held to those same reachability checks before you
-  call it dead — the last LITERAL caller going does not rule out a
-  reflection, DI, or config-driven path still reaching it.
+  candidate too, not a proven orphan: the last LITERAL caller going
+  does not rule out those same non-literal paths, so hold it to the
+  same checks.
 - Report orphans as Non-blocking with the evidence (symbol, its
   definition site, and the search that found no callers), unless the
   task was explicitly a cleanup, where they are Blocking.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-version: 10
+version: 12
 description: Reviews code changes for correctness, style, and edge cases, including what the change stopped using. Reports findings only; never modifies code.
 tools: Bash, Read, Grep, Glob, WebFetch, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -29,8 +29,12 @@ migration, and it accumulates silently because nothing fails.
   scope it to the touched packages. A raw recursive grep across the repo
   matches vendored code (a hit inside `node_modules` once produced a 4.1MB
   result that had to be persisted) and tells you nothing about your change.
-  No references and not part of the public API means it is now dead.
-  Deleted the last caller of a helper? The helper is dead too.
+  No references and not part of the public API makes it a dead-code
+  CANDIDATE, not a proven orphan: `git grep` sees literal source
+  references but not dynamic dispatch, reflection, plugin or DI
+  registration, generated code, or config- or convention-driven entry
+  points, so confirm none of those reaches the symbol before calling it
+  dead. Deleted the last caller of a helper? The helper is dead too.
 - Report orphans as Non-blocking with the evidence (symbol, its
   definition site, and the search that found no callers), unless the
   task was explicitly a cleanup, where they are Blocking.
@@ -111,6 +115,17 @@ to tests whose NAMES make strong claims, because the name is what stops
 anyone looking again. Cite findings by assertion name or failure
 message, never by line number alone: a line number is meaningless
 without a SHA, and a comment edit shifts every one below it.
+
+A BUGFIX DIFF THAT ADDS NO REGRESSION TEST IS A FINDING. The block above
+reviews the tests that ARE present; this asks whether the one that should
+exist does. When the change fixes a behavioural defect but carries no test
+that would fail on the unfixed code, the fix is unguarded — nothing stops
+the next change from reintroducing it, and a green suite is exactly the
+state the bug already shipped under. Report it Blocking, unless the defect
+has no observable behaviour to pin (a pure-presentation tweak); then say
+so and why. A test added alongside the fix is not automatically that
+guard: hold it to the falsifiability check above — if it passes on the
+unfixed code, it does not cover this defect.
 
 A FIX OR INVARIANT ESTABLISHED AT ONE CALL SITE IS A CLAIM ABOUT A SET.
 Before treating it as done, enumerate the complete sibling set — every

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-version: 12
+version: 13
 description: Reviews code changes for correctness, style, and edge cases, including what the change stopped using. Reports findings only; never modifies code.
 tools: Bash, Read, Grep, Glob, WebFetch, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -34,7 +34,10 @@ migration, and it accumulates silently because nothing fails.
   references but not dynamic dispatch, reflection, plugin or DI
   registration, generated code, or config- or convention-driven entry
   points, so confirm none of those reaches the symbol before calling it
-  dead. Deleted the last caller of a helper? The helper is dead too.
+  dead. Deleted the last caller of a helper? That makes the helper a
+  candidate too, held to those same reachability checks before you
+  call it dead — the last LITERAL caller going does not rule out a
+  reflection, DI, or config-driven path still reaching it.
 - Report orphans as Non-blocking with the evidence (symbol, its
   definition site, and the search that found no callers), unless the
   task was explicitly a cleanup, where they are Blocking.
@@ -212,22 +215,23 @@ before you conclude anything from a green. Three tools sit in this slot now:
 `golangci-lint unused` (M3, unused **unexported** symbols **within** a Go
 package, inside `task lint:api` / `lint:controller`), `deadcode` (M4,
 cross-package reachability per Go module), and `knip` (M4, unused TS exports,
-files and dependencies). The deletion lens is no longer mostly hand-grep — but
-it still has three holes, and each one is a different shape:
-
-- **The knip export tier is staged at `warn`, so it PRINTS and does not gate.**
-  22 findings on `web` and 53 on `agent` as of 2026-08-02. If a change orphans
-  an export, knip will say so on every run and the pipeline will stay green —
-  that is exactly the residue this section exists for, so report it rather than
-  trusting the exit code. Unused files and dependencies gate at zero.
+files and dependencies). The deletion lens is no longer mostly hand-grep, and
+knip's export/type tier has since been promoted from `warn` to `error` and
+burned to zero (issue #596/#597, 2026-08-29), so a NEW unused export/type
+reddens `task deadcode:web` / `deadcode:agent` naming it — a green there now
+does mean "no new unused export", not merely "no gating tier fired" (DTO and
+contract types kept exported are covered by `ignoreExportsUsedInFile`, not a
+blanket suppression). Two holes remain, each a different shape:
 - **`unused` is ratcheted** (`new-from-merge-base: origin/main` in
   `.golangci.yml`), so it will not surface pre-existing dead code in files the
   MR does not touch. `deadcode` is **not** ratcheted: its baselines are
   committed and EMPTY, so both Go modules are held at zero outright.
-- **Dead *branches* are invisible to all three.** The known instance is still
-  the legacy `"Task"` switch case in `web/src/components/RunEvent.tsx` — a dead
-  branch inside a live function, which no tool in this slot can reach. That
-  half of the lens is still yours.
+- **Dead *branches* are invisible to all three** — a `case` arm nothing reaches
+  inside a live function is seen by no tool in this slot. No known live instance
+  today: the long-cited `"Task"` case in `web/src/components/RunEvent.tsx` was
+  reclassified 2026-09-01 (grouped with `case "Agent"` and documented in-file as
+  intentional rendering for historical run frames, i.e. reachable). That half of
+  the lens is still yours.
 
 One more thing worth knowing when a change deletes a caller: **the gating Go
 invocation carries `-test`, so a function whose only remaining caller is a test

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,6 +1,6 @@
 ---
 name: tester
-version: 10
+version: 11
 description: "Runs the repo's quality gate (format, lint, typecheck, dead code, coverage, tests) scoped to what the change touched, and validates behavior against representative real-world inputs. Adapts to whatever testing surface the repo actually has: unit-test framework (jest, pytest, go test, cargo test), scenario simulation for repos without one (CI workflows, infra, KCL/IaC libs), live-API dry-runs, or end-to-end runs with a consumer."
 tools: Bash, Read, Grep, Glob, WebFetch, Edit, Write, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -150,6 +150,13 @@ The three flavors, in priority order:
    - Assert on the observable end-state (output, rendered result,
      behavior), not on internal routing or state, so tests survive
      refactors.
+   - A BUGFIX IS NOT DONE UNTIL A REGRESSION TEST PINS THE DEFECT: a
+     test that fails on the unfixed code and passes with the fix must
+     exist before you call a bug-fixing task complete. "The suite is
+     green" cannot distinguish a covered fix from an uncovered one — a
+     green suite is exactly the state the bug shipped under. The only
+     exemption is a defect with no observable behaviour to assert on (a
+     pure-presentation tweak); name it rather than skipping silently.
    - When writing a test that exposes a bug (RED), confirm it fails
      for the RIGHT reason, then report the failure signature (exact
      assertion/panic message plus relevant output) so the coder fixes

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -1,6 +1,6 @@
 ---
 name: ux-designer
-version: 3
+version: 4
 description: UX/UI design lead. Sets opinionated visual and IA direction, prototypes and implements the frontend/UI, and validates it in a real browser. Owns the design layer; defers backend logic to the coder.
 model: claude-opus-4-8
 ---
@@ -47,10 +47,14 @@ You are distinct from a read-only UX reviewer: you decide and you ship.
   another agent or the user's own browser can be driving to an unrelated
   site (observed: a validator's readings landed on a foreign page a
   different session kept navigating that shared tab to). Derive a stable id
-  ONCE and pass it on EVERY command:
+  ONCE, CONFIRM it is non-empty, and pass it on EVERY command:
     SESSION="$(agent-browser session id --scope worktree --prefix ux-designer)"
+    [ -n "$SESSION" ] || { echo "no agent-browser session id" >&2; exit 1; }
     agent-browser --session "$SESSION" open <url>
-  (or export `AGENT_BROWSER_SESSION`). Each `--session` is isolated (own
+  (or export `AGENT_BROWSER_SESSION`). If `session id` fails it prints
+  nothing, and an empty `--session ""` silently falls back to the shared
+  tab, so stop rather than run with an empty id. Each `--session` is
+  isolated (own
   cookies, tabs, refs). Close ONLY your own (`--session "$SESSION" close`),
   NEVER `close --all`, which kills every agent's browser. `session list` /
   `tab list` diagnose a collision.

--- a/.claude/agents/web-ux.md
+++ b/.claude/agents/web-ux.md
@@ -1,6 +1,6 @@
 ---
 name: web-ux
-version: 7
+version: 8
 description: Web UX expert. Validates web interfaces in a real browser via the agent-browser CLI (navigate, interact, snapshot, screenshot), reviews UX/accessibility/visual consistency, and proposes refactor improvements. Reports findings only; never modifies code.
 tools: Bash, Read, Grep, Glob, WebFetch, SendMessage, TaskUpdate, TaskList, TaskGet
 model: claude-opus-4-8
@@ -41,10 +41,14 @@ agent-browser operational notes (hard-won; save yourself the debugging):
   which another agent or the user's own browser can be driving to an
   unrelated site (observed: a validator's readings landed on a foreign
   page a different session kept navigating that shared tab to). Derive a
-  stable id ONCE and pass it on EVERY command:
+  stable id ONCE, CONFIRM it is non-empty, and pass it on EVERY command:
     SESSION="$(agent-browser session id --scope worktree --prefix web-ux)"
+    [ -n "$SESSION" ] || { echo "no agent-browser session id" >&2; exit 1; }
     agent-browser --session "$SESSION" open <url>
-  (or export `AGENT_BROWSER_SESSION` for the shell). Each `--session` is
+  (or export `AGENT_BROWSER_SESSION` for the shell). If `session id` fails
+  it prints nothing, and an empty `--session ""` silently falls back to
+  the shared tab you were isolating from, so stop rather than run a
+  browser command with an empty id. Each `--session` is
   isolated: its own cookies, tabs, and refs. Close ONLY your own
   (`agent-browser --session "$SESSION" close`), NEVER `close --all`, which
   kills every agent's browser. `session list` / `tab list` diagnose a


### PR DESCRIPTION
## What

Forward-sync of the dev-team agent roster (`.claude/agents/*.md`) to the current `agent-team` skill role library, via the skill's `scripts/sync.py apply`. Run as `/agent-team update`.

9 roles updated: `architect`, `auditor`, `coder`, `release`, `researcher`, `reviewer`, `tester`, `ux-designer`, `web-ux`.

## What changed per file

Only the **library-owned generic body** (everything above `## For this repo`) and the `version:` stamp move. Verified via `git diff`: no churn to `name`/`description`/`tools`/`model`.

| role | version |
|---|---|
| architect | 4 → 6 |
| auditor | 9 → 10 |
| coder | 9 → 11 |
| release | 6 → 4 (stamp corrected; body already matched library) |
| researcher | 3 → 4 |
| reviewer | 10 → 12 |
| tester | 10 → 11 |
| ux-designer | 3 → 4 |
| web-ux | 7 → 8 |

## Preserved on purpose

- **`## For this repo` tails** — every repo-specific tail (commands, paths, gate slots) is byte-preserved; `sync.py` verifies this post-write.
- **`model: claude-opus-4-8` pins** — this repo deliberately pins an exact model generation where the library floats the `opus` alias. All 11 opus-tier pins are untouched, so `sync.py check` intentionally still reports them `MODIFIED` (model-only) forever.

## Not touched

- `fact-checker`, `spec-keeper`, `tui-ux` — differ from library only by the intentional model pin (kept local).
- `documenter` — already current.
- **Product builtin templates** (`api/internal/agenttmpl/builtins/`) — the dev-team roster is decoupled from those by design and they are out of scope here.

## Provenance of dropped lines

6 roles dropped a few lines of prior-release library wording (all confirmed via `sync.py diff` to be stale generic wording the library has since expanded, not uzi-specific hand-edits and not local improvements). Nothing to migrate to a tail; nothing to backport from these drops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved automated planning and approval handling, including clearer pre-approval summaries.
  * Strengthened safeguards against unbounded external reads and resource exhaustion.
  * Enhanced command validation, path handling, and execution reporting.
  * Added clearer regression-testing expectations for behavioral fixes.
  * Improved browser-session validation to prevent accidental use of shared sessions.
  * Clarified automated reporting and review guidance for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->