### PR TITLE
bug(ci_fix, mr_rework): GitHub Actions pipeline not detected on agent branches, pipeline_ref stays null

### DIFF
--- a/api/internal/forge/github_pipelines.go
+++ b/api/internal/forge/github_pipelines.go
@@ -138,8 +138,10 @@ func (g *github) latestPipelineFromChecks(ctx context.Context, slug repoSlug, re
 	// check-suite, re-query workflow-runs filtered by that suite id. GitHub lists an
 	// Actions run under check-runs even when the branch/head_sha-filtered workflow-runs
 	// list is (transiently) empty, so this recovers a NATIVE workflow-run pipeline — its
-	// id is in the same space as the normal path, keeping ListPipelineJobs/JobLogTail
-	// working. Newest suite id (single monotonic id space) so a re-run's suite wins.
+	// id is a workflow-RUN id, the same space as the normal path, keeping
+	// ListPipelineJobs/JobLogTail working. Pick the newest Actions check-SUITE id so a
+	// re-run's suite wins (that suite id only SELECTS the run to recover; the returned
+	// pipeline's id is the workflow-run id, not the suite id).
 	if suiteID, ok := newestActionsSuiteID(runs); ok {
 		opt := &gh.ListWorkflowRunsOptions{
 			CheckSuiteID: suiteID,
@@ -176,8 +178,19 @@ func (g *github) latestPipelineFromChecks(ctx context.Context, slug repoSlug, re
 		webURL = fmt.Sprintf("https://github.com/%s/%s/commit/%s/checks", slug.owner, slug.repo, headSHA)
 	}
 	return Pipeline{
-		// ID is ALWAYS the newest check-suite id (single monotonic id space — never mix
-		// in check-run ids, which would collide with the workflow-run id space).
+		// ID is the newest check-SUITE id — a monotonic id space WITHIN this external-CI
+		// synthesis path for a given ref (never mix in check-run ids). This is NOT the
+		// same id sequence as the recovery/native path, which returns a workflow-RUN id;
+		// they are distinct GitHub id sequences. That is safe because a ref does not flip
+		// paths in normal operation: a repo whose CI is GitHub Actions stays on the
+		// recovery/native workflow-run path, and a repo whose CI is external stays on
+		// synthesis. The one known edge: if ACTIONS-RECOVERY's check_suite_id re-query is
+		// transiently empty for an Actions repo, that ref could momentarily synthesize a
+		// suite-id pipeline instead of its usual workflow-run id; because the two id
+		// sequences are unordered relative to each other, the ci_fix verification stamp's
+		// `pipeline_id < observed_pipeline_id` progress check could skip a single tick.
+		// Bounded and non-corrupting (the next non-empty recovery restores the run-id
+		// space), so it is left as-is.
 		ID:        newestSuiteID(runs, suites),
 		Ref:       ref,
 		SHA:       headSHA,
@@ -355,10 +368,17 @@ func collapseCheckRun(r *gh.CheckRun) string {
 // combineCheckRunStatuses folds a head commit's check-runs into ONE neutral pipeline
 // status, mirroring GitHub's combined-status precedence: any failure wins, else any
 // still-running yields in_progress, else any attention (action_required/stale/
-// cancelled) yields action_required, else success. The strings are stored verbatim so
+// cancelled) yields action_required, else "success" ONLY when at least one check-run
+// actually collapsed to "success". A set with NO failure, NO pending, NO attention and
+// NO real success — i.e. every check-run is neutral/skipped, or a completed run has a
+// nil conclusion that collapses to "" — returns "neutral": a token that is neither
+// pipelinestatus.IsFailed nor IsSuccess, so neither the mr_rework GATE 1 (IsSuccess) nor
+// the fix gate (IsFailed) fires. This matches the NATIVE workflow-run path, which stores
+// "neutral"/"skipped" verbatim (also not IsSuccess); greening an all-neutral head here
+// would be an asymmetric false-green. The strings are stored verbatim so
 // pipelinestatus.IsFailed/IsSuccess classify them exactly as the workflow-run path.
 func combineCheckRunStatuses(runs []*gh.CheckRun) string {
-	var hasFailure, hasPending, hasAttention bool
+	var hasFailure, hasPending, hasAttention, hasSuccess bool
 	for _, r := range runs {
 		switch collapseCheckRun(r) {
 		case "failure", "timed_out", "startup_failure", "error":
@@ -367,6 +387,8 @@ func combineCheckRunStatuses(runs []*gh.CheckRun) string {
 			hasPending = true
 		case "action_required", "stale", "cancelled":
 			hasAttention = true
+		case "success":
+			hasSuccess = true
 		}
 	}
 	switch {
@@ -376,8 +398,12 @@ func combineCheckRunStatuses(runs []*gh.CheckRun) string {
 		return "in_progress"
 	case hasAttention:
 		return "action_required"
-	default:
+	case hasSuccess:
 		return "success"
+	default:
+		// All neutral/skipped/empty: neither IsFailed nor IsSuccess, mirroring the
+		// native path's verbatim "neutral"/"skipped".
+		return "neutral"
 	}
 }
 

--- a/api/internal/forge/github_pipelines.go
+++ b/api/internal/forge/github_pipelines.go
@@ -119,7 +119,21 @@ func (g *github) latestPipelineFromChecks(ctx context.Context, slug repoSlug, re
 	if err != nil {
 		return Pipeline{}, err
 	}
-	suites, err := g.listCheckSuitesForRef(ctx, slug, checkRef)
+	// Pin the check-suites fetch to ONE commit. On the branch path both fetches key on a
+	// branch NAME, so a push landing between them would have runs describe commit A and
+	// suites commit B, and the synthesized Pipeline (SHA from runs, id from newestSuiteID
+	// over both) would mix the two. Fetch suites by the head SHA the check-runs already
+	// named so both describe one commit; when the check-runs name no SHA (e.g. the list is
+	// empty) fall back to the branch ref, and suites resolve the head SHA below as before.
+	// The MR path is unchanged: headSHA is the already-resolved PR head, so suitesRef is
+	// that SHA and this branch does not run.
+	suitesRef := checkRef
+	if headSHA == "" {
+		if sha := headSHAFromChecks(runs, nil); sha != "" {
+			suitesRef = sha
+		}
+	}
+	suites, err := g.listCheckSuitesForRef(ctx, slug, suitesRef)
 	if err != nil {
 		return Pipeline{}, err
 	}
@@ -134,15 +148,17 @@ func (g *github) latestPipelineFromChecks(ctx context.Context, slug repoSlug, re
 		headSHA = headSHAFromChecks(runs, suites)
 	}
 
-	// ACTIONS-RECOVERY (primary): if any check-run belongs to a GitHub-Actions
-	// check-suite, re-query workflow-runs filtered by that suite id. GitHub lists an
-	// Actions run under check-runs even when the branch/head_sha-filtered workflow-runs
-	// list is (transiently) empty, so this recovers a NATIVE workflow-run pipeline — its
-	// id is a workflow-RUN id, the same space as the normal path, keeping
+	// ACTIONS-RECOVERY (primary): if any check-run belongs to a github-actions
+	// check-suite — or, when no check-run does, the head lists a github-actions
+	// check-SUITE directly (the check-runs list can be empty/unavailable while the suite
+	// is present, issue #1005) — re-query workflow-runs filtered by that suite id. GitHub
+	// lists an Actions run under checks even when the branch/head_sha-filtered
+	// workflow-runs list is (transiently) empty, so this recovers a NATIVE workflow-run
+	// pipeline — its id is a workflow-RUN id, the same space as the normal path, keeping
 	// ListPipelineJobs/JobLogTail working. Pick the newest Actions check-SUITE id so a
 	// re-run's suite wins (that suite id only SELECTS the run to recover; the returned
 	// pipeline's id is the workflow-run id, not the suite id).
-	if suiteID, ok := newestActionsSuiteID(runs); ok {
+	if suiteID, ok := newestActionsSuiteIDFromChecks(runs, suites); ok {
 		opt := &gh.ListWorkflowRunsOptions{
 			CheckSuiteID: suiteID,
 			ListOptions:  gh.ListOptions{PerPage: 1},
@@ -277,6 +293,35 @@ func newestActionsSuiteID(runs []*gh.CheckRun) (int64, bool) {
 			continue
 		}
 		id := r.GetCheckSuite().GetID()
+		if id == 0 {
+			continue
+		}
+		if !found || id > best {
+			best, found = id, true
+		}
+	}
+	return best, found
+}
+
+// newestActionsSuiteIDFromChecks resolves the newest github-actions check-SUITE id from
+// BOTH sources, so ACTIONS-RECOVERY still fires when a head carries a github-actions
+// check-SUITE that no check-RUN surfaced — the check-runs list can be empty or
+// unavailable while the suite is present (issue #1005). Check-runs win first (via
+// newestActionsSuiteID, which reads their embedded suites); only when they name no
+// Actions suite does the suites list contribute — a gh.CheckSuite whose App.Slug ==
+// "github-actions" with a non-zero id, newest id winning. ok is false when neither
+// source names an Actions suite (the external-CI case that falls through to synthesis).
+func newestActionsSuiteIDFromChecks(runs []*gh.CheckRun, suites []*gh.CheckSuite) (int64, bool) {
+	if id, ok := newestActionsSuiteID(runs); ok {
+		return id, true
+	}
+	var best int64
+	var found bool
+	for _, s := range suites {
+		if s.GetApp().GetSlug() != "github-actions" {
+			continue
+		}
+		id := s.GetID()
 		if id == 0 {
 			continue
 		}

--- a/api/internal/forge/github_pipelines.go
+++ b/api/internal/forge/github_pipelines.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 
 	gh "github.com/google/go-github/v90/github"
+
+	"github.com/vtmocanu/uzi/api/internal/pipelinestatus"
 )
 
 // This file holds the GitHub driver's Actions / CI-fix methods (M4, D8). GitHub
@@ -39,10 +41,15 @@ func (g *github) LatestPipeline(ctx context.Context, projectID int64, ref string
 	// A hostile forge could return a null entry in workflow_runs, which decodes to
 	// a nil *WorkflowRun that passes len==0. go-github's Get* accessors are nil-safe,
 	// so toGitHubPipeline would not panic here (unlike the gitlab/forgejo drivers) —
-	// it would return a phantom zero-ID Pipeline the poller then treats as real. Reject
-	// it as "no pipeline".
+	// it would return a phantom zero-ID Pipeline the poller then treats as real.
+	// No usable workflow run: an agent-MR branch whose CI is GitHub Actions is exposed
+	// via CHECK-RUNS, not workflow-runs (issue #1005), so a null pipeline_ref here is
+	// why ci_fix never fired. Recover/synthesize from the head commit's checks before
+	// giving up — the branch path has no SHA in hand, so pass "" and let the helper
+	// resolve the true branch-head SHA from a returned check-run/suite. The helper
+	// still returns ErrNoPipeline when the head genuinely has no checks either.
 	if runs == nil || len(runs.WorkflowRuns) == 0 || runs.WorkflowRuns[0] == nil {
-		return Pipeline{}, ErrNoPipeline
+		return g.latestPipelineFromChecks(ctx, slug, ref, "")
 	}
 	return toGitHubPipeline(runs.WorkflowRuns[0]), nil
 }
@@ -65,6 +72,7 @@ func (g *github) LatestMRPipeline(ctx context.Context, projectID, mrIID int64) (
 	if head == "" {
 		return Pipeline{}, fmt.Errorf("github: latest MR pipeline: pull request %d has no head commit", mrIID)
 	}
+	headRef := pr.GetHead().GetRef() // branch name, for a synthesized pipeline's Ref
 	opt := &gh.ListWorkflowRunsOptions{
 		HeadSHA:     head,
 		ListOptions: gh.ListOptions{PerPage: 1},
@@ -76,12 +84,301 @@ func (g *github) LatestMRPipeline(ctx context.Context, projectID, mrIID int64) (
 	// A hostile forge could return a null entry in workflow_runs, which decodes to
 	// a nil *WorkflowRun that passes len==0. go-github's Get* accessors are nil-safe,
 	// so toGitHubPipeline would not panic here (unlike the gitlab/forgejo drivers) —
-	// it would return a phantom zero-ID Pipeline the poller then treats as real. Reject
-	// it as "no pipeline".
+	// it would return a phantom zero-ID Pipeline the poller then treats as real.
+	// No usable workflow run for the PR head: the reported CI (the `ci` workflow) is
+	// exposed via CHECK-RUNS, not workflow-runs (issue #1005), so recover/synthesize
+	// from the head commit's checks before giving up. The head SHA is already resolved
+	// from the PR, so reuse it (a moved head is picked up). The helper still returns
+	// ErrNoPipeline when that head genuinely has no checks either.
 	if runs == nil || len(runs.WorkflowRuns) == 0 || runs.WorkflowRuns[0] == nil {
-		return Pipeline{}, ErrNoPipeline
+		return g.latestPipelineFromChecks(ctx, slug, headRef, head)
 	}
 	return toGitHubPipeline(runs.WorkflowRuns[0]), nil
+}
+
+// latestPipelineFromChecks derives a pipeline from the head commit's CHECK-RUNS when
+// the workflow-runs query came up empty. GitHub exposes agent-MR CI (e.g. the `ci`
+// workflow's check-runs) via the check-runs API, not workflow-runs (issue #1005), so
+// without this the driver returns a null pipeline_ref and ci_fix never fires. headSHA
+// is the PR head on the MR path; on the branch path it is "" and the true branch-head
+// SHA is resolved from a returned check-run/suite — it MUST be the real head commit
+// (mr_rework GATE 2 keys staleness on the cached pipeline SHA, so a placeholder would
+// break it). ref is the branch ref carried onto a synthesized pipeline.
+func (g *github) latestPipelineFromChecks(ctx context.Context, slug repoSlug, ref, headSHA string) (Pipeline, error) {
+	// The check APIs take a git ref: the head SHA is the most precise (a moved head is
+	// still keyed correctly), and the branch ref is the only key in hand on the branch
+	// path. GitHub's commits/{ref}/check-runs resolves a branch ref to its HEAD commit.
+	checkRef := headSHA
+	if checkRef == "" {
+		checkRef = ref
+	}
+	if checkRef == "" {
+		return Pipeline{}, ErrNoPipeline
+	}
+	runs, err := g.listCheckRunsForRef(ctx, slug, checkRef)
+	if err != nil {
+		return Pipeline{}, err
+	}
+	suites, err := g.listCheckSuitesForRef(ctx, slug, checkRef)
+	if err != nil {
+		return Pipeline{}, err
+	}
+	// No checks of either kind → honest "no CI": preserve the pre-#1005 contract so a
+	// repo genuinely without CI still caches ErrNoPipeline, not a phantom pipeline.
+	if len(runs) == 0 && len(suites) == 0 {
+		return Pipeline{}, ErrNoPipeline
+	}
+	// Resolve the true head SHA on the branch path from a returned check-run/suite. It
+	// MUST be the real head commit (mr_rework staleness gate), never synthesized.
+	if headSHA == "" {
+		headSHA = headSHAFromChecks(runs, suites)
+	}
+
+	// ACTIONS-RECOVERY (primary): if any check-run belongs to a GitHub-Actions
+	// check-suite, re-query workflow-runs filtered by that suite id. GitHub lists an
+	// Actions run under check-runs even when the branch/head_sha-filtered workflow-runs
+	// list is (transiently) empty, so this recovers a NATIVE workflow-run pipeline — its
+	// id is in the same space as the normal path, keeping ListPipelineJobs/JobLogTail
+	// working. Newest suite id (single monotonic id space) so a re-run's suite wins.
+	if suiteID, ok := newestActionsSuiteID(runs); ok {
+		opt := &gh.ListWorkflowRunsOptions{
+			CheckSuiteID: suiteID,
+			ListOptions:  gh.ListOptions{PerPage: 1},
+		}
+		wf, _, err := g.client.Actions.ListRepositoryWorkflowRuns(ctx, slug.owner, slug.repo, opt)
+		if err != nil {
+			return Pipeline{}, g.wrapErr("latest pipeline from checks", err)
+		}
+		if wf != nil && len(wf.WorkflowRuns) > 0 && wf.WorkflowRuns[0] != nil {
+			return toGitHubPipeline(wf.WorkflowRuns[0]), nil
+		}
+	}
+
+	// SYNTHESIS FALLBACK (external / non-Actions CI, detection only): no Actions run is
+	// recoverable, so aggregate the check-runs into a neutral Pipeline. Without any
+	// check-run there is nothing to classify a status from, so treat suites-only as no
+	// CI. ListPipelineJobs/JobLogTail stay Actions-only for a synthesized id (a
+	// documented ci_fix limitation for pure external-CI repos; masking their 404 would
+	// hide a real deleted-run 404 on the normal path).
+	if len(runs) == 0 {
+		return Pipeline{}, ErrNoPipeline
+	}
+	newest := newestCheckRun(runs)
+	// WebURL: a failed check-run's page if any failed (that is where the human looks),
+	// else the newest check-run's; the commit checks page is a last resort only if no
+	// check-run carries an HTMLURL.
+	webURL := failedCheckRunURL(runs)
+	if webURL == "" {
+		webURL = newest.GetHTMLURL()
+	}
+	if webURL == "" {
+		// github.com only (D3), so the web host is fixed; last resort only.
+		webURL = fmt.Sprintf("https://github.com/%s/%s/commit/%s/checks", slug.owner, slug.repo, headSHA)
+	}
+	return Pipeline{
+		// ID is ALWAYS the newest check-suite id (single monotonic id space — never mix
+		// in check-run ids, which would collide with the workflow-run id space).
+		ID:        newestSuiteID(runs, suites),
+		Ref:       ref,
+		SHA:       headSHA,
+		Status:    combineCheckRunStatuses(runs),
+		WebURL:    webURL,
+		CreatedAt: newest.GetStartedAt().Time,   // best-effort; zero if absent
+		UpdatedAt: newest.GetCompletedAt().Time, // best-effort; zero if absent
+	}, nil
+}
+
+// listCheckRunsForRef returns every check-run for a git ref, fully paginated. A 404
+// (ref/commit absent or no checks surface) is treated as an empty list, not an error,
+// so a head genuinely without checks maps to ErrNoPipeline upstream rather than a hard
+// failure — the same "no CI" disposition the empty workflow-runs list already carries.
+func (g *github) listCheckRunsForRef(ctx context.Context, slug repoSlug, ref string) ([]*gh.CheckRun, error) {
+	opt := &gh.ListCheckRunsOptions{ListOptions: gh.ListOptions{PerPage: githubPerPage}}
+	wrap := func(e error) error { return g.wrapErr("latest pipeline from checks", e) }
+	return paginate(wrap, func(page int) ([]*gh.CheckRun, int, error) {
+		opt.Page = page
+		res, resp, err := g.client.Checks.ListCheckRunsForRef(ctx, slug.owner, slug.repo, ref, opt)
+		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return nil, 0, nil
+			}
+			return nil, 0, err
+		}
+		var items []*gh.CheckRun
+		if res != nil {
+			for _, r := range res.CheckRuns {
+				if r == nil {
+					continue // a hostile forge could null an entry; skip it
+				}
+				items = append(items, r)
+			}
+		}
+		next := 0
+		if resp != nil {
+			next = resp.NextPage
+		}
+		return items, next, nil
+	})
+}
+
+// listCheckSuitesForRef returns every check-suite for a git ref, fully paginated. 404
+// is treated as empty for the same reason as listCheckRunsForRef.
+func (g *github) listCheckSuitesForRef(ctx context.Context, slug repoSlug, ref string) ([]*gh.CheckSuite, error) {
+	opt := &gh.ListCheckSuiteOptions{ListOptions: gh.ListOptions{PerPage: githubPerPage}}
+	wrap := func(e error) error { return g.wrapErr("latest pipeline from checks", e) }
+	return paginate(wrap, func(page int) ([]*gh.CheckSuite, int, error) {
+		opt.Page = page
+		res, resp, err := g.client.Checks.ListCheckSuitesForRef(ctx, slug.owner, slug.repo, ref, opt)
+		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return nil, 0, nil
+			}
+			return nil, 0, err
+		}
+		var items []*gh.CheckSuite
+		if res != nil {
+			for _, s := range res.CheckSuites {
+				if s == nil {
+					continue
+				}
+				items = append(items, s)
+			}
+		}
+		next := 0
+		if resp != nil {
+			next = resp.NextPage
+		}
+		return items, next, nil
+	})
+}
+
+// newestActionsSuiteID returns the highest check-suite id among check-runs that belong
+// to the github-actions app (App.Slug == "github-actions") and carry a suite id, so
+// ACTIONS-RECOVERY re-queries the newest Actions suite. ok is false when no check-run
+// is an Actions run — the external-CI case that falls through to synthesis.
+func newestActionsSuiteID(runs []*gh.CheckRun) (int64, bool) {
+	var best int64
+	var found bool
+	for _, r := range runs {
+		if r.GetApp().GetSlug() != "github-actions" {
+			continue
+		}
+		id := r.GetCheckSuite().GetID()
+		if id == 0 {
+			continue
+		}
+		if !found || id > best {
+			best, found = id, true
+		}
+	}
+	return best, found
+}
+
+// newestSuiteID returns the highest check-suite id across the suites list and the
+// check-runs' embedded suites — the synthesized pipeline's ID (monotonic id space).
+func newestSuiteID(runs []*gh.CheckRun, suites []*gh.CheckSuite) int64 {
+	var best int64
+	for _, s := range suites {
+		if id := s.GetID(); id > best {
+			best = id
+		}
+	}
+	for _, r := range runs {
+		if id := r.GetCheckSuite().GetID(); id > best {
+			best = id
+		}
+	}
+	return best
+}
+
+// headSHAFromChecks resolves the branch-head commit SHA from a returned check-run
+// (its HeadSHA, or its suite's) or a check-suite. All check-runs on a ref share the
+// ref's HEAD commit, so the first non-empty value is the real head — required by the
+// mr_rework staleness gate, never a placeholder.
+func headSHAFromChecks(runs []*gh.CheckRun, suites []*gh.CheckSuite) string {
+	for _, r := range runs {
+		if sha := r.GetHeadSHA(); sha != "" {
+			return sha
+		}
+		if sha := r.GetCheckSuite().GetHeadSHA(); sha != "" {
+			return sha
+		}
+	}
+	for _, s := range suites {
+		if sha := s.GetHeadSHA(); sha != "" {
+			return sha
+		}
+	}
+	return ""
+}
+
+// newestCheckRun returns the check-run with the highest id (monotonic), used for the
+// synthesized pipeline's timestamps and WebURL fallback. Returns nil only for an empty
+// slice, which the caller has already excluded.
+func newestCheckRun(runs []*gh.CheckRun) *gh.CheckRun {
+	var newest *gh.CheckRun
+	for _, r := range runs {
+		if newest == nil || r.GetID() > newest.GetID() {
+			newest = r
+		}
+	}
+	return newest
+}
+
+// failedCheckRunURL returns the HTMLURL of the newest FAILED check-run (collapsed
+// status in the failed set), or "" if none failed — the page a human opens to see why
+// the pipeline is red.
+func failedCheckRunURL(runs []*gh.CheckRun) string {
+	var best *gh.CheckRun
+	for _, r := range runs {
+		if !pipelinestatus.IsFailed(collapseCheckRun(r)) {
+			continue
+		}
+		if best == nil || r.GetID() > best.GetID() {
+			best = r
+		}
+	}
+	if best == nil {
+		return ""
+	}
+	return best.GetHTMLURL()
+}
+
+// collapseCheckRun folds a check-run's status/conclusion into the single verbatim
+// value the neutral Pipeline/Job carries, the same D8 collapse the workflow-run path
+// uses (while not completed the value is the status; once completed it is the
+// conclusion).
+func collapseCheckRun(r *gh.CheckRun) string {
+	return githubActionsStatus(r.GetStatus(), r.GetConclusion())
+}
+
+// combineCheckRunStatuses folds a head commit's check-runs into ONE neutral pipeline
+// status, mirroring GitHub's combined-status precedence: any failure wins, else any
+// still-running yields in_progress, else any attention (action_required/stale/
+// cancelled) yields action_required, else success. The strings are stored verbatim so
+// pipelinestatus.IsFailed/IsSuccess classify them exactly as the workflow-run path.
+func combineCheckRunStatuses(runs []*gh.CheckRun) string {
+	var hasFailure, hasPending, hasAttention bool
+	for _, r := range runs {
+		switch collapseCheckRun(r) {
+		case "failure", "timed_out", "startup_failure", "error":
+			hasFailure = true
+		case "queued", "in_progress", "requested", "pending", "waiting":
+			hasPending = true
+		case "action_required", "stale", "cancelled":
+			hasAttention = true
+		}
+	}
+	switch {
+	case hasFailure:
+		return "failure"
+	case hasPending:
+		return "in_progress"
+	case hasAttention:
+		return "action_required"
+	default:
+		return "success"
+	}
 }
 
 // ListPipelineJobs returns a workflow run's jobs. pipelineID is a workflow run id —

--- a/api/internal/forge/github_pipelines_test.go
+++ b/api/internal/forge/github_pipelines_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/vtmocanu/uzi/api/internal/pipelinestatus"
 )
 
 // TestGitHubActionsStatusFold pins item-9 / D8: while not completed the neutral
@@ -337,6 +339,263 @@ func TestIsDisallowedLogIP(t *testing.T) {
 		if got := isDisallowedLogIP(ip); got != tc.disallowed {
 			t.Errorf("isDisallowedLogIP(%s) = %v, want %v", tc.ip, got, tc.disallowed)
 		}
+	}
+}
+
+// checkRun builds one check-runs API entry. appSlug/suiteID/headSHA are optional
+// (empty string / zero omit the sub-object or field).
+func checkRun(id int, name, status string, conclusion any, htmlURL, appSlug string, suiteID int, suiteHeadSHA string) map[string]any {
+	cr := map[string]any{
+		"id": id, "name": name, "status": status, "conclusion": conclusion, "html_url": htmlURL,
+	}
+	if appSlug != "" {
+		cr["app"] = map[string]any{"slug": appSlug}
+	}
+	if suiteID != 0 || suiteHeadSHA != "" {
+		cs := map[string]any{}
+		if suiteID != 0 {
+			cs["id"] = suiteID
+		}
+		if suiteHeadSHA != "" {
+			cs["head_sha"] = suiteHeadSHA
+		}
+		cr["check_suite"] = cs
+	}
+	return cr
+}
+
+func writeJSON(w http.ResponseWriter, v any) { _ = json.NewEncoder(w).Encode(v) }
+
+// TestGitHubLatestMRPipelineRecoversActionsRunFromChecks is the reported repro
+// (issue #1005): the head_sha-filtered workflow-runs list is empty, but the head
+// commit's check-runs belong to a github-actions check-suite. The driver must
+// re-query workflow-runs by that check_suite_id and return the NATIVE workflow run
+// (its id in the workflow-run space, so ListPipelineJobs/JobLogTail keep working) —
+// NOT ErrNoPipeline. FAILS on the pre-fix code (which returned ErrNoPipeline).
+func TestGitHubLatestMRPipelineRecoversActionsRunFromChecks(t *testing.T) {
+	const headSHA = "headsha999"
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+		},
+		// One path serves BOTH the head_sha (empty) and the check_suite_id (the run)
+		// queries — branch on the query string.
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("check_suite_id") == "555" {
+				writeJSON(w, map[string]any{"total_count": 1, "workflow_runs": []map[string]any{{
+					"id": 900, "head_branch": "feature", "head_sha": headSHA,
+					"status": "completed", "conclusion": "failure",
+					"html_url": "https://github.com/acme/widgets/actions/runs/900",
+				}}})
+				return
+			}
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 3, "check_runs": []map[string]any{
+				checkRun(11, "linux failure", "completed", "failure", "u-linux", "github-actions", 555, headSHA),
+				checkRun(12, "macos failure", "completed", "failure", "u-macos", "github-actions", 555, headSHA),
+				checkRun(13, "ready success", "completed", "success", "u-ready", "github-actions", 555, headSHA),
+			}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	p, err := d.LatestMRPipeline(context.Background(), 7, 4)
+	if err != nil {
+		t.Fatalf("LatestMRPipeline: %v", err)
+	}
+	if p.ID != 900 {
+		t.Errorf("recovery must return the native workflow-run id 900, got %d", p.ID)
+	}
+	if p.SHA != headSHA {
+		t.Errorf("SHA = %q, want %q", p.SHA, headSHA)
+	}
+	if !pipelinestatus.IsFailed(p.Status) {
+		t.Errorf("status %q must classify as failed", p.Status)
+	}
+	if p.WebURL != "https://github.com/acme/widgets/actions/runs/900" {
+		t.Errorf("WebURL = %q, want the native run url", p.WebURL)
+	}
+}
+
+// TestGitHubLatestMRPipelineSynthesizesExternalCI covers external (non-Actions) CI:
+// the check-runs belong to some_ci, not github-actions, so no workflow run is
+// recoverable. The driver must SYNTHESIZE a neutral pipeline from the check-runs
+// (status "failure", id = newest check-suite id, sha = head, WebURL = the failed
+// check-run's page) rather than return ErrNoPipeline.
+func TestGitHubLatestMRPipelineSynthesizesExternalCI(t *testing.T) {
+	const headSHA = "extsha42"
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+		},
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 2, "check_runs": []map[string]any{
+				checkRun(21, "lint", "completed", "success", "u-lint", "some-ci", 777, headSHA),
+				checkRun(22, "build", "completed", "failure", "u-build-failed", "some-ci", 777, headSHA),
+			}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-suites": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 2, "check_suites": []map[string]any{
+				{"id": 770, "head_sha": headSHA},
+				{"id": 777, "head_sha": headSHA},
+			}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	p, err := d.LatestMRPipeline(context.Background(), 7, 4)
+	if err != nil {
+		t.Fatalf("LatestMRPipeline: %v", err)
+	}
+	if p.Status != "failure" || !pipelinestatus.IsFailed(p.Status) {
+		t.Errorf("status = %q, want failure (IsFailed)", p.Status)
+	}
+	if p.SHA != headSHA {
+		t.Errorf("SHA = %q, want %q", p.SHA, headSHA)
+	}
+	if p.ID != 777 {
+		t.Errorf("ID = %d, want the newest check-suite id 777", p.ID)
+	}
+	if p.WebURL != "u-build-failed" {
+		t.Errorf("WebURL = %q, want the failed check-run's html_url", p.WebURL)
+	}
+}
+
+// TestGitHubLatestMRPipelineSynthesisAllGreen: every external check-run succeeded →
+// synthesized status "success" (IsSuccess).
+func TestGitHubLatestMRPipelineSynthesisAllGreen(t *testing.T) {
+	const headSHA = "greensha"
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+		},
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 2, "check_runs": []map[string]any{
+				checkRun(31, "lint", "completed", "success", "u1", "some-ci", 888, headSHA),
+				checkRun(32, "test", "completed", "success", "u2", "some-ci", 888, headSHA),
+			}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	p, err := d.LatestMRPipeline(context.Background(), 7, 4)
+	if err != nil {
+		t.Fatalf("LatestMRPipeline: %v", err)
+	}
+	if p.Status != "success" || !pipelinestatus.IsSuccess(p.Status) {
+		t.Errorf("status = %q, want success (IsSuccess)", p.Status)
+	}
+}
+
+// TestGitHubLatestMRPipelineSynthesisPrecedence pins the combine precedence for the
+// attention/pending mixes: neither classifies as failed or success.
+func TestGitHubLatestMRPipelineSynthesisPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		second     map[string]any // the non-success check-run
+		wantStatus string
+	}{
+		{"success+action_required", checkRun(42, "deploy", "completed", "action_required", "u", "some-ci", 900, "mixsha"), "action_required"},
+		{"success+in_progress", checkRun(42, "build", "in_progress", nil, "u", "some-ci", 900, "mixsha"), "in_progress"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const headSHA = "mixsha"
+			m := newMockGitHub(t, map[string]http.HandlerFunc{
+				"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+				},
+				"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+				},
+				"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"total_count": 2, "check_runs": []map[string]any{
+						checkRun(41, "lint", "completed", "success", "u", "some-ci", 900, headSHA),
+						tc.second,
+					}})
+				},
+			})
+			d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+			p, err := d.LatestMRPipeline(context.Background(), 7, 4)
+			if err != nil {
+				t.Fatalf("LatestMRPipeline: %v", err)
+			}
+			if p.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", p.Status, tc.wantStatus)
+			}
+			if pipelinestatus.IsFailed(p.Status) || pipelinestatus.IsSuccess(p.Status) {
+				t.Errorf("status %q must be neither failed nor success", p.Status)
+			}
+		})
+	}
+}
+
+// TestGitHubLatestMRPipelineHonestNoCI: empty workflow-runs AND empty check-runs AND
+// empty check-suites → still ErrNoPipeline. The check-runs endpoint MUST be queried
+// (asserted via checkRunsHit) so this genuinely exercises the new path — on the
+// pre-fix code the endpoint is never hit.
+func TestGitHubLatestMRPipelineHonestNoCI(t *testing.T) {
+	const headSHA = "nocish"
+	checkRunsHit := false
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+		},
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			checkRunsHit = true
+			writeJSON(w, map[string]any{"total_count": 0, "check_runs": []map[string]any{}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-suites": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "check_suites": []map[string]any{}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	if _, err := d.LatestMRPipeline(context.Background(), 7, 4); !errors.Is(err, ErrNoPipeline) {
+		t.Fatalf("no workflow runs AND no checks must be ErrNoPipeline, got %v", err)
+	}
+	if !checkRunsHit {
+		t.Fatal("the fix must consult the check-runs endpoint before giving up")
+	}
+}
+
+// TestGitHubLatestPipelineBranchSynthesizesFromChecks is the branch-path (LatestPipeline)
+// analog: empty branch workflow-runs + failing external check-runs whose head SHA is
+// carried only on the associated check-suite. The driver must resolve the REAL head
+// commit SHA from the suite (mr_rework staleness gate) and synthesize a failed pipeline.
+func TestGitHubLatestPipelineBranchSynthesizesFromChecks(t *testing.T) {
+	const branchHead = "branchhead999"
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		// Branch path keys the check APIs on the branch ref "feature".
+		"/repos/acme/widgets/commits/feature/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			// No top-level head_sha on the run; the SHA lives on its check-suite.
+			writeJSON(w, map[string]any{"total_count": 1, "check_runs": []map[string]any{
+				checkRun(51, "e2e", "completed", "failure", "u-e2e-failed", "some-ci", 1001, branchHead),
+			}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	p, err := d.LatestPipeline(context.Background(), 7, "feature")
+	if err != nil {
+		t.Fatalf("LatestPipeline: %v", err)
+	}
+	if p.SHA != branchHead {
+		t.Errorf("SHA = %q, want the resolved branch-head %q", p.SHA, branchHead)
+	}
+	if !pipelinestatus.IsFailed(p.Status) {
+		t.Errorf("status %q must classify as failed", p.Status)
+	}
+	if p.ID != 1001 {
+		t.Errorf("ID = %d, want the check-suite id 1001", p.ID)
 	}
 }
 

--- a/api/internal/forge/github_pipelines_test.go
+++ b/api/internal/forge/github_pipelines_test.go
@@ -655,6 +655,112 @@ func TestGitHubLatestPipelineBranchSynthesizesFromChecks(t *testing.T) {
 	}
 }
 
+// TestGitHubLatestMRPipelineRecoversActionsRunFromSuiteOnly is the FINDING-2 pin: the
+// head_sha-filtered workflow-runs list is empty AND the head's check-RUNS list is empty,
+// but a github-actions check-SUITE is listed for the head. ACTIONS-RECOVERY must resolve
+// the Actions suite id from the SUITES list (not only from check-runs), re-query
+// workflow-runs by that suite id, and return the NATIVE workflow run — NOT ErrNoPipeline.
+// FAILS on the pre-fix code, which read the suite id from check-runs only, skipped
+// recovery, and returned ErrNoPipeline (len(runs)==0).
+func TestGitHubLatestMRPipelineRecoversActionsRunFromSuiteOnly(t *testing.T) {
+	const headSHA = "suiteonly777"
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+		},
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("check_suite_id") == "666" {
+				writeJSON(w, map[string]any{"total_count": 1, "workflow_runs": []map[string]any{{
+					"id": 900, "head_branch": "feature", "head_sha": headSHA,
+					"status": "completed", "conclusion": "failure",
+					"html_url": "https://github.com/acme/widgets/actions/runs/900",
+				}}})
+				return
+			}
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		// Check-RUNS empty: the recoverable Actions suite is exposed ONLY via check-suites.
+		"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "check_runs": []map[string]any{}})
+		},
+		"/repos/acme/widgets/commits/" + headSHA + "/check-suites": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 1, "check_suites": []map[string]any{
+				{"id": 666, "head_sha": headSHA, "app": map[string]any{"slug": "github-actions"}},
+			}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	p, err := d.LatestMRPipeline(context.Background(), 7, 4)
+	if err != nil {
+		t.Fatalf("LatestMRPipeline: %v", err)
+	}
+	if p.ID != 900 {
+		t.Errorf("recovery must return the native workflow-run id 900, got %d", p.ID)
+	}
+	if p.SHA != headSHA {
+		t.Errorf("SHA = %q, want %q", p.SHA, headSHA)
+	}
+	if !pipelinestatus.IsFailed(p.Status) {
+		t.Errorf("status %q must classify as failed", p.Status)
+	}
+	if p.WebURL != "https://github.com/acme/widgets/actions/runs/900" {
+		t.Errorf("WebURL = %q, want the native run url", p.WebURL)
+	}
+}
+
+// TestGitHubLatestPipelineBranchPinsSuitesToCheckRunsCommit is the FINDING-1 pin: on the
+// branch path the check-runs and check-suites fetches both key on a branch NAME, so a
+// push landing between them makes check-runs describe commit A and check-suites commit B.
+// The synthesized pipeline must be pinned to the check-RUNS commit — its SHA and suite id
+// come from commit A — and the check-suites request must be made against the RESOLVED
+// SHA, not the branch name. FAILS on the pre-fix code, which fetched suites by the branch
+// ref and let commit B's newer suite id leak into the synthesized pipeline.
+func TestGitHubLatestPipelineBranchPinsSuitesToCheckRunsCommit(t *testing.T) {
+	const commitA = "commitaaaa111" // the commit the check-runs describe
+	const commitB = "commitbbbb222" // the branch head after a mid-fetch push
+	var suitesReqRef string
+	m := newMockGitHub(t, map[string]http.HandlerFunc{
+		"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+		},
+		// Check-RUNS keyed on the branch ref describe commit A (external CI → synthesis).
+		"/repos/acme/widgets/commits/feature/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"total_count": 1, "check_runs": []map[string]any{
+				checkRun(51, "e2e", "completed", "failure", "u-e2e-failed", "some-ci", 1000, commitA),
+			}})
+		},
+		// Branch-ref check-suites: what the BUGGY code queries — the branch advanced, so
+		// this describes commit B and carries a NEWER suite id (2000).
+		"/repos/acme/widgets/commits/feature/check-suites": func(w http.ResponseWriter, _ *http.Request) {
+			suitesReqRef = "feature"
+			writeJSON(w, map[string]any{"total_count": 1, "check_suites": []map[string]any{
+				{"id": 2000, "head_sha": commitB},
+			}})
+		},
+		// Resolved-SHA check-suites: what the FIXED code queries — commit A's suite (1000).
+		"/repos/acme/widgets/commits/" + commitA + "/check-suites": func(w http.ResponseWriter, _ *http.Request) {
+			suitesReqRef = commitA
+			writeJSON(w, map[string]any{"total_count": 1, "check_suites": []map[string]any{
+				{"id": 1000, "head_sha": commitA},
+			}})
+		},
+	})
+	d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+	p, err := d.LatestPipeline(context.Background(), 7, "feature")
+	if err != nil {
+		t.Fatalf("LatestPipeline: %v", err)
+	}
+	if suitesReqRef != commitA {
+		t.Errorf("check-suites must be fetched by the resolved SHA %q, got %q", commitA, suitesReqRef)
+	}
+	if p.SHA != commitA {
+		t.Errorf("SHA = %q, want the check-runs commit %q", p.SHA, commitA)
+	}
+	if p.ID != 1000 {
+		t.Errorf("ID = %d, want commit A's suite id 1000 (not commit B's 2000)", p.ID)
+	}
+}
+
 func asStr(v any) string {
 	if v == nil {
 		return "nil"

--- a/api/internal/forge/github_pipelines_test.go
+++ b/api/internal/forge/github_pipelines_test.go
@@ -492,6 +492,62 @@ func TestGitHubLatestMRPipelineSynthesisAllGreen(t *testing.T) {
 	}
 }
 
+// TestGitHubLatestMRPipelineSynthesisAllNeutral: every external check-run is
+// neutral/skipped (no failure, no pending, no attention, NO real success) → the
+// synthesized status must be "neutral", which is NEITHER IsFailed nor IsSuccess. This
+// pins the Edit-2 fix: the old `default: return "success"` false-greened such a head
+// through mr_rework's GATE 1 (IsSuccess), an asymmetry with the native workflow-run
+// path (which stores "neutral"/"skipped" verbatim, also not IsSuccess).
+func TestGitHubLatestMRPipelineSynthesisAllNeutral(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		runs []map[string]any
+	}{
+		{"all-skipped", []map[string]any{
+			checkRun(61, "lint", "completed", "skipped", "u1", "some-ci", 950, "neutsha"),
+			checkRun(62, "test", "completed", "skipped", "u2", "some-ci", 950, "neutsha"),
+		}},
+		{"all-neutral", []map[string]any{
+			checkRun(63, "lint", "completed", "neutral", "u3", "some-ci", 951, "neutsha"),
+			checkRun(64, "test", "completed", "neutral", "u4", "some-ci", 951, "neutsha"),
+		}},
+		{"neutral+skipped", []map[string]any{
+			checkRun(65, "lint", "completed", "neutral", "u5", "some-ci", 952, "neutsha"),
+			checkRun(66, "test", "completed", "skipped", "u6", "some-ci", 952, "neutsha"),
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const headSHA = "neutsha"
+			runs := tc.runs
+			m := newMockGitHub(t, map[string]http.HandlerFunc{
+				"/repos/acme/widgets/pulls/4": func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"number": 4, "state": "open", "head": map[string]any{"sha": headSHA, "ref": "feature"}})
+				},
+				"/repos/acme/widgets/actions/runs": func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"total_count": 0, "workflow_runs": []map[string]any{}})
+				},
+				"/repos/acme/widgets/commits/" + headSHA + "/check-runs": func(w http.ResponseWriter, _ *http.Request) {
+					writeJSON(w, map[string]any{"total_count": len(runs), "check_runs": runs})
+				},
+			})
+			d := newGitHubDriver(t, m, "ghp_classicTokenValue1234567890")
+			p, err := d.LatestMRPipeline(context.Background(), 7, 4)
+			if err != nil {
+				t.Fatalf("LatestMRPipeline: %v", err)
+			}
+			if pipelinestatus.IsSuccess(p.Status) {
+				t.Errorf("status %q must NOT be IsSuccess (all-neutral must not false-green)", p.Status)
+			}
+			if pipelinestatus.IsFailed(p.Status) {
+				t.Errorf("status %q must NOT be IsFailed (nothing actually failed)", p.Status)
+			}
+			if p.Status != "neutral" {
+				t.Errorf("status = %q, want neutral", p.Status)
+			}
+		})
+	}
+}
+
 // TestGitHubLatestMRPipelineSynthesisPrecedence pins the combine precedence for the
 // attention/pending mixes: neither classifies as failed or success.
 func TestGitHubLatestMRPipelineSynthesisPrecedence(t *testing.T) {

--- a/api/internal/pipelinestatus/pipelinestatus.go
+++ b/api/internal/pipelinestatus/pipelinestatus.go
@@ -25,6 +25,8 @@
 // tones, so those entries are not cross-checked against IsFailed (which is correct).
 package pipelinestatus
 
+import "sort"
+
 // failedStatuses are the terminal-FAILURE statuses across all three forges — the
 // pipelineBadge.ts "failed" tone: GitLab "failed"; Forgejo Actions run status
 // "failure"; Forgejo CommitStatusState "error" (an errored status is a failure,
@@ -49,6 +51,19 @@ var failedStatuses = map[string]struct{}{
 func IsFailed(status string) bool {
 	_, ok := failedStatuses[status]
 	return ok
+}
+
+// FailedStatuses returns the raw forge statuses IsFailed treats as terminal
+// failures, sorted, for callers that must mirror the set (e.g. the ci_autofix
+// candidate SQL predicate). Keep any new failure status in failedStatuses; this
+// accessor and IsFailed both read from it.
+func FailedStatuses() []string {
+	out := make([]string, 0, len(failedStatuses))
+	for s := range failedStatuses {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // IsSuccess reports a terminal PASS. Both forges spell it "success", so this needs

--- a/api/internal/store/ci_autofix.sql.go
+++ b/api/internal/store/ci_autofix.sql.go
@@ -135,7 +135,8 @@ SELECT per_branch.branch AS ref,
        ps.sha
 FROM per_branch
 JOIN pipeline_statuses ps
-    ON ps.repo_id = $1::uuid AND ps.ref = per_branch.branch AND ps.status = 'failed'
+    ON ps.repo_id = $1::uuid AND ps.ref = per_branch.branch
+   AND ps.status IN ('failed', 'failure', 'error', 'timed_out', 'startup_failure')
 JOIN repos rp ON rp.id = $1::uuid
 JOIN users u ON u.id = per_branch.user_id
 WHERE per_branch.branch <> rp.default_branch
@@ -188,7 +189,15 @@ type ListCIAutofixCandidateRefsRow struct {
 //     no anthropic_token_ciphertext column.
 //
 // The row carries the newest failed pipeline the detector will evaluate
-// (pipeline_id / web_url / sha from pipeline_statuses, status = 'failed').
+// (pipeline_id / web_url / sha from pipeline_statuses, whose status is any of the
+// forge failure spellings {failed, failure, error, timed_out, startup_failure}).
+// ps.status is the RAW forge pipeline status stored VERBATIM by the driver, so the
+// failure spelling is forge-specific: GitLab "failed"; Forgejo "failure"/"error";
+// GitHub Actions "failure"/"timed_out"/"startup_failure". This IN-list is the SQL twin
+// of pipelinestatus.IsFailed / pipelinestatus.failedStatuses (api/internal/pipelinestatus/
+// pipelinestatus.go) and MUST stay in sync with it: a new forge failure status added
+// there MUST be added here, or the automatic ci_fix candidate query silently never
+// matches that forge's failed pipelines (issue #1005).
 func (q *Queries) ListCIAutofixCandidateRefs(ctx context.Context, repoID uuid.UUID) ([]ListCIAutofixCandidateRefsRow, error) {
 	rows, err := q.db.Query(ctx, listCIAutofixCandidateRefs, repoID)
 	if err != nil {

--- a/api/internal/store/ci_autofix_drift_test.go
+++ b/api/internal/store/ci_autofix_drift_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vtmocanu/uzi/api/internal/pipelinestatus"
+)
+
+// TestCIAutofixCandidateQueryMirrorsFailedStatuses is the automated, DB-free drift
+// guard between pipelinestatus.failedStatuses (via FailedStatuses()) and the
+// `ps.status IN (...)` predicate of ListCIAutofixCandidateRefs. The two were only
+// kept in sync by a comment; issue #1005 was exactly a failure status
+// (GitHub's "failure") present in the Go set but missing from the SQL, so a whole
+// forge's failed pipelines silently never became auto-fix candidates.
+//
+// It reads the sqlc-generated query string constant directly (unexported, same
+// package) and asserts every FailedStatuses() entry appears as a quoted literal, and
+// that two known non-failures ('cancelled', 'success') do NOT appear inside the
+// ps.status IN (...) list. Adding a status to failedStatuses without updating the
+// SQL reddens this test.
+func TestCIAutofixCandidateQueryMirrorsFailedStatuses(t *testing.T) {
+	query := listCIAutofixCandidateRefs
+
+	// Positive: every canonical failure status must be a quoted literal in the query.
+	for _, status := range pipelinestatus.FailedStatuses() {
+		literal := "'" + status + "'"
+		if !strings.Contains(query, literal) {
+			t.Errorf("ListCIAutofixCandidateRefs is missing failure status %s (expected literal %s in the query); "+
+				"add it to the ps.status IN (...) predicate in queries/ci_autofix.sql and regenerate sqlc — "+
+				"pipelinestatus.failedStatuses and the SQL predicate MUST stay in sync (issue #1005)", status, literal)
+		}
+	}
+
+	// Negative boundary: slice out THIS query's ps.status IN ( ... ) clause and assert
+	// deliberate non-failures never leak into it. 'cancelled' / 'success' also appear
+	// elsewhere in the query (a CTE comment, r.status <> 'cancelled'), so the negative
+	// check must be scoped to the IN-list, not the whole string.
+	inClause := statusInClause(t, query)
+	for _, notFailure := range []string{"cancelled", "success"} {
+		literal := "'" + notFailure + "'"
+		if strings.Contains(inClause, literal) {
+			t.Errorf("ListCIAutofixCandidateRefs ps.status IN (...) predicate must NOT contain %s — it is a deliberate "+
+				"non-failure (a human cancel / a pass), not something uzi's ci_fix should act on (see pipelinestatus D8). "+
+				"Clause was: %s", literal, inClause)
+		}
+	}
+}
+
+// statusInClause returns just the `ps.status IN ( ... )` list from the query, so the
+// negative-boundary check cannot match a status literal that appears elsewhere.
+func statusInClause(t *testing.T, query string) string {
+	t.Helper()
+	const marker = "ps.status IN ("
+	start := strings.Index(query, marker)
+	if start < 0 {
+		t.Fatalf("could not locate %q in ListCIAutofixCandidateRefs — the query shape changed; update this drift guard", marker)
+	}
+	rest := query[start+len(marker):]
+	end := strings.Index(rest, ")")
+	if end < 0 {
+		t.Fatalf("could not find the closing paren of the ps.status IN (...) clause in ListCIAutofixCandidateRefs")
+	}
+	return rest[:end]
+}

--- a/api/internal/store/ci_autofix_integration_test.go
+++ b/api/internal/store/ci_autofix_integration_test.go
@@ -319,6 +319,17 @@ func TestCIAutofixCandidateFailureSpellingsLiveDB(t *testing.T) {
 	insertRun("agent/issue-103", 103, 203)
 	insertPipeline("agent/issue-103", 7103, "error")
 
+	// Negative boundary: two branches eligible in every other way (same owner, token,
+	// opt-in, non-default branch, mr_iid) but whose pipeline status is a deliberate
+	// NON-failure — 'cancelled' (a human cancel) and 'success' (a pass). Neither is a
+	// failure, so neither may surface as a candidate. Guards the ps.status IN (...)
+	// list against a future accidental superset.
+	notCandidates := []string{"agent/issue-104", "agent/issue-105"}
+	insertRun("agent/issue-104", 104, 204)
+	insertPipeline("agent/issue-104", 7104, "cancelled")
+	insertRun("agent/issue-105", 105, 205)
+	insertPipeline("agent/issue-105", 7105, "success")
+
 	cands, err := q.ListCIAutofixCandidateRefs(ctx, repoID)
 	if err != nil {
 		t.Fatalf("ListCIAutofixCandidateRefs: %v", err)
@@ -334,6 +345,12 @@ func TestCIAutofixCandidateFailureSpellingsLiveDB(t *testing.T) {
 		if got[ref] != pid {
 			t.Errorf("branch %q with a non-GitLab failure spelling must be a candidate (pipeline_id %d), got %d — the ps.status predicate hardcodes GitLab's \"failed\" spelling",
 				ref, pid, got[ref])
+		}
+	}
+	for _, ref := range notCandidates {
+		if _, ok := got[ref]; ok {
+			t.Errorf("branch %q has a NON-failure pipeline status (cancelled/success) and must NOT be an auto-fix candidate — the ps.status IN (...) predicate has become a superset of the failure set",
+				ref)
 		}
 	}
 }

--- a/api/internal/store/ci_autofix_integration_test.go
+++ b/api/internal/store/ci_autofix_integration_test.go
@@ -247,3 +247,93 @@ func TestCIAutofixLiveDB(t *testing.T) {
 		t.Fatalf("the kept ref must survive eviction: %v", err)
 	}
 }
+
+// TestCIAutofixCandidateFailureSpellingsLiveDB pins the issue #1005 forge-neutrality
+// fix: ListCIAutofixCandidateRefs must match EVERY forge's failure spelling, not just
+// GitLab's "failed". ps.status is the RAW forge pipeline status (GitHub Actions stores
+// "failure"/"timed_out"/"startup_failure"; Forgejo "failure"/"error"), so a GitHub or
+// Forgejo failed pipeline was silently never a candidate under the old `= 'failed'`
+// predicate — the reported symptom ("no ci_fix run has ever existed" on a GitHub repo
+// even with auto-fix enabled). This test seeds three otherwise-eligible agent-MR
+// branches whose pipeline statuses are "failure", "timed_out", and "error", and asserts
+// all three surface. It FAILS on the old `= 'failed'` predicate (0 candidates) and
+// PASSES with the IN-list fix. Its own repo/connection/user keep it independent of
+// TestCIAutofixLiveDB's exact-count assertion.
+func TestCIAutofixCandidateFailureSpellingsLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+
+	owner := uuid.New()
+	connID, repoID := uuid.New(), uuid.New()
+	mustExec(ctx, t, pool,
+		`INSERT INTO users (id, email, password_hash, ci_autofix_enabled) VALUES ($1, $2, 'x', true)`,
+		owner, fmt.Sprintf("autofix-spellings-%s@e2e", owner))
+	mustExec(ctx, t, pool,
+		`INSERT INTO user_secrets (user_id, kind, ciphertext, label) VALUES ($1, 'anthropic_token', $2, 'default')`,
+		owner, []byte{0x1})
+	mustExec(ctx, t, pool,
+		`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+		 VALUES ($1, $2, 'github', 'https://github.e2e', 'bot', 1, $3)`, connID, owner, []byte{0x1})
+	// Distinct forge_project_id from TestCIAutofixLiveDB (UNIQUE(connection_id,
+	// forge_project_id)); this test owns its own connection anyway.
+	mustExec(ctx, t, pool,
+		`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+		 VALUES ($1, $2, 2, 'gh/r', 'https://github.e2e/gh/r', 'main', true)`, repoID, connID)
+
+	insertRun := func(branch string, issueIID, mrIID int64) {
+		mustExec(ctx, t, pool,
+			`INSERT INTO runs (user_id, repo_id, kind, issue_iid, issue_title, issue_description, status, branch, mr_iid, created_at)
+			 VALUES ($1, $2, 'issue', $3, 't', 'd', 'completed', $4, $5, now())`,
+			owner, repoID, issueIID, branch, mrIID)
+	}
+	insertPipeline := func(ref string, pipelineID int64, status string) {
+		mustExec(ctx, t, pool,
+			`INSERT INTO pipeline_statuses (repo_id, ref, pipeline_id, sha, status, web_url, synced_at)
+			 VALUES ($1, $2, $3, 'deadbeef', $4, 'https://github.e2e/p', now())`,
+			repoID, ref, pipelineID, status)
+	}
+
+	// Three eligible agent-MR branches, each with a non-GitLab failure spelling. Under
+	// the old `= 'failed'` predicate NONE of these match; under the fix all three do.
+	want := map[string]int64{
+		"agent/issue-101": 7101, // GitHub Actions run conclusion "failure"
+		"agent/issue-102": 7102, // GitHub Actions run conclusion "timed_out"
+		"agent/issue-103": 7103, // Forgejo CommitStatusState "error"
+	}
+	insertRun("agent/issue-101", 101, 201)
+	insertPipeline("agent/issue-101", 7101, "failure")
+	insertRun("agent/issue-102", 102, 202)
+	insertPipeline("agent/issue-102", 7102, "timed_out")
+	insertRun("agent/issue-103", 103, 203)
+	insertPipeline("agent/issue-103", 7103, "error")
+
+	cands, err := q.ListCIAutofixCandidateRefs(ctx, repoID)
+	if err != nil {
+		t.Fatalf("ListCIAutofixCandidateRefs: %v", err)
+	}
+	got := make(map[string]int64, len(cands))
+	for _, c := range cands {
+		got[c.Ref.String] = c.PipelineID
+	}
+	if len(got) != len(want) {
+		t.Fatalf("want %d candidates (failure/timed_out/error spellings), got %d: %+v", len(want), len(got), cands)
+	}
+	for ref, pid := range want {
+		if got[ref] != pid {
+			t.Errorf("branch %q with a non-GitLab failure spelling must be a candidate (pipeline_id %d), got %d — the ps.status predicate hardcodes GitLab's \"failed\" spelling",
+				ref, pid, got[ref])
+		}
+	}
+}

--- a/api/internal/store/queries/ci_autofix.sql
+++ b/api/internal/store/queries/ci_autofix.sql
@@ -33,7 +33,8 @@
 --      no anthropic_token_ciphertext column.
 --
 -- The row carries the newest failed pipeline the detector will evaluate
--- (pipeline_id / web_url / sha from pipeline_statuses, status = 'failed').
+-- (pipeline_id / web_url / sha from pipeline_statuses, whose status is any of the
+-- forge failure spellings {failed, failure, error, timed_out, startup_failure}).
 WITH per_branch AS (
     SELECT DISTINCT ON (r.branch)
            r.branch, r.mr_iid, r.user_id
@@ -59,8 +60,16 @@ SELECT per_branch.branch AS ref,
        ps.web_url AS pipeline_web_url,
        ps.sha
 FROM per_branch
+-- ps.status is the RAW forge pipeline status stored VERBATIM by the driver, so the
+-- failure spelling is forge-specific: GitLab "failed"; Forgejo "failure"/"error";
+-- GitHub Actions "failure"/"timed_out"/"startup_failure". This IN-list is the SQL twin
+-- of pipelinestatus.IsFailed / pipelinestatus.failedStatuses (api/internal/pipelinestatus/
+-- pipelinestatus.go) and MUST stay in sync with it: a new forge failure status added
+-- there MUST be added here, or the automatic ci_fix candidate query silently never
+-- matches that forge's failed pipelines (issue #1005).
 JOIN pipeline_statuses ps
-    ON ps.repo_id = @repo_id::uuid AND ps.ref = per_branch.branch AND ps.status = 'failed'
+    ON ps.repo_id = @repo_id::uuid AND ps.ref = per_branch.branch
+   AND ps.status IN ('failed', 'failure', 'error', 'timed_out', 'startup_failure')
 JOIN repos rp ON rp.id = @repo_id::uuid
 JOIN users u ON u.id = per_branch.user_id
 WHERE per_branch.branch <> rp.default_branch

--- a/api/internal/uzidocs/embed/ci-autofix.md
+++ b/api/internal/uzidocs/embed/ci-autofix.md
@@ -88,6 +88,18 @@ guard above) is stubbed on Forgejo and GitHub: they have no equivalent
 per-project setting today, so the guard there falls back to the default
 protected-path globs.
 
+On GitHub, an agent-MR branch's CI is exposed through check-runs / check-suites
+on the head commit rather than the Actions workflow-runs list; when that list
+comes up empty, the GitHub driver now falls back to the head commit's
+check-runs (recovering the underlying Actions workflow run when possible), so
+a GitHub Actions branch gets a real pipeline status instead of reading as "no
+pipeline" — this is what lets the loop guard above evaluate and lets automatic
+CI fixes trigger for GitHub Actions CI. That fixes pipeline *detection*, not
+end-to-end validation: automatic CI-fix on GitHub is still unvalidated
+end-to-end, and for CI run by something other than GitHub Actions, detection
+works from check-runs but the failure snapshot a fix run reads (job logs)
+stays Actions-only, so a fix attempt there has less to go on.
+
 ## Good to know
 
 - **Never your default branch.** Only a branch an agent run of yours

--- a/docs/ci-autofix.md
+++ b/docs/ci-autofix.md
@@ -88,6 +88,18 @@ guard above) is stubbed on Forgejo and GitHub: they have no equivalent
 per-project setting today, so the guard there falls back to the default
 protected-path globs.
 
+On GitHub, an agent-MR branch's CI is exposed through check-runs / check-suites
+on the head commit rather than the Actions workflow-runs list; when that list
+comes up empty, the GitHub driver now falls back to the head commit's
+check-runs (recovering the underlying Actions workflow run when possible), so
+a GitHub Actions branch gets a real pipeline status instead of reading as "no
+pipeline" — this is what lets the loop guard above evaluate and lets automatic
+CI fixes trigger for GitHub Actions CI. That fixes pipeline *detection*, not
+end-to-end validation: automatic CI-fix on GitHub is still unvalidated
+end-to-end, and for CI run by something other than GitHub Actions, detection
+works from check-runs but the failure snapshot a fix run reads (job logs)
+stays Actions-only, so a fix attempt there has less to go on.
+
 ## Good to know
 
 - **Never your default branch.** Only a branch an agent run of yours


### PR DESCRIPTION
Implements issue #1005.

Closes #1005

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1005`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved GitHub CI detection by recovering workflow results from check runs and suites when standard workflow data is unavailable.
  - Added support for additional pipeline failure states, including timed-out, error, and startup failures.
  - Non-Actions checks can now contribute to pipeline status detection.
  - CI autofix candidates are now identified across the supported failure states.

- **Documentation**
  - Updated CI autofix documentation to describe expanded GitHub CI detection and supported failure statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->