### PR TITLE
fix(e2e): keep the FAIL-path artifact capture, not the leak sweep's overwrite (#990)

### DIFF
--- a/e2e/driver.sh
+++ b/e2e/driver.sh
@@ -116,8 +116,16 @@ _record() {
 _capture_artifacts() {
   local nn_slug="$1" secs="${2:-0}" dir svc since
   dir="$RUNROOT/artifacts/$nn_slug"
-  mkdir -p "$dir" 2>/dev/null || true
   touch "$RUNROOT/.keep-rundir" 2>/dev/null || true
+  # First capture wins (#990). On a FAIL+LEAK phase this runs twice for the same slug:
+  # the FAIL path (driver.sh:~366) with a window of secs+30, then the quarantine sweep,
+  # once per leaked run, with secs=0 -> a 30s window. The FAIL window is strictly wider,
+  # so a second pass would OVERWRITE the failing-phase container logs (agent crash, api/db
+  # boot -- all >30s old) with a 30s window that drops them, leaving empty <phase>/*.log
+  # in the uploaded artifacts. If the dir already exists, a richer capture ran first: keep
+  # it. This also collapses the redundant per-leaked-id re-capture in one sweep.
+  [ -d "$dir" ] && return 0
+  mkdir -p "$dir" 2>/dev/null || true
   since="$((secs + 30))s"
   for svc in api agent forge-fake db; do
     "${COMPOSE[@]}" logs --no-color --since "$since" "$svc" > "$dir/$svc.log" 2>&1 || true

--- a/e2e/driver.test.sh
+++ b/e2e/driver.test.sh
@@ -79,8 +79,19 @@ wait_status() { :; }
 # 00-preflight's leg 4 takes the deferred-note path). COMPOSE=(fake_docker) is set in
 # the parent test shell and inherited by run_driver's subshell.
 fake_docker() {
+  local n
   case "$1" in
-    logs) printf 'FAKE_DOCKER_LOGS %s\n' "$*" ;;
+    logs)
+      # When FAKE_DOCKER_SEQ names a file, stamp a monotonic call number into each log
+      # line so a test can tell a FIRST capture from a later OVERWRITING one (#990,
+      # case17). Unset (every other case) -> byte-identical to the original output.
+      if [ -n "${FAKE_DOCKER_SEQ:-}" ]; then
+        n=$(( $(cat "$FAKE_DOCKER_SEQ" 2>/dev/null || echo 0) + 1 ))
+        printf '%s' "$n" > "$FAKE_DOCKER_SEQ"
+        printf 'FAKE_DOCKER_LOGS seq=%s %s\n' "$n" "$*"
+      else
+        printf 'FAKE_DOCKER_LOGS %s\n' "$*"
+      fi ;;
     ps)   ;;   # no running services
     *)    ;;
   esac
@@ -125,7 +136,7 @@ begin() { cur="$1"; case_fail=0
   FAKE_API_LOG="$TMP/api-$2.log"; FAKE_DB_LOG="$TMP/db-$2.log"; TSV="$RUNROOT/results.tsv"
   rm -rf "$RUNROOT" "$PHASES_DIR"; mkdir -p "$RUNROOT" "$PHASES_DIR"
   : > "$ENVFILE"; : > "$FAKE_API_LOG"; : > "$FAKE_DB_LOG"
-  unset E2E_ONLY E2E_SKIP E2E_STRICT_LEAKS E2E_FAULT_PHASE FAKE_DB_IDS FAKE_CANCEL_CODE 2>/dev/null || true
+  unset E2E_ONLY E2E_SKIP E2E_STRICT_LEAKS E2E_FAULT_PHASE FAKE_DB_IDS FAKE_CANCEL_CODE FAKE_DOCKER_SEQ 2>/dev/null || true
 }
 bad() { printf '  - %s\n' "$1"; case_fail=1; }
 contains() { case "$1" in *"$2"*) return 0 ;; *) return 1 ;; esac; }
@@ -544,6 +555,32 @@ contains "$(cat "$TSV")" "r-leak-a" || bad "LEAK rows do not name r-leak-a (rows
 contains "$(cat "$TSV")" "r-leak-b" || bad "LEAK rows do not name r-leak-b (rows fused into one token)"
 contains "$(cat "$FAKE_API_LOG")" "cancel /api/runs/r-leak-a/inputs" || bad "r-leak-a not cancelled via the API"
 contains "$(cat "$FAKE_API_LOG")" "cancel /api/runs/r-leak-b/inputs" || bad "r-leak-b not cancelled via the API"
