### PR TITLE
docs(uzi-watcher): push protection is the second push-rejection class; fold the fix before the first push

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -257,7 +257,7 @@ Two things the workflow-scope entry does not prepare you for:
   because it prints the latter with rc 0 on an unresolved ref, and with the in-file allow
   directives disabled, because GitHub honours none of them; after a push-protection rejection, additionally confirm the
   literal GitHub named is gone from every commit with `git log -S 'THE_LITERAL'
-  origin/main..HEAD` (must print nothing) — GitHub's pattern set is not gitleaks', so a
+  origin/main..HEAD` (must print nothing and exit 0, on a range already proven to resolve) — GitHub's pattern set is not gitleaks', so a
   clean range scan alone does not prove GitHub will accept the push.
 
 The fixture form that satisfies both scanners, and why `//gitleaks:allow` is not enough,

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -252,7 +252,9 @@ Two things the workflow-scope entry does not prepare you for:
 - **Verify the RANGE, not the tip.** `task scan:secrets` reads tracked files at HEAD and
   goes green on a tip that is clean while an earlier commit still carries the literal.
   `resume-recipe.md`'s step-7 pre-flight now runs gitleaks over `origin/main..HEAD` for
-  exactly this reason; after a push-protection rejection, additionally confirm the
+  exactly this reason — read by its `N commits scanned` line as well as `no leaks found`,
+  because it prints the latter with rc 0 on an unresolved ref, and with the in-file allow
+  directives disabled, because GitHub honours none of them; after a push-protection rejection, additionally confirm the
   literal GitHub named is gone from every commit with `git log -S 'THE_LITERAL'
   origin/main..HEAD` (must print nothing) — GitHub's pattern set is not gitleaks', so a
   clean range scan alone does not prove GitHub will accept the push.
@@ -260,6 +262,11 @@ Two things the workflow-scope entry does not prepare you for:
 The fixture form that satisfies both scanners, and why `//gitleaks:allow` is not enough,
 is the authoring-side rule in `.claude/rules/prds.md` (*A PRD whose tests need
 secret-SHAPED strings*); it is not repeated here.
+
+All of this is a per-incident stopgap. The mechanism-level fix — a pre-push range scan in
+the worker's finalize path with a typed `fail_origin`, mirroring the workflow-scope guard in
+`agent/src/ci-config-guard.ts` — is issue #974; until it lands, this subsection is the
+whole remedy, and `uzi run get` reports the class only as free-text `failure_reason`.
 
 ### Proactive backups (before anything goes wrong)
 

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -251,7 +251,8 @@ Two things the workflow-scope entry does not prepare you for:
 - **Verify the RANGE, not the tip.** `task scan:secrets` reads tracked files at HEAD and
   goes green on a tip that is clean while an earlier commit still carries the literal.
   The checks that match what GitHub does: `gitleaks git --log-opts="origin/main..HEAD"
-  --no-banner` over the whole range (must print `no leaks found`), and a per-commit grep
+  --no-banner --redact` over the whole range (must print `no leaks found`; `--redact` keeps a
+  real hit out of the terminal and any captured log), and a per-commit grep
   for the retired literal (`for c in $(git rev-list origin/main..HEAD); do git grep -c
   LITERAL "$c" -- DIR; done`, every line 0). Both are in `resume-recipe.md`'s step-7
   pre-flight now.

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -230,6 +230,37 @@ in this skill dir is the consolidated, run-kind-agnostic recipe for landing it: 
 isolated worktree → restore uncommitted → rebase → pre-flight (workflow/migration) → gate →
 PR → admin-merge → cleanup.
 
+### Push protection: the second push-rejection class, and it changes one landing step
+
+**A `GH013 … Push cannot contain secrets` rejection is GitHub Push Protection, not the
+workflow-scope guardrail, and the work is recoverable the same way** (the bundle-out
+above, then `resume-recipe.md`). Measured 2026-09-01 on #954: the run finished all three
+milestones, its `task gate:api` was green, and the push was refused for a "GitLab Access
+Token" — two 20-character `glpat-` TEST FIXTURES that a widened scrub pattern had forced
+from `glpat-x`. `task scan:secrets` (gitleaks) flags the same lines, but it lives in
+`gate:repo`, which the worker's component gate never runs.
+
+Two things the workflow-scope entry does not prepare you for:
+
+- **Push protection scans EVERY commit in the push, so a fix commit on top is refused
+  too.** Rewriting the literal at the tip and pushing again fails identically, with the
+  ORIGINAL commit named in the message. The literal must be removed from the commit that
+  introduced it before the first push: `git reset --soft` back over the stack (or a
+  cherry-pick chain), fold the fix into that commit, re-apply the rest. Nothing was on the
+  remote, so this is history editing with no downstream.
+- **Verify the RANGE, not the tip.** `task scan:secrets` reads tracked files at HEAD and
+  goes green on a tip that is clean while an earlier commit still carries the literal.
+  The checks that match what GitHub does: `gitleaks git --log-opts="origin/main..HEAD"
+  --no-banner` over the whole range (must print `no leaks found`), and a per-commit grep
+  for the retired literal (`for c in $(git rev-list origin/main..HEAD); do git grep -c
+  LITERAL "$c" -- DIR; done`, every line 0). Both are in `resume-recipe.md`'s step-7
+  pre-flight now.
+
+The fixture form that satisfies both scanners is a constant assembled from parts
+(`"glpat-" + "notAReal" + "0123456789"`); `//gitleaks:allow` silences gitleaks only, and
+push protection has no in-file allow directive. The authoring-side rule, so a PRD never
+ships this shape in the first place, is in `.claude/rules/prds.md`.
+
 ### Proactive backups (before anything goes wrong)
 
 The recovery above is reactive — after a push rejection or a lost run. When you are
