### PR TITLE
fix(uzi-watcher): watch-ci.sh requires an explicit green conclusion + document the exit-0 blind spot

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -758,6 +758,22 @@ It exits **0** when every run for the SHA is `success`, **1** on a real red
 (supersession — see below), and **3** when no run ever appeared or they never settled.
 The underlying query, if you need it inline:
 
+**Exit 0 means "every run that EXISTS for the SHA is green" — NOT "the full expected
+workflow set ran."** Measured 2026-09-02 (a docs-only fix commit to `main`, `f015f1f`): only
+the `CodeQL` run existed for the SHA, and `ci.yml`/`kind-smoke.yml` never dispatched, so
+`watch-ci.sh` saw one green run and exited 0 — a *partial* dispatch read as a full green. A
+`[skip ci]` commit landing on top can also leave the current HEAD with no full CI run at all.
+So a green `watch-ci.sh` on a **prds/docs-only or `[skip ci]`-adjacent** push does **not**
+prove `validate-web`/`validate-api` ran. When you pushed a fix whose whole point is a gate
+(e.g. a `check-docs` fix), confirm it another way: run the gate locally (`task check-docs:web`
+etc.), OR wait for the next real code-change dispatch (the fix rides into a following PR's
+merged-with-base CI) to be the authoritative green. The reliable authority for merge-readiness
+stays the PR's OWN checks (`watch-pr.sh`), which run `pull_request`-triggered full CI; a bare
+green `main` badge can be a subset. *(A future `watch-ci.sh` improvement, suggested by the
+session that caught this: derive the EXPECTED workflow set from the last known-good `main`
+commit's runs and fail-closed — exit 3, "expected run absent" — until each expected workflow
+has a completed run for the target SHA, rather than exit-0 on a partial set.)*
+
 ```
 gh run list --repo OWNER/REPO --branch main --limit 8 \
   --json databaseId,headSha,status,conclusion \

--- a/.claude/skills/uzi-watcher/scripts/watch-ci.sh
+++ b/.claude/skills/uzi-watcher/scripts/watch-ci.sh
@@ -15,12 +15,18 @@
 #   max-polls  give up after this many (default: 60 → ~1h at the default interval)
 #
 # Exit codes (branch on these, not on the text):
-#   0  every run for the SHA concluded `success`
+#   0  every run for the SHA concluded green — `success`, or the values GitHub treats
+#      as passing for a completed check (`skipped` / `neutral`)
 #   1  at least one run concluded `failure` / `timed_out` / `startup_failure` (REAL red)
 #   2  runs concluded only `cancelled` (concurrency supersession, NOT a failure):
 #      a newer commit superseded this one — `git fetch origin <branch>` and
 #      re-watch the CURRENT HEAD, whose run exercises this change plus the newer one
-#   3  no run ever appeared, or they never settled within max-polls
+#   3  no run ever appeared, they never settled within max-polls, OR a run concluded a
+#      value that is neither green, red, nor cancelled (`action_required` / `stale`):
+#      fail closed and inspect, never merge on it. (Exit 0 means every run that
+#      EXISTS is green, NOT that the full expected workflow set ran — a partial
+#      dispatch, e.g. a docs-only or `[skip ci]`-adjacent push, can show one green
+#      run; confirm the gate another way. See SKILL.md "Post-merge CI".)
 #
 # A repo push to main sometimes spawns NO run at all (measured 2026-08-23 on a
 # docs-only commit with no [skip ci] marker); that surfaces here as exit 3 with a
@@ -49,6 +55,12 @@ while [ "$i" -lt "$MAX" ]; do
   if [ "$n" -gt 0 ] && [ "$pending" = "0" ]; then
     fails="$(printf '%s' "$runs" | jq '[.[] | select(.c=="failure" or .c=="timed_out" or .c=="startup_failure")] | length')"
     cancels="$(printf '%s' "$runs" | jq '[.[] | select(.c=="cancelled")] | length')"
+    # GitHub treats success/skipped/neutral as PASSING for a completed check; every
+    # OTHER completed conclusion (action_required, stale, and any value GitHub adds
+    # later) is NOT green. Count the green set explicitly and require EVERY run to be
+    # in it — the old `else → success` branch reported success for anything that was
+    # merely not-failure-and-not-cancelled, so an action_required/stale run read green.
+    greens="$(printf '%s' "$runs" | jq '[.[] | select(.c=="success" or .c=="skipped" or .c=="neutral")] | length')"
     printf 'ALL-COMPLETED\n%s\n' "$runs"
     if [ "$fails" -gt 0 ]; then
       echo "RESULT=failure"
@@ -58,8 +70,15 @@ while [ "$i" -lt "$MAX" ]; do
       echo "RESULT=cancelled (supersession: re-point at current origin/$BRANCH HEAD)"
       exit 2
     fi
-    echo "RESULT=success"
-    exit 0
+    if [ "$greens" -eq "$n" ]; then
+      echo "RESULT=success"
+      exit 0
+    fi
+    # A completed run concluded neither green (success/skipped/neutral), red
+    # (failure/timed_out/startup_failure) nor cancelled — e.g. action_required or
+    # stale. Fail closed: do NOT report success; surface it for inspection.
+    echo "RESULT=indeterminate (a run's conclusion is not in success/skipped/neutral — inspect, do not merge on this: $runs)"
+    exit 3
   fi
   i=$((i + 1))
   sleep "$INT"


### PR DESCRIPTION
## What

Two related changes to the uzi-watcher skill's post-merge CI watcher:

1. **fix `scripts/watch-ci.sh`** — require an explicit green conclusion. The success branch fired whenever no run was `failure`/`cancelled`, so a completed run concluding `action_required` or `stale` (neither red nor cancelled) read as `RESULT=success` (exit 0). GitHub treats only `success`/`skipped`/`neutral` as passing for a completed check; the fix counts that green set explicitly and requires every run to be in it, else fails closed as `indeterminate` (exit 3, inspect — never merge on it). *(Found by CodeRabbit on the first push of this PR.)*
2. **doc note in `SKILL.md`** — `watch-ci.sh` exit 0 means "every run that EXISTS for the SHA is green", NOT "the full expected workflow set ran." Measured 2026-09-02: a docs-only push to `main` (`f015f1f`) dispatched only `CodeQL`, so the poller read a partial dispatch as full green. Documents the local/next-PR confirmation paths and a suggested fail-closed improvement.

## Verification

- `shellcheck` clean.
- Behavioral: an `action_required` run now exits **3** (was 0); an all-green set including `skipped` still exits **0**; `failure`→1 and `cancelled`→2 unchanged.

Skill + script only. No product code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that a successful CI watcher result confirms only that detected workflows passed, not that every expected workflow ran.
  - Added guidance for validating documentation, PRD, and `[skip ci]` changes through local checks or a subsequent pull request CI run.
  - Documented a planned future improvement to detect missing expected workflows and fail safely.

- **Bug Fixes**
  - CI results marked as `skipped` or `neutral` are now treated as passing.
  - Results with conclusions such as `action_required` or `stale` are now reported as indeterminate instead of successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->