### PR TITLE
fix(forge): guard int64 to int narrowing of GitHub issue/PR numbers (CodeQL)

### DIFF
--- a/api/internal/forge/github.go
+++ b/api/internal/forge/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -128,6 +129,19 @@ func (g *github) wrapErr(op string, err error) error {
 	default:
 		return g.redact.error(fmt.Errorf("github: %s: %w", op, err))
 	}
+}
+
+// ghNum narrows a project-scoped int64 IID (a GitHub issue or PR number) to the
+// int the go-github client requires. GitHub issue and PR numbers are always small
+// positive integers, far below math.MaxInt32, so the guard is defensive: it turns
+// the silent truncation govulncheck's sibling static analysis (CodeQL
+// go/incorrect-integer-conversion) flags — impossible on the 64-bit build target,
+// where int is 64-bit — into an explicit out-of-range error instead.
+func ghNum(iid int64) (int, error) {
+	if iid < 0 || iid > math.MaxInt32 {
+		return 0, fmt.Errorf("number %d out of range", iid)
+	}
+	return int(iid), nil
 }
 
 // repoSlugFor resolves a numeric projectID to its owner/repo pair, caching the

--- a/api/internal/forge/github_ghnum_test.go
+++ b/api/internal/forge/github_ghnum_test.go
@@ -1,0 +1,41 @@
+package forge
+
+import (
+	"math"
+	"testing"
+)
+
+// TestGhNum pins the narrowing guard the go-github client's int issue/PR-number
+// argument forces on uzi's int64 IIDs (CodeQL go/incorrect-integer-conversion).
+// A real issue/PR number narrows unchanged; a value past int32 range or negative
+// errors instead of silently truncating on a hypothetical 32-bit build.
+func TestGhNum(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      int64
+		want    int
+		wantErr bool
+	}{
+		{"typical issue number", 4172, 4172, false},
+		{"one", 1, 1, false},
+		{"max int32 boundary", math.MaxInt32, math.MaxInt32, false},
+		{"just over int32", math.MaxInt32 + 1, 0, true},
+		{"negative", -1, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ghNum(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ghNum(%d) = %d, nil; want out-of-range error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ghNum(%d) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ghNum(%d) = %d; want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/api/internal/forge/github_issues.go
+++ b/api/internal/forge/github_issues.go
@@ -70,7 +70,11 @@ func (g *github) GetIssue(ctx context.Context, projectID, issueIID int64) (Issue
 	if err != nil {
 		return Issue{}, err
 	}
-	i, _, err := g.client.Issues.Get(ctx, slug.owner, slug.repo, int(issueIID))
+	num, err := ghNum(issueIID)
+	if err != nil {
+		return Issue{}, g.wrapErr("get issue", err)
+	}
+	i, _, err := g.client.Issues.Get(ctx, slug.owner, slug.repo, num)
 	if err != nil {
 		return Issue{}, g.wrapErr("get issue", err)
 	}
@@ -107,8 +111,12 @@ func (g *github) UpdateIssueDescription(ctx context.Context, projectID, issueIID
 	if err != nil {
 		return err
 	}
+	num, err := ghNum(issueIID)
+	if err != nil {
+		return g.wrapErr("update issue description", err)
+	}
 	req := gh.UpdateIssueRequest{Body: &description}
-	if _, _, err := g.client.Issues.Update(ctx, slug.owner, slug.repo, int(issueIID), req); err != nil {
+	if _, _, err := g.client.Issues.Update(ctx, slug.owner, slug.repo, num, req); err != nil {
 		return g.wrapErr("update issue description", err)
 	}
 	return nil
@@ -140,11 +148,15 @@ func (g *github) ListIssueComments(ctx context.Context, projectID, issueIID int6
 	if err != nil {
 		return nil, err
 	}
+	num, err := ghNum(issueIID)
+	if err != nil {
+		return nil, g.wrapErr("list issue comments", err)
+	}
 	opt := &gh.IssueListCommentsOptions{ListOptions: gh.ListOptions{PerPage: githubPerPage}}
 	wrap := func(e error) error { return g.wrapErr("list issue comments", e) }
 	return paginate(wrap, func(page int) ([]IssueComment, int, error) {
 		opt.Page = page
-		comments, resp, err := g.client.Issues.ListComments(ctx, slug.owner, slug.repo, int(issueIID), opt)
+		comments, resp, err := g.client.Issues.ListComments(ctx, slug.owner, slug.repo, num, opt)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -172,7 +184,11 @@ func (g *github) CreateIssueNote(ctx context.Context, projectID, issueIID int64,
 	if err != nil {
 		return IssueNote{}, err
 	}
-	c, _, err := g.client.Issues.CreateComment(ctx, slug.owner, slug.repo, int(issueIID), &gh.IssueComment{Body: &body})
+	num, err := ghNum(issueIID)
+	if err != nil {
+		return IssueNote{}, g.wrapErr("create issue note", err)
+	}
+	c, _, err := g.client.Issues.CreateComment(ctx, slug.owner, slug.repo, num, &gh.IssueComment{Body: &body})
 	if err != nil {
 		return IssueNote{}, g.wrapErr("create issue note", err)
 	}

--- a/api/internal/forge/github_labels.go
+++ b/api/internal/forge/github_labels.go
@@ -87,12 +87,16 @@ func (g *github) UpdateIssueLabels(ctx context.Context, projectID, issueIID int6
 	if err != nil {
 		return err
 	}
+	num, err := ghNum(issueIID)
+	if err != nil {
+		return g.wrapErr("update issue labels", err)
+	}
 	// GitHub's set-replace is PUT /issues/{n}/labels (ReplaceLabelsForIssue). Read
 	// the current set, compute the target client-side (current − remove + add), and
 	// PUT once. An unrelated label the caller neither adds nor removes SURVIVES
 	// because it stays in target. The read/write is not transactional, so the same
 	// lost-update window the Forgejo/GitLab drivers accept (D3) applies.
-	cur, _, err := g.client.Issues.Get(ctx, slug.owner, slug.repo, int(issueIID))
+	cur, _, err := g.client.Issues.Get(ctx, slug.owner, slug.repo, num)
 	if err != nil {
 		return g.wrapErr("update issue labels: read current issue", err)
 	}
@@ -123,7 +127,7 @@ func (g *github) UpdateIssueLabels(ctx context.Context, projectID, issueIID int6
 	for name := range target {
 		names = append(names, name)
 	}
-	if _, _, err := g.client.Issues.ReplaceLabelsForIssue(ctx, slug.owner, slug.repo, int(issueIID), names); err != nil {
+	if _, _, err := g.client.Issues.ReplaceLabelsForIssue(ctx, slug.owner, slug.repo, num, names); err != nil {
 		return g.wrapErr("update issue labels", err)
 	}
 	return nil
@@ -138,11 +142,15 @@ func (g *github) ListIssueLabelEvents(ctx context.Context, projectID, issueIID i
 	// which needed a hand-parse): each IssueEvent carries event, actor, created_at,
 	// and a single label object. "labeled"→add, "unlabeled"→remove; other events are
 	// skipped. Chronological (oldest first), matching the GitLab driver. Paginated.
+	num, err := ghNum(issueIID)
+	if err != nil {
+		return nil, g.wrapErr("list issue label events", err)
+	}
 	opt := &gh.ListOptions{PerPage: githubPerPage}
 	wrap := func(e error) error { return g.wrapErr("list issue label events", e) }
 	return paginate(wrap, func(page int) ([]LabelEvent, int, error) {
 		opt.Page = page
-		events, resp, err := g.client.Issues.ListIssueEvents(ctx, slug.owner, slug.repo, int(issueIID), opt)
+		events, resp, err := g.client.Issues.ListIssueEvents(ctx, slug.owner, slug.repo, num, opt)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/api/internal/forge/github_mr.go
+++ b/api/internal/forge/github_mr.go
@@ -18,7 +18,11 @@ func (g *github) GetMergeRequest(ctx context.Context, projectID, mrIID int64) (M
 	if err != nil {
 		return MergeRequest{}, err
 	}
-	pr, _, err := g.client.PullRequests.Get(ctx, slug.owner, slug.repo, int(mrIID))
+	num, err := ghNum(mrIID)
+	if err != nil {
+		return MergeRequest{}, g.wrapErr("get merge request", err)
+	}
+	pr, _, err := g.client.PullRequests.Get(ctx, slug.owner, slug.repo, num)
 	if err != nil {
 		return MergeRequest{}, g.wrapErr("get merge request", err)
 	}
@@ -73,7 +77,10 @@ func (g *github) ListMergeRequestComments(ctx context.Context, projectID, mrIID 
 	if err != nil {
 		return nil, err
 	}
-	number := int(mrIID)
+	number, err := ghNum(mrIID)
+	if err != nil {
+		return nil, g.wrapErr("list merge request comments", err)
+	}
 
 	var out []MRComment
 
@@ -410,11 +417,15 @@ func (g *github) ReplyMergeRequestComment(ctx context.Context, projectID, mrIID 
 	if err != nil {
 		return err
 	}
+	num, err := ghNum(mrIID)
+	if err != nil {
+		return g.wrapErr("reply merge request comment", err)
+	}
 	commentID, err := strconv.ParseInt(strings.TrimSpace(replyID), 10, 64)
 	if err != nil {
 		return fmt.Errorf("github: reply merge request comment: invalid reply id %q", replyID)
 	}
-	if _, _, err := g.client.PullRequests.CreateCommentInReplyTo(ctx, slug.owner, slug.repo, int(mrIID), body, commentID); err != nil {
+	if _, _, err := g.client.PullRequests.CreateCommentInReplyTo(ctx, slug.owner, slug.repo, num, body, commentID); err != nil {
 		return g.wrapErr("reply merge request comment", err)
 	}
 	return nil

--- a/api/internal/forge/github_pipelines.go
+++ b/api/internal/forge/github_pipelines.go
@@ -64,7 +64,11 @@ func (g *github) LatestMRPipeline(ctx context.Context, projectID, mrIID int64) (
 	if err != nil {
 		return Pipeline{}, err
 	}
-	pr, _, err := g.client.PullRequests.Get(ctx, slug.owner, slug.repo, int(mrIID))
+	num, err := ghNum(mrIID)
+	if err != nil {
+		return Pipeline{}, g.wrapErr("latest MR pipeline", err)
+	}
+	pr, _, err := g.client.PullRequests.Get(ctx, slug.owner, slug.repo, num)
 	if err != nil {
 		return Pipeline{}, g.wrapErr("latest MR pipeline", err)
 	}


### PR DESCRIPTION
## Why

CodeQL `go/incorrect-integer-conversion` reports **5 high** code-scanning alerts (#34-#38) on `main`, all in the github forge driver: it converts uzi's `int64` IID to the `int` the go-github client requires for an issue/PR number (`int(issueIID)` / `int(mrIID)`). The same pattern exists at ~11 sites across `github_issues.go`, `github_labels.go`, `github_mr.go`, `github_pipelines.go`.

**These are false positives in practice** — the api builds/runs 64-bit only (where `int` is 64-bit, so `int(int64)` is a lossless identity), and GitHub issue/PR numbers are always small positive integers far below `MaxInt32`. But rather than dismiss 5 standing high alerts (this repo's ethos is fix-not-suppress; the govulncheck gate has no allowlist by design), this hardens the seam so the alerts clear and a malformed/out-of-range IID errors instead of silently truncating on a hypothetical 32-bit build.

## Change

- New checked helper `ghNum(iid int64) (int, error)` in `github.go`, erroring when `iid < 0 || iid > math.MaxInt32` — the standard CodeQL-recognized guard.
- Every `int(issueIID)` / `int(mrIID)` conversion (11 sites) routed through it, wrapped with the enclosing op's existing error message.
- Unit test `TestGhNum` (typical, `MaxInt32` boundary, just-over, negative). Placed in its own file to avoid the `whole-files` lint ratchet pulling a pre-existing unrelated finding into scope.

No behavior change on the 64-bit target. Local `task gate:api` (GOTOOLCHAIN=go1.26.6) green: lint + gosec + vulncheck + deadcode + tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub issue and pull-request handling by validating numeric identifiers before API requests.
  - Prevented invalid or oversized identifiers from being truncated or incorrectly processed.
  - Added clearer error handling when identifiers are negative or exceed supported limits.
- **Tests**
  - Added coverage for valid identifiers, boundary values, oversized values, and negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->