@@ -732,8 +763,10 @@ as supersession.
 ## When a run fails
 
 Read the reason: `uzi run get RUN --json | jq '{status, failure_reason, health_reason}'`.
-Common causes: the workflow-scope push rejection above; a `limit_wait` that never cleared;
-a genuine gate failure. Report the `failure_reason` verbatim and decide re-run vs. revise
+Common causes: the workflow-scope push rejection above; a GitHub Push Protection
+rejection (`GH013 … Push cannot contain secrets` — see *Push protection* under the PVC
+recovery section: recoverable, but the fix must be folded into the introducing commit);
+a `limit_wait` that never cleared; a genuine gate failure. Report the `failure_reason` verbatim and decide re-run vs. revise
 vs. hand back to the user.
 
 ## Cross-session handoff

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -249,8 +249,9 @@ Two things the workflow-scope entry does not prepare you for:
   editing: fix the file, then `git commit --fixup=INTRO_SHA` and
   `GIT_SEQUENCE_EDITOR=: git rebase --autosquash -i origin/main` — the fix lands in that
   commit and every later commit replays unchanged (verified on a three-commit stack).
-- **Verify the RANGE, not the tip.** `task scan:secrets` reads tracked files at HEAD and
-  goes green on a tip that is clean while an earlier commit still carries the literal.
+- **Verify the RANGE, not the tip.** `task scan:secrets` scans the working tree as it is on
+  disk (`gitleaks dir`) and gates on the index — one snapshot — so it goes green on a tip
+  that is clean while an earlier commit still carries the literal.
   `resume-recipe.md`'s step-7 pre-flight now runs gitleaks over `origin/main..HEAD` for
   exactly this reason — read by its `N commits scanned` line as well as `no leaks found`,
   because it prints the latter with rc 0 on an unresolved ref, and with the in-file allow

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -233,34 +233,33 @@ PR → admin-merge → cleanup.
 ### Push protection: the second push-rejection class, and it changes one landing step
 
 **A `GH013 … Push cannot contain secrets` rejection is GitHub Push Protection, not the
-workflow-scope guardrail, and the work is recoverable the same way** (the bundle-out
-above, then `resume-recipe.md`). Measured 2026-09-01 on #954: the run finished all three
-milestones, its `task gate:api` was green, and the push was refused for a "GitLab Access
-Token" — two 20-character `glpat-` TEST FIXTURES that a widened scrub pattern had forced
-from `glpat-x`. `task scan:secrets` (gitleaks) flags the same lines, but it lives in
-`gate:repo`, which the worker's component gate never runs.
+workflow-scope guardrail, and the work is recoverable the same way (see above).**
+Measured 2026-09-01 on #954: the run finished all three milestones, its `task gate:api`
+was green, and the push was refused for a "GitLab Access Token" — two 20-character
+`glpat-` TEST FIXTURES that a widened scrub pattern had forced from `glpat-x`. `task
+scan:secrets` (gitleaks) flags the same lines, but it lives in `gate:repo`, which the
+worker's component gate never runs.
 
 Two things the workflow-scope entry does not prepare you for:
 
 - **Push protection scans EVERY commit in the push, so a fix commit on top is refused
   too.** Rewriting the literal at the tip and pushing again fails identically, with the
