### PR TITLE
fix(e2e): inflate gzipped git-upload-pack requests in forge-fake CGI bridge

### DIFF
--- a/e2e/forge-fake/forge-fake.mjs
+++ b/e2e/forge-fake/forge-fake.mjs
@@ -584,6 +584,17 @@ function handleGit(req, res, url) {
       CONTENT_LENGTH: req.headers["content-length"] || "",
       REMOTE_USER: EXPECT_USER || "anon",
       REMOTE_ADDR: req.socket.remoteAddress || "127.0.0.1",
+      // git gzips the git-upload-pack REQUEST body once the want-list crosses a size
+      // threshold (a clone of a many-ref bare does; a tiny one does not, which is why
+      // this only bit CI's fuller bare and passed a laptop repro). git-http-backend
+      // inflates that body ONLY when HTTP_CONTENT_ENCODING is present; without it,
+      // `git upload-pack` reads the gzip magic (1f 8b) as a pktline and dies with
+      // "protocol error: bad line length character", surfacing client-side as
+      // "the remote end hung up unexpectedly". receive-pack (push) bodies are never
+      // gzipped, so phase 20 never hit this. Also forward Git-Protocol so a protocol-v2
+      // clone negotiates v2 rather than silently degrading to v0.
+      HTTP_CONTENT_ENCODING: req.headers["content-encoding"] || "",
+      GIT_PROTOCOL: req.headers["git-protocol"] || "",
     },
   });
   req.pipe(cgi.stdin);


### PR DESCRIPTION
## What

Phase 70 (`handoff`, #966 M5) is the first host-side smart-HTTP **clone** through `forge-fake`. It was the last red phase on the gitlab e2e lane after the #984/#990/#993/#994/#995/#996 fixes (fresh run went 47 PASS / 1 FAIL).

## Root cause

`git` gzips the `git-upload-pack` **request** body once the want-list crosses ~1KB (a clone of a many-ref bare does; a tiny laptop bare does not, which is why this only bit the fuller CI bare and passed local repros). forge-fake's CGI bridge forwarded `CONTENT_TYPE`/`CONTENT_LENGTH` but **not** `Content-Encoding`, so `git-http-backend` never inflated the body and fed gzip magic (`1f 8b`) straight to `git upload-pack`:

```
git-http-backend: fatal: protocol error: bad line length character: ?<binary>?
```

surfacing client-side as `fatal: the remote end hung up unexpectedly`. `receive-pack` (push) bodies are never gzipped, so phase 20 never hit this.

## Fix

Forward into the CGI env:
- `HTTP_CONTENT_ENCODING` — the trigger `git-http-backend` reads to inflate the request
- `GIT_PROTOCOL` (from the `Git-Protocol` header) — so a protocol-v2 clone negotiates v2 instead of silently degrading to v0

## Verification

Standalone forge-fake + a 402-ref bare (forces gzip, matching CI):
- **unfixed**: clone `rc=128`, exact `bad line length` backend error + hang-up
- **fixed**: clone `rc=0`, all refs cloned, no backend error, auth gate intact (no-auth 401 / authed 200)

Full gitlab e2e lane dispatched on this branch to confirm green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git smart-HTTP compatibility by supporting compressed requests and Git protocol v2 negotiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->