### PR TITLE
bug: parseNotifPage offset has no upper bound — offset > MaxInt32 truncates to negative, 500 instead of the documented 400 (CodeQL #28)

### DIFF
--- a/api/internal/handler/notifications.go
+++ b/api/internal/handler/notifications.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -240,10 +241,10 @@ func parseNotifPage(r *http.Request) (lim, off int32, err error) {
 	}
 	if s := r.URL.Query().Get("offset"); s != "" {
 		v, e := strconv.Atoi(s)
-		if e != nil || v < 0 {
+		if e != nil || v < 0 || v > math.MaxInt32 {
 			return 0, 0, errors.New("invalid offset")
 		}
-		off = int32(v) //nolint:gosec // G109: pagination offset, validated non-negative; a pathological value causes a query error, not unsafe behavior
+		off = int32(v) //nolint:gosec // G109: v is bounded to [0, math.MaxInt32] just above; the explicit upper bound clears CodeQL's range check, this nolint only silences gosec's syntactic one
 	}
 	return lim, off, nil
 }

--- a/api/internal/handler/notifications_test.go
+++ b/api/internal/handler/notifications_test.go
@@ -283,12 +283,36 @@ func TestListNotificationsPageClampAndValidation(t *testing.T) {
 		t.Fatalf("offset = %d, want 7", db.listOff)
 	}
 
-	for _, bad := range []string{"limit=0", "limit=abc", "offset=-1", "offset=x"} {
+	for _, bad := range []string{"limit=0", "limit=abc", "offset=-1", "offset=x", "offset=2147483648"} {
 		rec := httptest.NewRecorder()
 		h.ListNotifications(rec, notifUser(httptest.NewRequest(http.MethodGet, "/api/notifications?"+bad, nil), user, false))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("?%s: status = %d, want 400", bad, rec.Code)
 		}
+	}
+}
+
+// TestListNotificationsOffsetUpperBound pins CodeQL #28: an offset above
+// math.MaxInt32 must be a 400 "invalid offset", NOT truncated to a negative
+// int32 that reaches the query (which Postgres rejects as a 500). Failing-first
+// against the unfixed code, ListNotifications returns 200 and the fake records a
+// negative offset; the fix rejects it before any query runs.
+func TestListNotificationsOffsetUpperBound(t *testing.T) {
+	user := uuid.New()
+	db := &fakeNotifDB{}
+	h := &Handler{q: store.New(db)}
+
+	rec := httptest.NewRecorder()
+	h.ListNotifications(rec, notifUser(httptest.NewRequest(http.MethodGet, "/api/notifications?offset=2147483648", nil), user, false))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid offset") {
+		t.Fatalf("body = %q, want it to contain \"invalid offset\"", rec.Body.String())
+	}
+	if db.listOff < 0 {
+		t.Fatalf("listOff = %d: a truncated negative offset reached the query", db.listOff)
 	}
 }
 


### PR DESCRIPTION
Implements issue #1016.

Closes #1016

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1016`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Notification pagination now rejects offsets exceeding the supported range with a clear HTTP 400 error.
  - Prevents invalid oversized offsets from being converted into incorrect values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->