-  ORIGINAL commit named in the message. The literal must be removed from the commit that
-  introduced it before the first push: `git reset --soft` back over the stack (or a
-  cherry-pick chain), fold the fix into that commit, re-apply the rest. Nothing was on the
-  remote, so this is history editing with no downstream.
+  ORIGINAL commit named in the message. The literal must leave the commit that introduced
+  it before the first push, and nothing is on the remote yet, so this is plain history
+  editing: fix the file, then `git commit --fixup=INTRO_SHA` and
+  `GIT_SEQUENCE_EDITOR=: git rebase --autosquash -i origin/main` — the fix lands in that
+  commit and every later commit replays unchanged (verified on a three-commit stack).
 - **Verify the RANGE, not the tip.** `task scan:secrets` reads tracked files at HEAD and
   goes green on a tip that is clean while an earlier commit still carries the literal.
-  The checks that match what GitHub does: `gitleaks git --log-opts="origin/main..HEAD"
-  --no-banner --redact` over the whole range (must print `no leaks found`; `--redact` keeps a
-  real hit out of the terminal and any captured log), and a per-commit grep
-  for the retired literal (`for c in $(git rev-list origin/main..HEAD); do git grep -c
-  LITERAL "$c" -- DIR; done`, every line 0). Both are in `resume-recipe.md`'s step-7
-  pre-flight now.
+  `resume-recipe.md`'s step-7 pre-flight now runs gitleaks over `origin/main..HEAD` for
+  exactly this reason; after a push-protection rejection, additionally confirm the
+  literal GitHub named is gone from every commit with `git log -S 'THE_LITERAL'
+  origin/main..HEAD` (must print nothing) — GitHub's pattern set is not gitleaks', so a
+  clean range scan alone does not prove GitHub will accept the push.
 
-The fixture form that satisfies both scanners is a constant assembled from parts
-(`"glpat-" + "notAReal" + "0123456789"`); `//gitleaks:allow` silences gitleaks only, and
-push protection has no in-file allow directive. The authoring-side rule, so a PRD never
-ships this shape in the first place, is in `.claude/rules/prds.md`.
+The fixture form that satisfies both scanners, and why `//gitleaks:allow` is not enough,
+is the authoring-side rule in `.claude/rules/prds.md` (*A PRD whose tests need
+secret-SHAPED strings*); it is not repeated here.
 
 ### Proactive backups (before anything goes wrong)
 
@@ -767,8 +766,8 @@ Read the reason: `uzi run get RUN --json | jq '{status, failure_reason, health_r
 Common causes: the workflow-scope push rejection above; a GitHub Push Protection
 rejection (`GH013 … Push cannot contain secrets` — see *Push protection* under the PVC
 recovery section: recoverable, but the fix must be folded into the introducing commit);
-a `limit_wait` that never cleared; a genuine gate failure. Report the `failure_reason` verbatim and decide re-run vs. revise
-vs. hand back to the user.
+a `limit_wait` that never cleared; a genuine gate failure.
+Report the `failure_reason` verbatim and decide re-run vs. revise vs. hand back to the user.
 
 ## Cross-session handoff
 

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -246,7 +246,7 @@ Two things the workflow-scope entry does not prepare you for:
   too.** Rewriting the literal at the tip and pushing again fails identically, with the
   ORIGINAL commit named in the message. The literal must leave the commit that introduced
   it before the first push, and nothing is on the remote yet, so this is plain history
-  editing: fix the file, then `git commit --fixup=INTRO_SHA` and
+  editing: fix the file, `git add` it, then `git commit --fixup=INTRO_SHA` and
   `GIT_SEQUENCE_EDITOR=: git rebase --autosquash -i origin/main` — the fix lands in that
   commit and every later commit replays unchanged (verified on a three-commit stack).
 - **Verify the RANGE, not the tip.** `task scan:secrets` scans the working tree as it is on

--- a/.claude/skills/uzi-watcher/resume-recipe.md
+++ b/.claude/skills/uzi-watcher/resume-recipe.md
@@ -94,7 +94,8 @@ cd <the repo>                              # your normal checkout; work happens 
    git diff --name-only origin/main..HEAD -- .github/workflows/
    git log  --name-only origin/main..HEAD -- .github/workflows/
    git diff --name-only origin/main..HEAD -- api/internal/store/migrations/   # renumber if non-empty
-   gitleaks git --log-opts="origin/main..HEAD" --no-banner   # push protection scans EVERY commit: must print "no leaks found"
+   gitleaks git --log-opts="origin/main..HEAD" --no-banner --redact   # push protection scans EVERY commit: must print "no leaks found"; --redact keeps a real hit out of the log
+   for c in $(git rev-list origin/main..HEAD); do git grep -c LITERAL "$c" -- DIR; done   # after a push-protection rejection: the retired literal, every line 0
    ```
 8. **Gate the touched components** (only the ones the diff touches): `task gate:api`,
    `gate:web`, `gate:agent`, `gate:controller`, and `./e2e/run-store-it.sh` if a `*_livedb`

