### PR TITLE
chore(renovate): pin npm >=11.3.0 so lockfile bumps keep all platform nodes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,10 @@
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependencies", "renovate"],
-  "postUpdateOptions": ["gomodTidy"],
+  "postUpdateOptions": ["gomodTidy", "npmInstallTwice"],
+  "constraints": {
+    "npm": ">=11.3.0"
+  },
   "prHourlyLimit": 5,
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",


### PR DESCRIPTION
## Problem

Renovate's Linux runner produces `package-lock.json` updates that **prune non-host-platform optional native dependency nodes**. On PR #1044 (`@anthropic-ai/claude-agent-sdk` 0.3.246 → 0.3.247) it bumped all 8 platform references in the parent's `optionalDependencies` and 7 of the 8 individual package nodes, but **deleted the `node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64` node entirely**. The lock then references `darwin-arm64@0.3.247` with no node for it, so `npm ci` refuses:

```
npm error Missing: @anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.247 from lock file
```

Both `validate-agent` and `test-agent` fail on that. It is **latent for `web/` too** (oxc, oxlint, rolldown, `@tailwindcss/oxide`, lightningcss all ship platform-split native `optionalDependencies`).

## Root cause

An npm arborist regression, not a Renovate bug: npm **10.3.0** started pruning foreign-platform optional nodes on *in-place* lockfile updates ([npm/cli#7961](https://github.com/npm/cli/issues/7961)), fixed in npm **11.3.0** ([npm/cli#8184](https://github.com/npm/cli/pull/8184)). Renovate runs its lockfile update with its own bundled npm; if that npm is in the 10.3–11.2 window it births the broken lock.

## Fix

- `constraints.npm: ">=11.3.0"` forces Renovate's runner onto the fixed npm when it regenerates the lock.
- `postUpdateOptions: [..., "npmInstallTwice"]` is documented insurance for residual "lock out of sync" cases.

Config-only, covers both `agent/` and `web/`, no new workflow or push token needed. The CI `npm ci` gate stays as the belt-and-braces catch (the one open npm-11 edge case, [npm/cli#9342](https://github.com/npm/cli/issues/9342), is private-registry-only; this repo uses npmjs).

## Follow-up

Once this lands on `main`, retrigger Renovate on #1044 (tick its rebase box) so Renovate regenerates that lock with the fixed npm. No manual lockfile edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance to run Go module cleanup and repeated npm installation checks.
  * Set the minimum supported npm version for automated dependency operations to 11.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->