### PR TITLE
GitLab forge: filing a finding fails with "create label: 400 color is missing" (empty-color label not defaulted)

### DIFF
--- a/api/internal/forge/forgejo.go
+++ b/api/internal/forge/forgejo.go
@@ -33,8 +33,9 @@ const forgejoPerPage = 50
 // forgejoDefaultLabelColor is used when EnsureLabels is handed a label with no
 // color. uzi's callers always pin one (board columns, PromoteLabelColor), but
 // Forgejo's CreateLabel rejects an empty color outright (its client-side
-// validator requires a 6-hex value), where GitLab lets the server assign one —
-// so the driver supplies a neutral default rather than fail a label create.
+// validator requires a 6-hex value). GitLab's label-create API likewise requires
+// a color, so all three drivers supply a neutral default rather than fail a
+// label create.
 const forgejoDefaultLabelColor = "#ededed"
 
 // forgejo is the Forgejo REST driver, built on code.gitea.io/sdk/gitea (D5):

--- a/api/internal/forge/gitlab.go
+++ b/api/internal/forge/gitlab.go
@@ -22,6 +22,11 @@ const developerAccessLevel = int(gitlab.DeveloperPermissions) // 30
 // maximum, minimizing round-trips on busy projects.
 const perPage = 100
 
+// gitlabDefaultLabelColor is used when EnsureLabels is handed a label with no
+// color. GitLab's label-create API rejects a create with a missing color, so
+// the driver supplies a neutral default rather than fail (mirrors forgejo/github).
+const gitlabDefaultLabelColor = "#ededed"
+
 // maxTraceBytes is the fail-closed ceiling on a single job trace JobLogTail will
 // process. Well above any real CI log's tail need (the snapshot keeps only the
 // last CI_FIX_LOG_TAIL_BYTES, 32 KiB), so a legitimate trace never trips it; a
@@ -283,9 +288,11 @@ func (g *gitLab) EnsureLabels(ctx context.Context, projectID int64, labels []Lab
 			continue
 		}
 		opt := &gitlab.CreateLabelOptions{Name: gitlab.Ptr(l.Name)}
-		if l.Color != "" {
-			opt.Color = gitlab.Ptr(l.Color)
+		color := l.Color
+		if color == "" {
+			color = gitlabDefaultLabelColor
 		}
+		opt.Color = gitlab.Ptr(color)
 		if _, _, err := g.client.Labels.CreateLabel(projectID, opt, gitlab.WithContext(ctx)); err != nil {
 			return g.wrapErr(fmt.Sprintf("create label %q", l.Name), err)
 		}

--- a/api/internal/forge/gitlab_test.go
+++ b/api/internal/forge/gitlab_test.go
@@ -289,6 +289,62 @@ func TestEnsureLabelsCreatesOnlyMissing(t *testing.T) {
 	}
 }
 