--- a/.claude/skills/uzi-watcher/resume-recipe.md
+++ b/.claude/skills/uzi-watcher/resume-recipe.md
@@ -87,13 +87,14 @@ cd <the repo>                              # your normal checkout; work happens 
    ```sh
    git add -A && git commit -m "chore: recover work from run RUN"   # skip if step 5 restored nothing
    ```
-7. **Pre-flight (both `.github/workflows` checks must be empty)** — confirms no workflow
+7. **Pre-flight (both `.github/workflows` checks must be empty, and gitleaks over the RANGE clean)** — confirms no workflow
    surprise (YOUR token has `workflow` scope, so an intended workflow edit is fine to push;
    an empty result just means a plain rebase already landed main's copy):
    ```sh
    git diff --name-only origin/main..HEAD -- .github/workflows/
    git log  --name-only origin/main..HEAD -- .github/workflows/
    git diff --name-only origin/main..HEAD -- api/internal/store/migrations/   # renumber if non-empty
+   gitleaks git --log-opts="origin/main..HEAD" --no-banner   # push protection scans EVERY commit: must print "no leaks found"
    ```
 8. **Gate the touched components** (only the ones the diff touches): `task gate:api`,
    `gate:web`, `gate:agent`, `gate:controller`, and `./e2e/run-store-it.sh` if a `*_livedb`

--- a/.claude/skills/uzi-watcher/resume-recipe.md
+++ b/.claude/skills/uzi-watcher/resume-recipe.md
@@ -94,8 +94,15 @@ cd <the repo>                              # your normal checkout; work happens 
    git diff --name-only origin/main..HEAD -- .github/workflows/
    git log  --name-only origin/main..HEAD -- .github/workflows/
    git diff --name-only origin/main..HEAD -- api/internal/store/migrations/   # renumber if non-empty
-   go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --log-opts="origin/main..HEAD" --no-banner --redact   # EVERY commit in the range (push protection scans them all); must print "no leaks found". Same pinned route as scripts/scan-secrets.sh; --redact is a no-op without -v, harmless
+   git rev-list --count origin/main..HEAD                                     # the range length: must be > 0, and must equal the scan's "N commits scanned" line below
+   go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --log-opts="origin/main..HEAD" --no-banner --ignore-gitleaks-allow   # EVERY commit in the range (push protection scans them all); pinned like scripts/scan-secrets.sh
    ```
+   Read the scan by its two lines, not by its exit code: `N commits scanned.` must match the
+   `rev-list` count (measured on 8.30.1: an unresolved `origin/main` prints a git `fatal`,
+   then `0 commits scanned.`, then `no leaks found`, rc 0 — the fail-open shape), and then
+   `no leaks found`. `--ignore-gitleaks-allow` matters because GitHub honours no in-file
+   allow directive; a `.gitleaksignore` or a `.gitleaks.toml` allowlist would silence this
+   scan the same way, so a green here with either present in the tree proves nothing.
    After a push-protection rejection specifically, also run `git log -S 'THE_LITERAL' origin/main..HEAD` (the literal
    GitHub named) — it must print nothing. GitHub's pattern set is not gitleaks',
    so a clean range scan alone does not prove the push will be accepted; see SKILL.md's

--- a/.claude/skills/uzi-watcher/resume-recipe.md
+++ b/.claude/skills/uzi-watcher/resume-recipe.md
@@ -104,7 +104,9 @@ cd <the repo>                              # your normal checkout; work happens 
    allow directive; a `.gitleaksignore` or a `.gitleaks.toml` allowlist would silence this
    scan the same way, so a green here with either present in the tree proves nothing.
    After a push-protection rejection specifically, also run `git log -S 'THE_LITERAL' origin/main..HEAD` (the literal
-   GitHub named) — it must print nothing. GitHub's pattern set is not gitleaks',
+   GitHub named) — it must print nothing AND exit 0, after the `rev-list` count above has
+   already proven the range resolves: an unresolved ref prints nothing too, with a `fatal`
+   on stderr and rc 128, which reads as "literal gone" if only stdout is watched. GitHub's pattern set is not gitleaks',
    so a clean range scan alone does not prove the push will be accepted; see SKILL.md's
    *Push protection* subsection for the fold-into-the-introducing-commit step that precedes it.
 8. **Gate the touched components** (only the ones the diff touches): `task gate:api`,

--- a/.claude/skills/uzi-watcher/resume-recipe.md
+++ b/.claude/skills/uzi-watcher/resume-recipe.md
@@ -94,9 +94,12 @@ cd <the repo>                              # your normal checkout; work happens 
    git diff --name-only origin/main..HEAD -- .github/workflows/
    git log  --name-only origin/main..HEAD -- .github/workflows/
    git diff --name-only origin/main..HEAD -- api/internal/store/migrations/   # renumber if non-empty
-   gitleaks git --log-opts="origin/main..HEAD" --no-banner --redact   # push protection scans EVERY commit: must print "no leaks found"; --redact keeps a real hit out of the log
-   for c in $(git rev-list origin/main..HEAD); do git grep -c LITERAL "$c" -- DIR; done   # after a push-protection rejection: the retired literal, every line 0
+   go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --log-opts="origin/main..HEAD" --no-banner --redact   # EVERY commit in the range (push protection scans them all); must print "no leaks found". Same pinned route as scripts/scan-secrets.sh; --redact is a no-op without -v, harmless
    ```
+   After a push-protection rejection specifically, also run `git log -S 'THE_LITERAL' origin/main..HEAD` (the literal
+   GitHub named) — it must print nothing. GitHub's pattern set is not gitleaks',
+   so a clean range scan alone does not prove the push will be accepted; see SKILL.md's
+   *Push protection* subsection for the fold-into-the-introducing-commit step that precedes it.
 8. **Gate the touched components** (only the ones the diff touches): `task gate:api`,
    `gate:web`, `gate:agent`, `gate:controller`, and `./e2e/run-store-it.sh` if a `*_livedb`
    test changed. Use the repo's pinned toolchains (`GOTOOLCHAIN`, node@24 for web — see the


### PR DESCRIPTION
Docs only: `.claude/skills/uzi-watcher/SKILL.md` (+37/−2) and `resume-recipe.md` (+2/−1). Opened as a PR for CodeRabbit review.

Measured on #954 (2026-09-01): a finished, gate-green run had its push refused by GitHub Push Protection for two 20-character `glpat-` test fixtures (landed via PVC recovery as #968). The skill's failure list only knew the workflow-scope rejection, and its recovery recipe had no check for this class. Two facts the new subsection records:

- **Push protection scans every commit in the push**, so a fix commit on top is refused too, with the original commit named. The literal must be folded into the introducing commit before the first push (nothing is on the remote, so it is history editing with no downstream).
- **`task scan:secrets` checks the tip only**, so the pre-flight needs `gitleaks git --log-opts="origin/main..HEAD"` over the range plus a per-commit grep for the retired literal. Both added to `resume-recipe.md` step 7.

Also adds the cause to *When a run fails*. The authoring-side rule (assemble fixtures at runtime, gate on `task scan:secrets`) landed in `.claude/rules/prds.md` via #969. `agnix` clean apart from the pre-existing length warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Guidance**
  * Added troubleshooting guidance for GitHub Push Protection failures.
  * Added recovery steps for removing detected secrets from commit history.
  * Added instructions for verifying entire commit ranges before pushing.
  * Documented additional checks for ref resolution, scan results, allowlists, and literal matches.
* **Bug Fixes**
  * Improved failure diagnostics to identify Push Protection rejections and recommend recovery actions.
  * Pre-push checks now scan all commits ahead of the main branch for leaked secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->