### PR TITLE
e2e: mr-rework card pipeline never reaches 'success' (stays 'none'), phase times out

### DIFF
--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -114,10 +114,24 @@ services:
       # the mr_rework detector waits after the newest review comment before queuing a
       # rework. Shrunk from the shipped 3m default so phase 71 can inject a note and
       # observe the rework fire inside the suite's runtime budget. Overlay-only; the
-      # production default (config.go) is untouched. CI_WATCH_MAX_REFS is deliberately
-      # left unset here so it takes its >0 default — it gates the whole pipeline/MR
-      # detector and mr_rework never fires with it at 0.
+      # production default (config.go) is untouched.
       MR_REVIEW_QUIET_PERIOD: 2s
+      # Pipeline-watch ref cap (PRD #6): how many agent run branches the poller keeps in
+      # the CI-badge / mr_rework pipeline-status cache, NEWEST FIRST (ListWatchedRunRefsForRepo
+      # `ORDER BY created_at DESC LIMIT`, api/internal/store/queries/pipeline_statuses.sql).
+      # The shipped default is 20 (config.go CI_WATCH_MAX_REFS). That is a >0 GATE — it must
+      # stay above 0 or the whole pipeline/MR detector (and thus mr_rework) never fires — but
+      # it is ALSO a cap, and 20 is too small for this suite: the single long-lived e2e stack
+      # accumulates ~25-30 watched agent branches across its phases, and phase 71 (which runs
+      # LAST) reuses the OLDEST one — agent/issue-2 from phase 15 — for its card #2 pipeline
+      # badge (wait_card_pipeline) AND the mr_rework detector's green-head-pipeline GATE 1. At
+      # the default cap that ancient branch is evicted from the newest-20 window, its pipeline
+      # is never synced, and card #2 stays 'none' (issue #996). Raise it well above the suite's
+      # total branch count so no phase's branch ages out. The sync's per-tick cost is bounded
+      # by the number of branches that ACTUALLY exist (~30), not by this ceiling, so a generous
+      # value is free; 500 leaves ample headroom for suite growth. Overlay-only; production
+      # keeps the 20 default.
+      CI_WATCH_MAX_REFS: "500"
       # Point the SSRF allowlist + the boot seed at the fake forge.
       FORGE_ALLOWED_BASE_URLS: https://forge-fake.e2e
       # Poll rarely by DEFAULT: the harness drives issues/runs directly, and a long

--- a/e2e/phases/71-mr-rework.sh
+++ b/e2e/phases/71-mr-rework.sh
@@ -25,6 +25,15 @@
 # The forge-fake note author defaults to id 2 (a reviewer): forge-fake's /api/v4/user
 # returns id 1 (the bot), and BuildReviewCommentsSnapshot drops notes authored by the bot
 # id, so a bot-authored note is a SILENT no-fire. Every injected note passes author_id=2.
+#
+# WATCHED-REF CAP (issue #996): card #$IID (agent/issue-$IID) is the OLDEST agent branch in
+# the suite — it is the phase-15 happy-path branch and this phase runs last. Both GATE 1's
+# card-pipeline badge below AND the mr_rework detector read the pipeline-status cache, which
+# the poller fills NEWEST-FIRST up to CI_WATCH_MAX_REFS (ListWatchedRunRefsForRepo). At the
+# shipped default of 20 this ancient branch is evicted from the watched set, its pipeline is
+# never synced, and card #$IID's badge stays 'none' — so the overlay raises CI_WATCH_MAX_REFS
+# well above the suite's branch count (docker-compose.e2e.yml). Do not reuse an old branch
+# here without keeping that cap high enough to still watch it.
 say "PRD #966 M6: mr_rework run kind (review-landed rework on a settled MR)"
 
 AGENTBRANCH="agent/issue-$IID"


### PR DESCRIPTION
Implements issue #996.

Closes #996

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-996`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by increasing the number of code references retained during test runs.
  * Prevented older test branches from being removed too early, helping ensure merge-request rework and pipeline synchronization checks complete consistently.
  * Added guidance for configuring reference retention based on the number of branches covered by the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->