### PR TITLE
fix(e2e): propagate TID and PRINTED_OUT across phase subshells (#966 regression)

### DIFF
--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -553,6 +553,13 @@ rm -f "$RUNROOT/.keep-rundir"; rm -rf "$RUNROOT/artifacts"
 MARGINS_FILE="$RUNROOT/wait-margins.tsv"
 : > "$MARGINS_FILE"
 
+# Shared scratch path for the run_printed_instructions helper (below), used by the
+# printed-instructions-menu (37) and review-row-cap (39) phases. Defined here as a
+# top-level global so it reaches EVERY such phase across PRD #966's per-phase subshells;
+# a phase-local assignment (37 used to set it) dies with that subshell and leaves 39's
+# call reading an unbound var under `set -u`.
+PRINTED_OUT="$RUNROOT/.printed-instruction.out"
+
 # Self-signed cert for forge-fake.e2e (trusted by api/worker/git in the overlay).
 cat > "$RUNROOT/certs/openssl.cnf" <<'EOF'
 [req]

--- a/e2e/phases/11-skills-authz.sh
+++ b/e2e/phases/11-skills-authz.sh
@@ -5,7 +5,7 @@
 # lane:     gitlab
 # executor: any
 # requires: FRESHJAR
-# provides: -
+# provides: TID
 # handoff:  -
 # mutates:  -
 # restores: -
@@ -32,7 +32,9 @@
 #      is no `repos_test.go` anywhere under `api/` (PRD #97 M4, fable review).
 # Uses the fresh non-admin user registered above (FRESHJAR).
 say "PRD #16 skills authz: a non-admin cannot reach admin / other-user surfaces"
-# $TID is also consumed by the PRD #16 skill-delivery phase further down — resolve it here.
+# $TID is also consumed by the PRD #16 skill-delivery phase (28) further down — resolve it
+# here and declare `provides: TID` so the driver round-trips it across PRD #966's per-phase
+# subshells (a bare assignment would die with this subshell, leaving 28 with an unbound var).
 TID="$(apiget /api/agent-templates | jq -r '.templates[0].id // empty')"
 [ -n "$TID" ] || fail "no agent template to authorize against"
 

--- a/e2e/phases/28-skills-templates-tools.sh
+++ b/e2e/phases/28-skills-templates-tools.sh
@@ -4,7 +4,7 @@
 # critical: no
 # lane:     gitlab
 # executor: any
-# requires: -
+# requires: TID
 # provides: -
 # handoff:  -
 # mutates:  allocates the builtin prd-lifecycle skill (shared) to template TID; flips repo_skills_enabled=true on REPO_ID; creates + allocates a user-scoped template (e2e-mine); sets then clears a tier-1 tool profile on REPO_ID

--- a/e2e/phases/37-printed-instructions-menu.sh
+++ b/e2e/phases/37-printed-instructions-menu.sh
@@ -92,7 +92,8 @@ say "PRD #98 M8c: printed instructions EXECUTED verbatim from the emitting comma
 #
 # The `|| fail` on the exec below is a FLOOR (an instruction that errors is definitionally
 # false), not the row's assertion — every caller asserts an OUTCOME afterwards.
-PRINTED_OUT="$RUNROOT/.printed-instruction.out"
+# PRINTED_OUT is a lib.sh top-level global (the run_printed_instructions scratch path),
+# so it is available to this phase and to review-row-cap (39) without a per-phase set.
 # --- arrange: one coordinate on TWO reviews ----------------------------------
 # The undo row needs the group dismiss to settle TWO members, because the count assertion
 # is the mechanism and a count of 1 makes it indistinguishable from `head -1`. Two members


### PR DESCRIPTION
Two more cross-phase variables that PRD #966's per-phase subshells stopped propagating, same class as the worker-token fix in #986. Both phases were unreachable in CI until #984 (#986) unblocked `happy-path-restart`, so the regressions were latent.

## Fixes

- **TID**: phase 11 (`skills-authz`) resolves the agent-template id and phase 28 (`skills-templates-tools`) consumes it, but phase 11 declared `provides: -`, so the assignment died with its subshell and phase 28 hit `TID: unbound variable` under `set -u`. Now `provides: TID` / `requires: TID` so the driver round-trips it.
- **PRINTED_OUT**: the `run_printed_instructions` helper (lib.sh) reads `$PRINTED_OUT`, but only phase 37 set it (locally). Phase 39 (`review-row-cap`) calls the helper and hit `PRINTED_OUT: unbound variable`. Moved to a lib.sh top-level global (a harness scratch path, like `MARGINS_FILE`) so every caller has it; dropped phase 37's now-redundant local assignment.

## Testing

- `task lint:shell` clean, `task check:e2e-registry-doc` clean (50 phases), `task test:e2e-driver` 21/21.
- e2e.yml dispatched on this branch to confirm `skills-templates-tools` and `review-row-cap` flip FAIL→PASS.

## Scope note

This does **not** green the gitlab lane. #984's fix unmasked 6 pre-existing failures; this PR fixes the 2 that are the same #966 cross-phase-variable class. The other 4 (`live-ws-bearer`, `schedules-sweep`, `handoff`, `mr-rework`) need investigation and are filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed end-to-end test phases so printed-instruction output is shared reliably across phase subprocesses.
  - Corrected phase value handling so the template tools phase receives the identifier produced by the skills authorization phase.
  - Improved consistency of cross-phase test execution by declaring required inputs and provided values explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->