+// TestEnsureLabelsDefaultsColor pins the GitLab bug fix: a label with no color
+// must still create successfully (GitLab's API rejects a missing color), and an
+// explicitly-pinned color must pass through untouched.
+func TestEnsureLabelsDefaultsColor(t *testing.T) {
+	newColorMock := func(t *testing.T, recorded map[string]string) *mockGitLab {
+		t.Helper()
+		return newMockGitLab(t, map[string]http.HandlerFunc{
+			"/api/v4/projects/7/labels": func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					w.Header().Set("X-Next-Page", "")
+					_ = json.NewEncoder(w).Encode([]map[string]any{})
+				case http.MethodPost:
+					var body struct {
+						Name  string `json:"name"`
+						Color string `json:"color"`
+					}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					if body.Color == "" {
+						// Reproduce real GitLab: a create with no color is a 400.
+						w.WriteHeader(http.StatusBadRequest)
+						_ = json.NewEncoder(w).Encode(map[string]any{"message": "color is missing"})
+						return
+					}
+					recorded[body.Name] = body.Color
+					_ = json.NewEncoder(w).Encode(map[string]any{"name": body.Name, "color": body.Color})
+				}
+			},
+		})
+	}
+
+	// 1. Empty-color label (the finding-marker shape) must default and succeed.
+	recorded := map[string]string{}
+	m := newColorMock(t, recorded)
+	d := newTestDriver(t, m, "glpat-abcdefabcdef")
+	if err := d.EnsureLabels(context.Background(), 7, []Label{{Name: "agent-found"}}); err != nil {
+		t.Fatalf("EnsureLabels with empty color: %v", err)
+	}
+	if got := recorded["agent-found"]; got == "" {
+		t.Error("expected a non-empty default color to be sent for an empty-color label")
+	} else if got != gitlabDefaultLabelColor {
+		t.Errorf("expected default color %q, got %q", gitlabDefaultLabelColor, got)
+	}
+
+	// 2. A caller-pinned color must pass through unchanged (default must not clobber it).
+	recorded2 := map[string]string{}
+	m2 := newColorMock(t, recorded2)
+	d2 := newTestDriver(t, m2, "glpat-abcdefabcdef")
+	if err := d2.EnsureLabels(context.Background(), 7, []Label{{Name: "custom", Color: "#6e49cb"}}); err != nil {
+		t.Fatalf("EnsureLabels with explicit color: %v", err)
+	}
+	if got := recorded2["custom"]; got != "#6e49cb" {
+		t.Errorf("explicit color should pass through unchanged, got %q", got)
+	}
+}
+
 func TestUserExistsByUsername(t *testing.T) {
 	var gotUsername string
 	m := newMockGitLab(t, map[string]http.HandlerFunc{
@@ -470,7 +526,7 @@ func TestCreateIssueNoteSendsBody(t *testing.T) {
 // token below is a fake, long enough for the redactor to act on (it ignores
 // secrets under 8 chars); its exact shape is irrelevant to what redaction proves.
 func TestNewMethodsRedactErrors(t *testing.T) {
-	const token = "fake-pat-redaction-probe-0123456789"
+	const token = "fake-pat-redaction-probe-0123456789" //nolint:gosec // G101 false positive: fake redaction-probe fixture, never a real secret //gitleaks:allow
 	leak := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{"message": "boom " + token})
@@ -523,7 +579,7 @@ func TestGetMergeRequestReturnsState(t *testing.T) {
 }
 
 func TestGetMergeRequestRedactsError(t *testing.T) {
-	const token = "glpat-supersecret-mrtoken-XYZ" //gitleaks:allow // fake PAT fixture: proves GetMergeRequest redacts, never a real secret
+	const token = "glpat-supersecret-mrtoken-XYZ" //nolint:gosec //gitleaks:allow // fake PAT fixture: proves GetMergeRequest redacts, never a real secret
 	m := newMockGitLab(t, map[string]http.HandlerFunc{
 		"/api/v4/projects/7/merge_requests/13": func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -837,7 +893,7 @@ func TestDefaultBranchProtectionUnprotectedIsNotSafe(t *testing.T) {
 func TestNewMethodErrorsAreRedacted(t *testing.T) {
 	// A non-glpat, low-entropy literal (the redactor scrubs any secret >= 8 chars,
 	// not just real PAT formats) so this fixture carries no scanner-tripping token.
-	const token = "uzi-redaction-test-token-not-real"
+	const token = "uzi-redaction-test-token-not-real" //nolint:gosec // G101 false positive: fake redaction-test fixture, never a real secret //gitleaks:allow
 	// 403 (not 5xx/429) so the client-go retryable transport does not back off and
 	// retry — the driver still builds a redacted error from the echoed body.
 	leak := func(w http.ResponseWriter, _ *http.Request) {
@@ -991,7 +1047,7 @@ func TestGitLabListMethodsSkipNullElements(t *testing.T) {
 }
 
 func TestErrorsAreRedacted(t *testing.T) {
-	const token = "glpat-supersecret-eviltoken-XYZ" //gitleaks:allow // fake PAT fixture: the mock server echoes it back so the driver's redactor is proven to strip it, never a real secret
+	const token = "glpat-supersecret-eviltoken-XYZ" //nolint:gosec //gitleaks:allow // fake PAT fixture: the mock server echoes it back so the driver's redactor is proven to strip it, never a real secret
 	m := newMockGitLab(t, map[string]http.HandlerFunc{
 		// Echo the token back inside the error body — worst case: the server
 		// itself leaks it. The driver must still not surface it.

--- a/api/internal/handler/labels.go
+++ b/api/internal/handler/labels.go
@@ -104,8 +104,8 @@ func missingLabels(existing []forge.Label, requested []string) []string {
 
 // ensureRepoLabels ensures the requested labels exist on the forge project and returns the
 // deduped, non-blank set it ensured. It hands EnsureLabels the requested labels directly
-// (EnsureLabels skips any that already exist), with an empty color so each driver applies
-// its own default — mirroring findings_file.go's `forge.Label{{Name: marker}}`. An empty
+// (EnsureLabels skips any that already exist), with an empty color so each of the three
+// drivers applies its own neutral default — mirroring findings_file.go's `forge.Label{{Name: marker}}`. An empty
 // request is a no-op (no forge call). Split out as a package function taking a forge.Forge
 // so the WARN/CONFIRM logic is unit-testable against a fake forge without a DB.
 func ensureRepoLabels(ctx context.Context, f forge.Forge, projectID int64, requested []string) ([]string, error) {


### PR DESCRIPTION
Implements issue #1032.

Closes #1032

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1032`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GitLab labels without a specified color now receive a neutral default color when created.
  - Explicit label colors continue to be preserved across supported forge integrations.

- **Documentation**
  - Clarified that supported forge integrations apply their own neutral default color when a label color is left empty.

- **Tests**
  - Added coverage for default and explicitly specified label colors during GitLab label creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->