### PR TITLE
fix(deps): bump golang.org/x/crypto to v0.56.0 (api) for x/crypto/ssh CVEs

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.5
 	gitlab.com/gitlab-org/api/client-go/v2 v2.59.1
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -216,8 +216,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef h1:LkZ48HFgy/TvhTI0bcWkjgFkgLyKUwcTbDjS0DUjw+A=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=


### PR DESCRIPTION
## Why (repo-wide red, not one PR's fault)

`vulncheck:api` began failing across the open renovate batch (and is now latently red on `main`) after two `golang.org/x/crypto` advisories landed in the live govulncheck DB:

- **GO-2026-6354** — DoS via deadlocked undecided channel in `golang.org/x/crypto/ssh`
- the companion `x/crypto/ssh` advisory

Both are **CALLED** (not just imported), traced through `api/internal/pushbroker/pushbroker.go:458` → `ssh.NewClientConn`. Both **fixed in `golang.org/x/crypto@v0.56.0`**. govulncheck has no allowlist/baseline, so the fix is the bump.

## Change

`api/go.mod`: `golang.org/x/crypto v0.55.0 → v0.56.0` (+ `go.sum`). No code change. `controller` does not call `x/crypto` (its vulncheck gate is green), so this is api-only.

Unblocks #1033 #1039 #1044 #1045 #1046 — they rebase green once this lands.

Local `task gate:api` (GOTOOLCHAIN=go1.26.6) passed: lint + deadcode + vulncheck + tests all clear.