### PR TITLE
fix(e2e): re-deliver the worker join token across phase restarts (#984)

### DIFF
--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -81,12 +81,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# The worker join token, minted once (after the API is up) then handed to every
-# `up`/recreate via the base compose `worker_token` Docker secret (env source
-# UZI_WORKER_TOKEN, exported below). The entrypoint hardens that secret to 0400
-# worker:worker on every start, so it persists read-only across restarts and the
-# runner uid cannot read it (PRD #51 M5) — no per-start file re-delivery needed.
-# shellcheck disable=SC2034  # set by phase 13 (provides: WTOKEN), read by later phases (PRD #966 M1 split)
+# The worker join token, minted once by phase 13 (after the API is up) then handed to
+# every `up`/recreate via the base compose `worker_token` Docker secret (env source
+# UZI_WORKER_TOKEN, which phase 13 exports AND provides so it reaches later phases). The
+# entrypoint hardens that secret to 0400 worker:worker on every start, so it persists
+# read-only across restarts and the runner uid cannot read it (PRD #51 M5) — no per-start
+# file re-delivery needed.
+# shellcheck disable=SC2034  # set by phase 13 (provides: WTOKEN UZI_WORKER_TOKEN), read by later phases (PRD #966 M1 split)
 WTOKEN=""
 
 # retry_read CMD [ARGS...] — run a READ-ONLY command with a short bounded retry, so one
@@ -767,9 +768,11 @@ EOF
 
 # Per-run env-file: strong generated secrets for the base stack + the scratch dir
 # the overlay bind-mounts. UZI_WORKER_TOKEN is only a placeholder here (the worker is
-# not up yet); run-e2e.sh EXPORTS the real minted token before the agent starts, and a
-# shell export overrides the --env-file value for the `worker_token` secret source
-# (verified: compose ranks shell env above --env-file for an env-sourced secret).
+# not up yet); phase 13 mints the real token, EXPORTS it before starting the agent, and
+# declares `provides: UZI_WORKER_TOKEN` so the export is round-tripped to every later
+# phase across PRD #966's per-phase subshells (a bare export would not survive). A shell
+# export overrides the --env-file value for the `worker_token` secret source (verified:
+# compose ranks shell env above --env-file for an env-sourced secret).
 cat > "$ENVFILE" <<EOF
 E2E_RUN_DIR=$RUNROOT
 E2E_WEB_PORT=$WEB_PORT

--- a/e2e/phases/13-worker-join-online.sh
+++ b/e2e/phases/13-worker-join-online.sh
@@ -5,7 +5,7 @@
 # lane:     gitlab
 # executor: any
 # requires: -
-# provides: WTOKEN
+# provides: WTOKEN UZI_WORKER_TOKEN
 # handoff:  -
 # mutates:  -
 # restores: -
@@ -14,9 +14,13 @@ say "issue a worker join token and bring the worker online"
 WTOKEN="$(apipost /api/workers '{"name":"e2e-worker"}' | jq -r '.token')"
 [ -n "$WTOKEN" ] && [ "$WTOKEN" != null ] || fail "no worker token minted"
 # Hand the minted token to the base `worker_token` Docker secret (env source). A shell
-# export overrides the --env-file placeholder and persists for every later `up` /
-# recreate / restart in this run, so no per-start re-delivery is needed. The entrypoint
-# hardens /run/secrets/worker_token to 0400 worker on each start.
+# export overrides the --env-file placeholder for THIS phase's `up` below. To reach a
+# LATER phase's `up`/recreate (15 restart, 45 force-recreate, 59 restart), the export
+# must ALSO be a declared provide: under PRD #966's per-phase subshells a bare export
+# dies with this subshell, but a `provides:` var is round-tripped to the top-level shell
+# (declare -p keeps the -x, so it re-exports) and inherited by every later phase. Hence
+# `provides: … UZI_WORKER_TOKEN` above, and `requires: UZI_WORKER_TOKEN` on the consumers.
+# The entrypoint hardens /run/secrets/worker_token to 0400 worker on each start.
 export UZI_WORKER_TOKEN="$WTOKEN"
 "${COMPOSE[@]}" up -d --wait agent
 wait_worker_online

--- a/e2e/phases/15-happy-path-restart.sh
+++ b/e2e/phases/15-happy-path-restart.sh
@@ -4,7 +4,7 @@
 # critical: yes
 # lane:     gitlab
 # executor: any
-# requires: -
+# requires: UZI_WORKER_TOKEN
 # provides: IID RUN MR_IID
 # handoff:  -
 # mutates:  -
@@ -31,8 +31,12 @@ pass "PRD #37: run detected + reported the repo's .claude/agents/ roster (repo-c
 
 say "restart-resilience: down/up (keep volumes) while parked at the gate"
 "${COMPOSE[@]}" down                       # keeps the named volumes (pgdata, agentdata)
-# No token re-delivery: the exported UZI_WORKER_TOKEN re-sources the `worker_token`
-# secret on the next `up`, and the entrypoint re-hardens it 0400 worker (PRD #51 M5).
+# The recreated worker re-registers into its EXISTING row using the same join token:
+# UZI_WORKER_TOKEN reaches this (post-#966) subshell via phase 13's `provides` round-trip
+# (see `requires: UZI_WORKER_TOKEN` above), so the `up` below re-sources the real token
+# into the `worker_token` secret and overrides the --env-file placeholder — the entrypoint
+# re-hardens it 0400 worker (PRD #51 M5). Without the provide the worker would send the
+# placeholder token and the API would 401 it (invalid worker token) — issue #984.
 "${COMPOSE[@]}" up -d --wait db api web forge-fake
 wait_http
 login

--- a/e2e/phases/45-bounded-concurrency.sh
+++ b/e2e/phases/45-bounded-concurrency.sh
@@ -5,7 +5,7 @@
 # lane:     gitlab
 # executor: any
 # race-sensitive: yes
-# requires: -
+# requires: UZI_WORKER_TOKEN
 # provides: -
 # handoff:  -
 # mutates:  -
@@ -53,8 +53,10 @@ else
     || fail "could not enable group/repo2"
   pass "second repo group/repo2 enabled (id $REPO2_ID)"
 
-  # Recreate the one worker at cap 2. The exported UZI_WORKER_TOKEN still sources the
-  # `worker_token` secret, so the recreated container re-reads the same join token.
+  # Recreate the one worker at cap 2. UZI_WORKER_TOKEN reaches this (post-#966) subshell
+  # via phase 13's `provides` round-trip (see `requires: UZI_WORKER_TOKEN` above), so the
+  # force-recreated container re-reads the SAME join token and re-registers into its
+  # existing row; without the provide it would read the --env-file placeholder and 401.
   printf 'UZI_E2E_MAX_CONCURRENT_RUNS=2\n' >> "$ENVFILE"
   "${COMPOSE[@]}" up -d --no-deps --force-recreate agent >/dev/null
   # Wait for the NEW worker's registration to actually LAND its advertised cap —

--- a/e2e/phases/59-restart-agent.sh
+++ b/e2e/phases/59-restart-agent.sh
@@ -4,7 +4,7 @@
 # critical: no
 # lane:     gitlab
 # executor: any
-# requires: -
+# requires: UZI_WORKER_TOKEN
 # provides: SCHED_AGENT_UP
 # handoff:  -
 # mutates:  compose:agent(restarted)


### PR DESCRIPTION
## Root cause (a PRD #966 regression, not a timeout)

`happy-path-restart` does a mid-run `down`/`up` that **recreates** the worker container. The recreated worker must re-register with the join token minted in `worker-join-online` (phase 13). Instead it sent the `--env-file` placeholder (`e2e-placeholder-unused`); the API rejected it **401 "invalid worker token"**, the worker **exited**, and `wait_worker_online` timed out (`worker status never reached 'online'`) — failing the gitlab lane 2/2 (only that lane runs this phase).

Confirmed by reading a live kept stack: worker container `Exited(1)` with the 401, the worker row intact (so it wasn't slowness — the token was wrong).

PRD #966 introduced **per-phase subshells**. Phase 13 does `export UZI_WORKER_TOKEN` in its own subshell, so by phase 15's restart `up` (a separate subshell) the export is gone. The initial join works only because its `up` shares phase 13's subshell.

The earlier hypothesis (slow cold-rejoin, bump the ceiling to 90s) was wrong: a 90s branch run failed identically, and it reproduced locally on a fast machine.

## Fix (the harness's own provides/requires contract)

- Phase 13 `provides: UZI_WORKER_TOKEN` — the driver round-trips the exported var to every later phase (`declare -p` preserves `-x`, so it re-exports). Verified.
- Phases 15/45/59 (the agent restart / force-recreate sites) `requires: UZI_WORKER_TOKEN` — a future regression now fails loud, naming phase 13, instead of a silent 401 timeout.
- Corrected four stale comments that asserted the broken pre-#966 export mechanism (including lib.sh's false "run-e2e.sh EXPORTS the token").

Also fixes the **latent** same-cause breakage in phase 45 (`--force-recreate`, sdk-only) and 59, both masked in stub CI by phase 15 failing first.

## Testing

- `task lint:shell` clean (113 scripts), `task check:e2e-registry-doc` clean (50 phases), `task test:e2e-driver` 21/21.
- Local gitlab lane (preflight + worker-join-online + happy-path-restart): **happy-path-restart PASS in 29s** (was FAIL at the wait ceiling). Worker re-registers into its existing row and comes back online.
- Full gitlab-lane CI dispatched on this branch to confirm.

No behavioral regression test applies to a harness token-delivery fix; the phase itself is the end-to-end assertion (and now fails loudly via `requires:` if the token stops propagating).

Closes #984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end worker lifecycle coverage by consistently reusing the worker token across join, restart, and bounded-concurrency scenarios.
  * Enhanced validation of worker re-registration after recreation, including restart-agent and health-check flows.
  * Clarified test-phase token handoffs to ensure workers authenticate with the existing credentials rather than placeholder values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->