### PR TITLE
docs(comments): follow-ups from the #1017 and #1021 splits: repoint two web comments, rebind StreamRun and ValidateMerged doc comments

### DIFF
--- a/api/internal/settings/settings_labels.go
+++ b/api/internal/settings/settings_labels.go
@@ -72,6 +72,12 @@ func LabelChanged(committed, updates map[string]string) bool {
 	return false
 }
 
+// reservedSelfImproveLabel is the self-improve tracker's label. Its canonical home is
+// schedsvc.SelfImproveTrackingLabel; settings cannot import schedsvc (schedsvc imports
+// settings), so the value is mirrored here and pinned to the canonical one by an external
+// test so the two cannot drift. See ValidateMerged.
+const reservedSelfImproveLabel = "uzi-self-improve"
+
 // ValidateMerged enforces the cross-key label rules on the effective post-update
 // state (current values overlaid with the pending update), so a PUT touching one
 // key is still checked against the others' stored values. PRD #764: the
@@ -79,12 +85,6 @@ func LabelChanged(committed, updates map[string]string) bool {
 // equal pair would autopilot every runnable issue, conflating "uzi's to run" with
 // "skip the plan gate" — and from the finding label (see below). Each error names the
 // key to change.
-// reservedSelfImproveLabel is the self-improve tracker's label. Its canonical home is
-// schedsvc.SelfImproveTrackingLabel; settings cannot import schedsvc (schedsvc imports
-// settings), so the value is mirrored here and pinned to the canonical one by an external
-// test so the two cannot drift. See ValidateMerged.
-const reservedSelfImproveLabel = "uzi-self-improve"
-
 func ValidateMerged(merged map[string]string) error {
 	if merged[KeyUziLabel] == merged[KeyAutopilotLabel] {
 		return errors.New("uzi_label must differ from autopilot_label")

--- a/api/internal/uzicli/fake_runs.go
+++ b/api/internal/uzicli/fake_runs.go
@@ -203,6 +203,15 @@ func (f *FakeClient) SubmitRunInput(_ context.Context, runID, kind, body string,
 	return f.InputResp, nil
 }
 
+// StreamRun replays StreamEvents to a subscriber and then holds the stream open
+// until the caller cancels, mirroring a live socket that has simply gone quiet
+// rather than one that ended. StreamErr models an unusable socket (the D8
+// fall-back-to-polling path); it is returned in preference to Err so a test can
+// have the REST reads succeed while only the stream fails, which is exactly the
+// degradation the TUI has to handle and which a global Err cannot express.
+//
+// The events go through NormalizeRunEvent, like the live decode boundary, so a
+// fake cannot deliver a frame shape the real client would have made inert.
 func (f *FakeClient) StreamRun(ctx context.Context, runID string) (*RunStream, error) {
 	f.LastStreamRunID = runID
 	if f.StreamErr != nil {

--- a/api/internal/uzicli/fake_schedules.go
+++ b/api/internal/uzicli/fake_schedules.go
@@ -9,15 +9,6 @@ import (
 // fake_schedules.go holds the FakeClient schedule methods (uzi schedule) split
 // out of fake.go (PRD #1017).
 
-// StreamRun replays StreamEvents to a subscriber and then holds the stream open
-// until the caller cancels, mirroring a live socket that has simply gone quiet
-// rather than one that ended. StreamErr models an unusable socket (the D8
-// fall-back-to-polling path); it is returned in preference to Err so a test can
-// have the REST reads succeed while only the stream fails, which is exactly the
-// degradation the TUI has to handle and which a global Err cannot express.
-//
-// The events go through NormalizeRunEvent, like the live decode boundary, so a
-// fake cannot deliver a frame shape the real client would have made inert.
 func (f *FakeClient) ListSchedules(context.Context) ([]apitypes.ScheduleDTO, error) {
 	if f.Err != nil {
 		return nil, f.Err

--- a/web/src/pages/RunView.test.tsx
+++ b/web/src/pages/RunView.test.tsx
@@ -2374,7 +2374,7 @@ describe("JudgePanel (PRD #46 M4)", () => {
   // undefined — and `undefined !== null` is true, so every `pendingJudge !== null` guard
   // walks straight into `pendingJudge.state` and throws during render. There is no
   // ErrorBoundary in web/src, so that TypeError unmounts the whole app over a missing
-  // optional field. api/internal/uzicli/client.go handles the same skew on the CLI side.
+  // optional field. api/internal/uzicli/client_runs.go handles the same skew on the CLI side.
   it("treats an absent pending_judge as no pending judge rather than throwing (#119)", async () => {
     mockApi.getRunReview.mockResolvedValue({ review: review() } as unknown as Awaited<
       ReturnType<typeof api.getRunReview>

--- a/web/src/pages/runView/JudgePanel.tsx
+++ b/web/src/pages/runView/JudgePanel.tsx
@@ -143,7 +143,7 @@ export function JudgePanel({
       // Absent destructures to undefined, and `undefined !== null` is true — every
       // `pendingJudge !== null` guard would then walk into `pendingJudge.state` and throw
       // during render. There is no ErrorBoundary in web/src, so that TypeError would blank
-      // the whole app over a missing optional field. (api/internal/uzicli/client.go
+      // the whole app over a missing optional field. (api/internal/uzicli/client_runs.go
       // handles the same skew on the CLI side.)
       setPendingJudge(pending_judge ?? null);
     },


### PR DESCRIPTION
Comment-only follow-up to PR #1027 (#1017) and PR #1029 (#1021), epic #915 Batch 4. No code moves, no behaviour change.

- `web/src/pages/runView/JudgePanel.tsx:146` and `web/src/pages/RunView.test.tsx:2377` named `api/internal/uzicli/client.go` for the `pending_judge` skew handling; `RunReview` now lives in `client_runs.go` (PR #1027). Repointed.
- `api/internal/uzicli`: the `FakeClient.StreamRun` doc block was bound by adjacency to `ListSchedules` (pre-existing, moved verbatim into `fake_schedules.go`). Moved above `StreamRun` in `fake_runs.go`; `go doc` now attaches it there and `ListSchedules` has no doc. CodeRabbit finding on PR #1027.
- `api/internal/settings`: the `ValidateMerged` doc block was bound to the `reservedSelfImproveLabel` const (pre-existing, moved verbatim into `settings_labels.go` by PR #1029). Split the two blocks and moved the `ValidateMerged` one above its func. CodeRabbit finding on PR #1029.

Both rebinds were kept out of the motion PRs on purpose: they change `go doc` output, which those PRs used as their byte-identity proof.

Local gates: `task lint:api` 0 issues; `go vet` + `go test -count=1 -race` for `internal/uzicli`, `internal/settings`, `cmd/uzi` green; `task lint:web` and `task typecheck:web` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated documentation for run streaming behavior, event handling, cancellation, and validation.
  * Removed obsolete scheduling documentation.
  * Updated internal file references in comments and tests following a file rename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->