### PR TITLE
PRD: TUI sketch harness — preview a new TUI feature before implementing it

### DIFF
--- a/.claude/rules/tui.md
+++ b/.claude/rules/tui.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - api/cmd/uzi/tui_*.go
+  - api/cmd/uzi/sketch.go
   - api/cmd/uzi/uxlab/**
 ---
 
@@ -28,6 +29,14 @@ screenshot lies silently.
 **One source of truth.** The demo, the screenshots, and the shipped views all run
 the same `tuiModel` (the factoryui prototype was retired at PRD #325 M7), so
 changing a view moves both. Do not reintroduce a parallel mock model.
+
+**Exception: the sketch harness (`api/cmd/uzi/sketch.go`, PRD #1061), gated and throwaway.**
+For previewing a feature that does not render yet, hand-built frames (Tier A) or a
+local-state `tea.Model` (Tier B) are allowed via `uzi tui --sketch <name>`, passed
+NO client. It is delete-when-done, not maintained: only the permanent `template`
+sketch ships on `main`; every other sketch is branch-local and gets deleted once
+its keepable `View` shape is lifted into the real `tuiModel`. Do not wire a real
+client into a sketch, and do not let a feature sketch merge to `main`.
 
 **Terminal-injection guard (D7).** Untrusted cells (titles, owner email, agent
 output) MUST be drawn through `m.renderer.Plain` (= `capCell(cellText(s))`;

--- a/api/cmd/uzi/sketch.go
+++ b/api/cmd/uzi/sketch.go
@@ -1,0 +1,218 @@
+package main
+
+// The sketch harness — a throwaway surface for previewing a not-yet-built TUI feature
+// (PRD #1061). A `sketch` is authored once and yields both a live interactive preview
+// (`uzi tui --sketch <name>`) and, via the uxlab generator, light/dark screenshots.
+//
+// Sketches render PURE STRINGS / local state and are passed NO uzicli.Client by
+// construction: the keepable half (the lipgloss View shape/layout) is meant to be
+// lifted into the real tuiModel, at which point the sketch is DELETED, not maintained.
+// That "no client" structure is what keeps this from becoming a second maintained TUI
+// (the retired `factoryui`). Exactly one permanent `template` sketch ships as the
+// copyable example; every other sketch is a branch-local throwaway.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/vtmocanu/uzi/api/internal/uzicli"
+)
+
+// sketch is one prototype. Tier A supplies static `frames`; Tier B optionally supplies
+// its own `model` for key-driven feel. `frames` may be nil only for a Tier-B-only sketch.
+type sketch struct {
+	title  string
+	frames func(dark bool) []string // Tier A: static frames; nil only for a Tier-B-only sketch
+	model  func() tea.Model         // Tier B: optional; when set, the live preview runs this
+}
+
+// sketches is the registry both the runtime `--sketch` command and the uxlab screenshot
+// generator consume, so a sketch authored once is previewable live and screenshotted.
+var sketches = map[string]sketch{
+	"template": {
+		title:  "template",
+		frames: templateFrames,
+	},
+}
+
+// sketchNames returns the registered sketch keys in sorted order (for `--sketch` listing).
+func sketchNames() []string {
+	names := make([]string, 0, len(sketches))
+	for name := range sketches {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ---- layout primitives ----------------------------------------------------
+//
+// Small lipgloss helpers that source their colours from the SHIPPED palette
+// (newPalette(dark), tui_render.go) so a sketch inherits the real TUI's palette and
+// cannot drift into ad-hoc colours. They exist to be copied into a new sketch.
+
+// header renders a bold tungsten title line.
+func header(p palette, title string) string {
+	return p.title.Render(title)
+}
+
+// pane renders body inside the palette's bordered, padded structural box.
+func pane(p palette, body string) string {
+	return p.box.Render(body)
+}
+
+// statusbar renders a faint key-hint line.
+func statusbar(p palette, hint string) string {
+	return p.faint.Render(hint)
+}
+
+// templateFrames is the permanent minimal copyable example: a header, a pane with a
+// couple of lines, and a statusbar, built ONLY from the primitives + newPalette(dark).
+// Two frames so the frame-host paging is demonstrable.
+func templateFrames(dark bool) []string {
+	p := newPalette(dark)
+	frame := func(status string, lines ...string) string {
+		return strings.Join([]string{
+			header(p, "sketch: template"),
+			"",
+			pane(p, strings.Join(lines, "\n")),
+			"",
+			statusbar(p, status),
+		}, "\n")
+	}
+	return []string{
+		frame("n/→ next · p/← prev · t theme · q quit",
+			"This is a sketch frame.",
+			"Copy this template to prototype a new TUI view.",
+			p.sel.Render("Colours come from the shipped palette."),
+		),
+		frame("frame 2 of 2 · p/← prev · t theme · q quit",
+			"A second frame demonstrates the host's paging.",
+			p.faint.Render("Everything here is static text — no client, no API."),
+		),
+	}
+}
+
+// ---- generic Tier A host ---------------------------------------------------
+
+// sketchHost renders a Tier A sketch's current frame fullscreen with paging and a
+// light/dark toggle. It holds no client and issues no commands.
+type sketchHost struct {
+	frames        func(dark bool) []string
+	dark          bool
+	cur           []string // frames(dark), re-evaluated on a theme toggle
+	frameIdx      int
+	width, height int
+	showHelp      bool
+}
+
+var _ tea.Model = sketchHost{}
+
+// newSketchHost builds a host over a sketch's frames-producing closure, defaulting to
+// the dark palette (the TUI's own default).
+func newSketchHost(frames func(dark bool) []string) sketchHost {
+	dark := true
+	return sketchHost{frames: frames, dark: dark, cur: frames(dark)}
+}
+
+func (h sketchHost) Init() tea.Cmd { return nil }
+
+func (h sketchHost) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		h.width, h.height = msg.Width, msg.Height
+		return h, nil
+	case tea.KeyPressMsg:
+		return h.handleKey(keyString(msg))
+	}
+	return h, nil
+}
+
+func (h sketchHost) handleKey(k string) (tea.Model, tea.Cmd) {
+	switch k {
+	case keyQuit, keyEsc, keyCtrlC:
+		return h, tea.Quit
+	case "n", keyRight:
+		if h.frameIdx < len(h.cur)-1 {
+			h.frameIdx++
+		}
+	case "p", keyLeft:
+		if h.frameIdx > 0 {
+			h.frameIdx--
+		}
+	case "t":
+		h.dark = !h.dark
+		h.cur = h.frames(h.dark)
+		if h.frameIdx > len(h.cur)-1 {
+			h.frameIdx = len(h.cur) - 1
+		}
+	case keyHelp:
+		h.showHelp = !h.showHelp
+	}
+	return h, nil
+}
+
+func (h sketchHost) View() tea.View {
+	var v tea.View
+	v.AltScreen = true
+	v.WindowTitle = "uzi sketch"
+
+	body := "(sketch has no frames)"
+	switch {
+	case h.showHelp:
+		body = strings.Join([]string{
+			"n / →      next frame",
+			"p / ←      previous frame",
+			"t          toggle light / dark",
+			"?          this help",
+			"q / esc    quit",
+		}, "\n")
+	case len(h.cur) > 0:
+		idx := h.frameIdx
+		if idx < 0 {
+			idx = 0
+		}
+		if idx > len(h.cur)-1 {
+			idx = len(h.cur) - 1
+		}
+		body = h.cur[idx]
+	}
+	v.SetContent(body)
+	return v
+}
+
+// ---- dispatch --------------------------------------------------------------
+
+// runTUISketch runs the named sketch, or — for the "list" sentinel, an empty name, or an
+// unknown key — prints the registered sketch names and returns nil (a discovery
+// affordance, not an error). Sketches are passed NO uzicli.Client.
+func runTUISketch(ctx context.Context, env Env, name string) error {
+	sk, ok := sketches[name]
+	if name == "list" || name == "" || !ok {
+		printSketchList(env)
+		return nil
+	}
+	var m tea.Model
+	if sk.model != nil {
+		m = sk.model()
+	} else {
+		m = newSketchHost(sk.frames)
+	}
+	p := tea.NewProgram(m, tea.WithContext(ctx), tea.WithInput(env.Stdin), tea.WithOutput(env.Stdout))
+	if _, err := p.Run(); err != nil {
+		return uzicli.Exitf(uzicli.ExitGeneric, "tui sketch: %v", err)
+	}
+	return nil
+}
+
+// printSketchList writes the sorted sketch names to env.Stdout, one per line.
+func printSketchList(env Env) {
+	_, _ = fmt.Fprintln(env.Stdout, "available sketches:")
+	for _, name := range sketchNames() {
+		_, _ = fmt.Fprintln(env.Stdout, "  "+name)
+	}
+}

--- a/api/cmd/uzi/sketch.go
+++ b/api/cmd/uzi/sketch.go
@@ -187,6 +187,15 @@ func (h sketchHost) View() tea.View {
 
 // ---- dispatch --------------------------------------------------------------
 
+// sketchModel returns the tea.Model to run for a sketch: its own Tier-B model when
+// one is supplied, otherwise the generic Tier-A frame host over its frames.
+func sketchModel(sk sketch) tea.Model {
+	if sk.model != nil {
+		return sk.model()
+	}
+	return newSketchHost(sk.frames)
+}
+
 // runTUISketch runs the named sketch, or — for the "list" sentinel, an empty name, or an
 // unknown key — prints the registered sketch names and returns nil (a discovery
 // affordance, not an error). Sketches are passed NO uzicli.Client.
@@ -196,12 +205,7 @@ func runTUISketch(ctx context.Context, env Env, name string) error {
 		printSketchList(env)
 		return nil
 	}
-	var m tea.Model
-	if sk.model != nil {
-		m = sk.model()
-	} else {
-		m = newSketchHost(sk.frames)
-	}
+	m := sketchModel(sk)
 	p := tea.NewProgram(m, tea.WithContext(ctx), tea.WithInput(env.Stdin), tea.WithOutput(env.Stdout))
 	if _, err := p.Run(); err != nil {
 		return uzicli.Exitf(uzicli.ExitGeneric, "tui sketch: %v", err)

--- a/api/cmd/uzi/sketch_test.go
+++ b/api/cmd/uzi/sketch_test.go
@@ -99,6 +99,47 @@ func TestSketchHostRendersAndClamps(t *testing.T) {
 	press(keyHelp)
 }
 
+// The paging clamp and the theme re-clamp are pinned here against a sketch whose two
+// themes return DIFFERENT frame counts (dark→3, light→1). Asserting on the host's
+// frameIdx STATE — not the rendered content — is what makes these branches
+// falsifiable: View() clamps the index defensively before rendering, so a rendered
+// frame stays valid even if handleKey's clamps were removed; only the state exposes
+// the regression. (template has 2 frames in both themes and cannot exercise this.)
+func TestSketchHostPagingAndThemeReclamp(t *testing.T) {
+	asym := func(dark bool) []string {
+		if dark {
+			return []string{"dark-0", "dark-1", "dark-2"}
+		}
+		return []string{"light-0"}
+	}
+	h := newSketchHost(asym) // defaults dark → 3 frames
+
+	step := func(k string) {
+		t.Helper()
+		next, _ := h.handleKey(k)
+		h = next.(sketchHost)
+	}
+
+	// Over-page: 5×"n" on a 3-frame slice must clamp frameIdx at len-1 == 2.
+	// (Drop handleKey's "n" clamp and frameIdx would run to 5 here.)
+	for i := 0; i < 5; i++ {
+		step("n")
+	}
+	if h.frameIdx != 2 {
+		t.Fatalf("after over-paging, frameIdx = %d, want 2 (clamped at len-1)", h.frameIdx)
+	}
+
+	// Toggle to the light theme (1 frame). frameIdx was 2 and must re-clamp to 0.
+	// (Drop the "t" re-clamp and frameIdx would stay 2 with only 1 frame present.)
+	step("t")
+	if h.frameIdx != 0 {
+		t.Fatalf("after theme toggle to a 1-frame theme, frameIdx = %d, want 0 (re-clamped)", h.frameIdx)
+	}
+	if got := content(h.View()); got != "light-0" {
+		t.Fatalf("after re-clamp, View() = %q, want the sole light frame %q", got, "light-0")
+	}
+}
+
 // stubSketchModel is a minimal tea.Model used to prove the Tier-B dispatch path.
 type stubSketchModel struct{}
 

--- a/api/cmd/uzi/sketch_test.go
+++ b/api/cmd/uzi/sketch_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/vtmocanu/uzi/api/internal/uzicli"
+)
+
+// Every registered Tier-A sketch must yield at least one non-empty frame in BOTH
+// themes. This is a property over the whole registry, not the roster — a new
+// branch-local sketch is covered automatically, and a sketch that ships an empty
+// frame (a broken copy of the template) reddens here.
+func TestSketchRegistryFramesNonEmpty(t *testing.T) {
+	for name, sk := range sketches {
+		if sk.frames == nil {
+			continue // Tier-B-only sketch: no static frames to check.
+		}
+		for _, dark := range []bool{true, false} {
+			frames := sk.frames(dark)
+			if len(frames) == 0 {
+				t.Errorf("sketch %q frames(%v) returned no frames", name, dark)
+				continue
+			}
+			for i, f := range frames {
+				if strings.TrimSpace(f) == "" {
+					t.Errorf("sketch %q frames(%v)[%d] is empty", name, dark, i)
+				}
+			}
+		}
+	}
+}
+
+// The permanent `template` sketch is the copyable example and must always be
+// registered with frames and a title. This reads the `title` field, which is
+// otherwise write-only. It deliberately does NOT assert the registry size or any
+// other name, so a branch-local sketch cannot break it.
+func TestSketchTemplateRegistered(t *testing.T) {
+	sk, ok := sketches["template"]
+	if !ok {
+		t.Fatal(`sketches["template"] is not registered`)
+	}
+	if sk.frames == nil {
+		t.Error("template sketch has nil frames")
+	}
+	if sk.title == "" {
+		t.Error("template sketch has an empty title")
+	}
+}
+
+// content reads the rendered string out of a tea.View, mirroring how the uxlab
+// generator does it (m.View().Content).
+func content(v tea.View) string { return v.Content }
+
+// The Tier-A host renders without panic across a key sequence that exercises the
+// paging clamps and the theme toggle. Driving many `n` past the last frame then
+// rendering must not index out of range, and the theme toggle must re-clamp.
+func TestSketchHostRendersAndClamps(t *testing.T) {
+	h := newSketchHost(sketches["template"].frames)
+
+	if got := content(h.View()); strings.TrimSpace(got) == "" {
+		t.Fatalf("initial host View() is empty")
+	}
+
+	// press drives one key through handleKey and re-renders, asserting no panic and
+	// (with a non-empty frame slice) non-empty content.
+	press := func(k string) {
+		t.Helper()
+		next, _ := h.handleKey(k)
+		var ok bool
+		h, ok = next.(sketchHost)
+		if !ok {
+			t.Fatalf("handleKey(%q) returned a non-sketchHost model %T", k, next)
+		}
+		if got := content(h.View()); len(h.cur) > 0 && strings.TrimSpace(got) == "" {
+			t.Fatalf("View() after key %q is empty", k)
+		}
+	}
+
+	// Advance well past the last frame: the paging must clamp, not panic or overflow.
+	for i := 0; i < 10; i++ {
+		press("n")
+	}
+	press(keyRight)
+	// Go back to the start.
+	for i := 0; i < 10; i++ {
+		press("p")
+	}
+	press(keyLeft)
+	// Toggle theme (re-evaluates frames and re-clamps), then page again.
+	press("t")
+	for i := 0; i < 10; i++ {
+		press("n")
+	}
+	press("t")
+	// Open help.
+	press(keyHelp)
+}
+
+// stubSketchModel is a minimal tea.Model used to prove the Tier-B dispatch path.
+type stubSketchModel struct{}
+
+func (stubSketchModel) Init() tea.Cmd { return nil }
+func (m stubSketchModel) Update(tea.Msg) (tea.Model, tea.Cmd) {
+	return m, nil
+}
+func (stubSketchModel) View() tea.View {
+	var v tea.View
+	v.SetContent("stub sketch model")
+	return v
+}
+
+// sketchModel dispatches to a sketch's own Tier-B model when one is supplied, and to
+// the generic Tier-A host otherwise. Both arms are exercised so the dispatch is
+// tested, not merely un-gated.
+func TestSketchModelDispatch(t *testing.T) {
+	// Tier B: a sketch supplying its own model.
+	sk := sketch{title: "stub", model: func() tea.Model { return stubSketchModel{} }}
+	m := sketchModel(sk)
+	if _, ok := m.(stubSketchModel); !ok {
+		t.Fatalf("sketchModel with a model closure returned %T, want stubSketchModel", m)
+	}
+	if got := content(m.View()); strings.TrimSpace(got) == "" {
+		t.Errorf("Tier-B model View() is empty")
+	}
+
+	// Tier A: a sketch with only frames dispatches to the generic host.
+	a := sketchModel(sketch{frames: sketches["template"].frames})
+	if _, ok := a.(sketchHost); !ok {
+		t.Fatalf("sketchModel with only frames returned %T, want sketchHost", a)
+	}
+}
+
+// A bare `--sketch` on a TTY lists the registered sketches and exits OK, rather than
+// launching a program. The list always contains the permanent `template`.
+func TestSketchCLIListsOnTTY(t *testing.T) {
+	env := fakeEnv(&uzicli.FakeClient{})
+	env.StdoutTTY = true
+	out, _, code := runCLI(t, env, "tui", "--sketch")
+	if code != uzicli.ExitOK {
+		t.Fatalf("bare --sketch exit = %d, want %d", code, uzicli.ExitOK)
+	}
+	if !strings.Contains(out, "template") {
+		t.Errorf("bare --sketch did not list the template sketch:\n%s", out)
+	}
+}
+
+// An unknown sketch name lists rather than errors — the discovery affordance.
+func TestSketchCLIUnknownNameLists(t *testing.T) {
+	env := fakeEnv(&uzicli.FakeClient{})
+	env.StdoutTTY = true
+	out, _, code := runCLI(t, env, "tui", "--sketch", "definitely-not-a-real-sketch")
+	if code != uzicli.ExitOK {
+		t.Fatalf("unknown --sketch exit = %d, want %d", code, uzicli.ExitOK)
+	}
+	if !strings.Contains(out, "template") {
+		t.Errorf("unknown --sketch name did not fall back to listing:\n%s", out)
+	}
+}
+
+// On a non-TTY the tui guard fires BEFORE any dispatch, so even a valid sketch name
+// returns a usage error and never launches a program (which would hang on the empty
+// test stdin).
+func TestSketchCLINonTTYGuard(t *testing.T) {
+	_, errOut, code := runCLI(t, fakeEnv(&uzicli.FakeClient{}), "tui", "--sketch", "template")
+	if code != uzicli.ExitUsage {
+		t.Fatalf("non-TTY --sketch exit = %d, want %d (usage guard)", code, uzicli.ExitUsage)
+	}
+	if !strings.Contains(errOut, "terminal") {
+		t.Errorf("non-TTY guard message should mention the terminal requirement:\n%s", errOut)
+	}
+}

--- a/api/cmd/uzi/tui.go
+++ b/api/cmd/uzi/tui.go
@@ -660,6 +660,7 @@ func (m tuiModel) renderHelp() string {
 // newTUICmd wires `uzi tui [run-id]`.
 func newTUICmd(env Env, gf *globalFlags) *cobra.Command {
 	var demo bool
+	var sketch string
 	cmd := &cobra.Command{
 		Use:   "tui [run-id]",
 		Short: "Watch runs live in a full-screen terminal UI",
@@ -679,6 +680,12 @@ func newTUICmd(env Env, gf *globalFlags) *cobra.Command {
 			// M7): a hidden showcase that drives the SHIPPED views, so it cannot drift.
 			if demo {
 				return runTUIDemo(cmd.Context(), env)
+			}
+			// --sketch previews a throwaway TUI sketch by name with no server (PRD #1061),
+			// a hidden discovery-friendly flag parallel to --demo. Changed() so a bare or
+			// valued --sketch triggers it while a plain `uzi tui` is unaffected.
+			if cmd.Flags().Changed("sketch") {
+				return runTUISketch(cmd.Context(), env, sketch)
 			}
 			c, err := env.client(gf)
 			if err != nil {
@@ -707,6 +714,9 @@ func newTUICmd(env Env, gf *globalFlags) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&demo, "demo", false, "run a self-contained demo over seeded fixtures (no server)")
 	_ = cmd.Flags().MarkHidden("demo")
+	cmd.Flags().StringVar(&sketch, "sketch", "", "preview a throwaway TUI sketch by name (no server); bare --sketch lists them")
+	cmd.Flags().Lookup("sketch").NoOptDefVal = "list" // bare --sketch => the "list" sentinel, not a cobra "flag needs an argument" error
+	_ = cmd.Flags().MarkHidden("sketch")
 	return cmd
 }
 

--- a/api/cmd/uzi/uxlab/README.md
+++ b/api/cmd/uzi/uxlab/README.md
@@ -7,7 +7,9 @@ human) can regenerate the images and Read the PNGs to critique the visuals. It a
 
 The redesign that this lab was built to develop (PRD #325, the "factory shift board") is now
 **the shipped TUI**. There is no separate prototype any more: the demo and the screenshots
-both drive the real `tuiModel`, so what you see here is what users get.
+both drive the real `tuiModel`, so what you see here is what users get. The one deliberate,
+gated exception is the throwaway **sketch harness** for previewing a feature that does not
+exist yet — see "Prototyping a new TUI feature (sketches)" below.
 
 ## Run the TUI live (no server)
 
@@ -84,10 +86,52 @@ Every scene is rendered from the SHIPPED model, `-dark` and `-light`.
 
 | Path | What |
 |---|---|
-| `../uxlab_gen_test.go` | the screenshot generator: drives the shipped `tuiModel` into every scene |
+| `../uxlab_gen_test.go` | the screenshot generator: drives the shipped `tuiModel` into every scene (and, per sketch, `sketches`) |
 | `../demo.go` | the `uzi tui --demo` showcase (shipped model + fake client + live ticker) |
+| `../sketch.go` | the sketch harness: the `sketches` registry, its lipgloss primitives, and the Tier-A frame host |
 | `gen.sh` / `render.sh` | regenerate ANSI frames / render them to PNG |
 | `devbox.json` | pins `freeze`; scripts `demo`, `gen`, `render`, `build` |
+
+## Prototyping a new TUI feature (sketches)
+
+Everything above renders the **shipped** TUI — the `scenes` map and `--demo` both drive the
+real `tuiModel`, so they can only show a view that already exists. A **sketch** is for the
+step before that: previewing a feature whose render code does not exist yet, to answer "does
+it look right, does it feel right to drive" before you build it for real.
+
+Two rungs, pick the cheaper one first:
+
+- **Tier A — static frames (the common case).** Supply a `frames func(dark bool) []string`
+  that builds a few frames from the shared lipgloss primitives (`header`/`pane`/`statusbar`)
+  and the shipped palette (`newPalette(dark)`). A generic host renders them fullscreen with
+  paging (`n`/`p` or `←`/`→`), a light/dark toggle (`t`), help (`?`), and quit (`q`/esc) — no
+  per-sketch UI code. This covers look, states, and both palettes in ~20 lines.
+- **Tier B — a real `tea.Model` (opt-in).** Supply a `model func() tea.Model` for key-driven
+  feel that static frames can't show. Use it only when the interaction itself is the thing
+  you're prototyping.
+
+**How to add one.** Add an entry to the `sketches` registry in `../sketch.go` — copy the
+permanent `template` entry as a starting point, and build its `frames` only from the
+`header`/`pane`/`statusbar` primitives plus `newPalette(dark)` so it inherits the shipped
+palette rather than drifting into ad-hoc colours. Then:
+
+```sh
+cd api && go run ./cmd/uzi tui --sketch <name>   # live preview, no server
+```
+
+A bare `uzi tui --sketch` (or `--sketch list`, or an unknown name) prints the registered
+sketch names. `devbox run build` picks up any Tier-A sketch automatically — no generator
+edit needed — and produces its `sketch-<name>-<frameIndex>-<theme>.png` alongside the shipped
+scenes; a Tier-B-only sketch (no `frames`) is live-preview-only and isn't screenshotted.
+
+**The point of a sketch is to be deleted.** A sketch is passed no `uzicli.Client` by
+construction — wiring the real API into one defeats the purpose and is not supported. Once a
+sketch has answered the "should we build this" question, lift its keepable lipgloss `View`
+shape into the real `tuiModel` and **delete the sketch** rather than maintaining it. Feature
+sketches are branch-local throwaways that should not merge to `main`: the harness ships
+exactly one permanent entry, `template`, as the copyable example. This discipline is what
+keeps the harness from becoming a second maintained TUI, the fate of the retired
+`factoryui` prototype.
 
 ## Adding a state
 

--- a/api/cmd/uzi/uxlab_gen_test.go
+++ b/api/cmd/uzi/uxlab_gen_test.go
@@ -70,7 +70,7 @@ func TestGenerateUXLabFrames(t *testing.T) {
 	}
 
 	outDir := filepath.Join("uxlab", "frames")
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil { //nolint:gosec // G301: dev-tool frame output dir holds non-sensitive generated artifacts; 0755 keeps it browsable
 		t.Fatal(err)
 	}
 
@@ -117,10 +117,43 @@ func TestGenerateUXLabFrames(t *testing.T) {
 			}
 			body := scenes[name](dark)
 			path := filepath.Join(outDir, fmt.Sprintf("%s-%s.ansi", name, theme))
-			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil { //nolint:gosec // G306: generated ANSI frame is non-sensitive; 0644 keeps it readable by render.sh/freeze
 				t.Fatalf("write %s: %v", path, err)
 			}
 			t.Logf("wrote %s (%d bytes)", path, len(body))
+		}
+	}
+
+	// Screenshot every Tier-A sketch from the shared registry (sketch.go), so a sketch
+	// authored once is previewable live AND rendered to static frames with no per-sketch
+	// generator code here. A Tier-B-only sketch (frames == nil) is live-preview-only and
+	// has no static frame to render, so it is skipped; a Tier-B sketch that ALSO supplies
+	// frames IS screenshotted. Filenames are sketch-<name>-<frameIndex>-<theme>.ansi —
+	// theme LAST so render.sh's *-light detection works, frameIndex before it because a
+	// Tier-A sketch has many frames per theme (unlike a scene, which is one string).
+	sketchKeys := make([]string, 0, len(sketches))
+	for name := range sketches {
+		sketchKeys = append(sketchKeys, name)
+	}
+	sort.Strings(sketchKeys)
+
+	for _, name := range sketchKeys {
+		sk := sketches[name]
+		if sk.frames == nil {
+			continue // Tier-B-only: live preview only, no static frame to render.
+		}
+		for _, dark := range []bool{true, false} {
+			theme := "dark"
+			if !dark {
+				theme = "light"
+			}
+			for i, body := range sk.frames(dark) {
+				path := filepath.Join(outDir, fmt.Sprintf("sketch-%s-%d-%s.ansi", name, i, theme))
+				if err := os.WriteFile(path, []byte(body), 0o644); err != nil { //nolint:gosec // G306: generated ANSI frame is non-sensitive; 0644 keeps it readable by render.sh/freeze
+					t.Fatalf("write %s: %v", path, err)
+				}
+				t.Logf("wrote %s (%d bytes)", path, len(body))
+			}
 		}
 	}
 }

--- a/prds/done/1061-tui-sketch-harness.md
+++ b/prds/done/1061-tui-sketch-harness.md
@@ -2,7 +2,7 @@
 
 **Issue**: #1061
 **Priority**: Medium (developer velocity / internal tooling)
-**Status**: Draft
+**Status**: Implemented — M1–M5 landed on branch `agent/issue-1061` (2026-09-03), `task gate:api` green. SC2–SC6 are covered by `api/cmd/uzi/sketch_test.go` (registry frames property, the Tier-A host render + paging/theme clamps pinned by an asymmetric-frame mutation test, the Tier-B dispatch via a stub model, the CLI list affordance on a TTY, and the non-TTY `ExitUsage` guard) plus the generator/screenshot wiring in `uxlab_gen_test.go`. SC1 (the interactive `uzi tui --sketch template` session) is the documented manual/pty acceptance, not a gate unit test — matching the untested `--demo` precedent. The `devbox run build` PNG-render step is CI/local-devbox-only (freeze cannot be fetched in the uzi worker); the `.ansi` frame emission is proven and `render.sh` is unchanged.
 
 ## Problem
 


### PR DESCRIPTION
Implements issue #1061.

Closes #1061

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1061`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a sketch preview mode to `uzi tui`, allowing available sketches to be listed and launched without connecting to an API client.
  - Added fullscreen preview controls for paging through frames, switching themes, viewing help, and quitting.
  - Added support for both static visual sketches and interactive previews.
  - Generated UX frames for registered sketches across dark and light themes.

- **Documentation**
  - Documented sketch usage, supported tiers, screenshot generation, and lifecycle expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->