+end
+
+# ============================================================================
+# Case 17 (#990) — a FAIL+LEAK phase captures artifacts TWICE for the same slug (the
+# FAIL path, then the quarantine sweep with secs=0 -> a 30s window). The FAIL capture's
+# window is strictly wider, so the second pass must NOT overwrite the failing-phase
+# container logs. FAKE_DOCKER_SEQ stamps a monotonic call number: the FAIL capture is
+# seq 1-4 (api,agent,forge-fake,db), a would-be LEAK re-capture seq 5-8. api.log must
+# keep the FIRST capture (seq=1), never the overwriting one (seq=5).
+# Mutation: revert driver.sh's `[ -d "$dir" ] && return 0` guard -> api.log becomes
+# seq=5 (the 30s LEAK window that dropped the failing-phase logs in the real bug).
+begin "case17: FAIL+LEAK capture is not overwritten by the leak sweep" 17
+export FAKE_DB_IDS="r-leak17" FAKE_CANCEL_CODE=200 FAKE_DOCKER_SEQ="$TMP/dseq-17"
+rm -f "$FAKE_DOCKER_SEQ"
+mkphase "$PHASES_DIR/10-failleak.sh" "fail and leak" no "" "" "" <<'BODY'
+fail "boom and leak"
+BODY
+run_driver 17
+adir="$RUNROOT/artifacts/10-failleak"
+has_row failleak FAIL || bad "failleak not FAIL"
+has_row failleak LEAK || bad "no LEAK row — the double-capture scenario did not reproduce"
+[ -f "$adir/api.log" ] || bad "api.log not captured"
+contains "$(cat "$adir/api.log" 2>/dev/null)" "seq=1" \
+  || bad "api.log is not the FAIL-path (first) capture: $(cat "$adir/api.log" 2>/dev/null)"
+contains "$(cat "$adir/api.log" 2>/dev/null)" "seq=5" \
+  && bad "api.log was OVERWRITTEN by the leak-sweep re-capture (#990): $(cat "$adir/api.log" 2>/dev/null)"
 end
 
 # ============================================================================


### PR DESCRIPTION
## Problem

On a critical-phase failure that also records a LEAK, the uploaded per-phase artifact logs (`artifacts/<phase>/{api,agent,db}.log`) come out **empty** — exactly the logs needed to diagnose the failure. Observed on the #984 `happy-path-restart` failures (runs 33597098555, 33598367133).

## Root cause

`_capture_artifacts` runs **twice** for the same slug on a FAIL+LEAK phase and each pass rewrites `artifacts/<slug>/*.log` with `>` (truncate):

- FAIL path (`driver.sh:~366`): window `secs+30` (rich).
- Quarantine LEAK sweep (`driver.sh:~164`), once per leaked run: `secs=0` → a **30s** window.

The LEAK re-capture runs last, so the failing-phase logs (agent crash, api/db boot — all >30s old) fall outside the 30s window and are dropped. Only forge-fake's most recent line survived, the exact observed pattern.

## Fix

First capture wins: return early when the slug's artifacts dir already exists, keeping the strictly-wider FAIL-path capture. Also collapses the redundant per-leaked-id re-capture within one sweep.

## Regression test

`driver.test.sh` case 17 drives a FAIL+LEAK phase with a `FAKE_DOCKER_SEQ` call-counter so the first capture stamps `seq=1` and a would-be overwrite stamps `seq=5`; asserts `api.log` keeps `seq=1`.

- Guard removed → case17 RED (`api.log` = `seq=5`).
- Guard restored → `cases=22 passed=22`; `scripts/check-e2e-driver.sh` clean.
- `shellcheck --severity=warning -x` clean on both files.

Unblocks CI-side diagnosis of #993-996.

Closes #990.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original diagnostic artifacts when multiple results occur during the same phase.
  * Prevented later leak-sweep captures from overwriting artifacts from an earlier failure.
  * Maintained existing Docker log behavior when capture sequencing is not enabled.

* **Tests**
  * Added coverage for artifact preservation across failure and leak results.
  * Reset capture-sequencing state between test cases for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->