### PR TITLE
PRD: Autofix (MR rework + CI autofix) for scheduled runs (prompt + self_improve)

### DIFF
--- a/api/internal/forgesvc/mr_watch.go
+++ b/api/internal/forgesvc/mr_watch.go
@@ -226,9 +226,13 @@ func (s *Service) guardedMRMove(ctx context.Context, repoID uuid.UUID, forgeProj
 }
 
 // recordMRState persists the observed MR state (runs.mr_state is written only by
-// forgesvc MR-state sync — SyncMRStates and SyncScheduledMRStates, over disjoint
-// run sets, PRD #908 — both through the single SetRunMRState statement).
-// Best-effort: a write failure only means the same edge is
+// forgesvc MR-state sync — SyncMRStates and SyncScheduledMRStates, PRD #908 — both
+// through the single SetRunMRState statement). The two syncs cover near-disjoint run
+// sets (issue vs prompt/self_improve); they can overlap on the newest self_improve run
+// when its shared tracking issue is cached (that run satisfies both candidate queries),
+// but both read live forge state and drive the same idempotent record/cancel path, and
+// the board move is a guarded no-op for the un-promoted tracking issue, so a same-tick
+// double observation is harmless. Best-effort: a write failure only means the same edge is
 // re-observed next tick, and the guards make the retry a no-op if the card has
 // already moved.
 func (s *Service) recordMRState(ctx context.Context, runID uuid.UUID, state string) {

--- a/api/internal/forgesvc/mr_watch.go
+++ b/api/internal/forgesvc/mr_watch.go
@@ -225,8 +225,10 @@ func (s *Service) guardedMRMove(ctx context.Context, repoID uuid.UUID, forgeProj
 	return moveApplied
 }
 
-// recordMRState persists the observed MR state (SetRunMRState is the sole writer
-// of runs.mr_state). Best-effort: a write failure only means the same edge is
+// recordMRState persists the observed MR state (runs.mr_state is written only by
+// forgesvc MR-state sync — SyncMRStates and SyncScheduledMRStates, over disjoint
+// run sets, PRD #908 — both through the single SetRunMRState statement).
+// Best-effort: a write failure only means the same edge is
 // re-observed next tick, and the guards make the retry a no-op if the card has
 // already moved.
 func (s *Service) recordMRState(ctx context.Context, runID uuid.UUID, state string) {

--- a/api/internal/forgesvc/scheduled_mr_watch.go
+++ b/api/internal/forgesvc/scheduled_mr_watch.go
@@ -71,25 +71,25 @@ func (s *Service) recordScheduledMRState(ctx context.Context, repoID uuid.UUID, 
 	if observed == stored {
 		return // no transition
 	}
-	switch {
-	case stored == forge.MRStateOpened && observed == forge.MRStateClosed:
-		// close-edge: a confirmed close means an in-flight rework can never land -> abort it
-		// (issue #853). No board move (board-free). On cancel failure leave mr_state
+	switch observed {
+	case forge.MRStateClosed, forge.MRStateMerged:
+		// terminal edge from a valid non-terminal stored state (opened OR locked): a
+		// confirmed close/merge means an in-flight rework can never land -> abort it
+		// (issue #853). This MUST fire for stored=='locked' too — a locked->closed (or
+		// ->merged) transition is still a terminal edge. The earlier stored=='opened'-only
+		// close arm leaked a rework when the MR passed through `locked` before closing
+		// (review finding, PRD #908): `locked`->`closed` fell to the default arm, which
+		// records `closed` (self-evicting the run from the candidate set) without ever
+		// cancelling. No board move (board-free). On cancel failure leave mr_state
 		// unadvanced so the next tick re-observes the edge and retries.
 		if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
-			slog.Warn("forgesvc: cancel scheduled rework on MR close failed, will retry", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "error", err)
+			slog.Warn("forgesvc: cancel scheduled rework on MR terminal state failed, will retry", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "state", observed, "error", err)
 			return
 		}
 		s.recordMRState(ctx, c.ID, observed)
 	default:
-		// KNOWN non-edge transition (merged / locked). A merge means the branch is gone ->
-		// abort any in-flight rework (issue #853); locked is transient -> no cancel.
-		if observed == forge.MRStateMerged {
-			if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
-				slog.Warn("forgesvc: cancel scheduled rework on MR merge failed, will retry", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "error", err)
-				return
-			}
-		}
+		// KNOWN non-terminal transition: `locked` (transient during merge processing) or a
+		// `locked`->`opened` settle. Record, never cancel — the gate stays open.
 		s.recordMRState(ctx, c.ID, observed)
 	}
 }

--- a/api/internal/forgesvc/scheduled_mr_watch.go
+++ b/api/internal/forgesvc/scheduled_mr_watch.go
@@ -1,0 +1,90 @@
+package forgesvc
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/vtmocanu/uzi/api/internal/forge"
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// SyncScheduledMRStates is the board-FREE MR-state recorder for the scheduled lanes
+// (prompt, self_improve) — PRD #908. The poller calls it once per repo per tick, right
+// after SyncMRStates. Unlike SyncMRStates it moves NO board card: prompt runs are
+// issue-less and the self_improve tracking issue is not board-promoted. It only records
+// runs.mr_state (via the existing recordMRState, the sole SQL writer — invariant preserved)
+// and, on the opened->closed / ->merged edge, cancels an in-flight rework via the existing
+// cancelReworkOnClosedMR (issue #853 contract, reused verbatim). Reads the run set from
+// ListScheduledMRStateWatchCandidates, which self-evicts a run once its mr_state is terminal.
+//
+// Like SyncMRStates it never returns a per-candidate error (log-and-skip); only a failure
+// to enumerate candidates surfaces to the poller.
+func (s *Service) SyncScheduledMRStates(ctx context.Context, repoID uuid.UUID, forgeProjectID int64, f forge.Forge) error {
+	candidates, err := s.q.ListScheduledMRStateWatchCandidates(ctx, repoID)
+	if err != nil {
+		return err
+	}
+	for _, c := range candidates {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		s.recordScheduledMRState(ctx, repoID, forgeProjectID, f, c)
+	}
+	return nil
+}
+
+// recordScheduledMRState reconciles one scheduled run's MR state against the stored value,
+// board-free. It is a second implementation of syncOneMRState's observe->persist->cancel
+// contract WITHOUT the board move; the two must agree on: unknown-state -> no write; the
+// NULL bootstrap records without acting; opened->closed and ->merged cancel exactly once;
+// locked is transient (no cancel); a forge read failure or a cancel failure leaves mr_state
+// unadvanced so the next tick retries.
+func (s *Service) recordScheduledMRState(ctx context.Context, repoID uuid.UUID, forgeProjectID int64, f forge.Forge, c store.ListScheduledMRStateWatchCandidatesRow) {
+	mr, err := f.GetMergeRequest(ctx, forgeProjectID, c.MrIid.Int64)
+	if err != nil {
+		slog.Warn("forgesvc: scheduled MR-state read failed", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "error", err)
+		return
+	}
+	observed := mr.State
+	if !forge.IsKnownMRState(observed) {
+		slog.Warn("forgesvc: ignoring unknown scheduled MR state", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "state", observed)
+		return
+	}
+	if !c.MrState.Valid {
+		// Bootstrap: first observation records without acting. No rework was ever gated in
+		// for a run whose mr_state was NULL, so there is nothing to cancel; recording an
+		// `opened` here is exactly what opens the rework gate for a scheduled MR.
+		s.recordMRState(ctx, c.ID, observed)
+		return
+	}
+	stored := c.MrState.String
+	if observed == stored {
+		return // no transition
+	}
+	switch {
+	case stored == forge.MRStateOpened && observed == forge.MRStateClosed:
+		// close-edge: a confirmed close means an in-flight rework can never land -> abort it
+		// (issue #853). No board move (board-free). On cancel failure leave mr_state
+		// unadvanced so the next tick re-observes the edge and retries.
+		if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
+			slog.Warn("forgesvc: cancel scheduled rework on MR close failed, will retry", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "error", err)
+			return
+		}
+		s.recordMRState(ctx, c.ID, observed)
+	case stored == forge.MRStateClosed && observed == forge.MRStateOpened:
+		// reopen-edge: no card to restore; just record so the rework gate reopens.
+		s.recordMRState(ctx, c.ID, observed)
+	default:
+		// KNOWN non-edge transition (merged / locked). A merge means the branch is gone ->
+		// abort any in-flight rework (issue #853); locked is transient -> no cancel.
+		if observed == forge.MRStateMerged {
+			if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
+				slog.Warn("forgesvc: cancel scheduled rework on MR merge failed, will retry", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "error", err)
+				return
+			}
+		}
+		s.recordMRState(ctx, c.ID, observed)
+	}
+}

--- a/api/internal/forgesvc/scheduled_mr_watch.go
+++ b/api/internal/forgesvc/scheduled_mr_watch.go
@@ -19,6 +19,14 @@ import (
 // cancelReworkOnClosedMR (issue #853 contract, reused verbatim). Reads the run set from
 // ListScheduledMRStateWatchCandidates, which self-evicts a run once its mr_state is terminal.
 //
+// SCOPE BOUNDARY (PRD #908 design, "self-bounding like Lane B"): closed AND merged are
+// terminal for this lane — the candidate query drops a run at mr_state='closed', so a
+// scheduled MR that a reviewer closes then REOPENS is not re-watched and does not regain
+// mr_rework eligibility. That is deliberate: unlike the issue lane's board-coupled Lane A
+// (which keeps watching a closed-issue run for the reopen edge), a board-free recorder that
+// kept polling closed MRs forever would reintroduce the unbounded-growth cost the design
+// rejected. There is therefore no closed->opened arm below (unlike syncOneMRState).
+//
 // Like SyncMRStates it never returns a per-candidate error (log-and-skip); only a failure
 // to enumerate candidates surfaces to the poller.
 func (s *Service) SyncScheduledMRStates(ctx context.Context, repoID uuid.UUID, forgeProjectID int64, f forge.Forge) error {
@@ -72,9 +80,6 @@ func (s *Service) recordScheduledMRState(ctx context.Context, repoID uuid.UUID, 
 			slog.Warn("forgesvc: cancel scheduled rework on MR close failed, will retry", "repo", repoID, "run", c.ID, "mr", c.MrIid.Int64, "error", err)
 			return
 		}
-		s.recordMRState(ctx, c.ID, observed)
-	case stored == forge.MRStateClosed && observed == forge.MRStateOpened:
-		// reopen-edge: no card to restore; just record so the rework gate reopens.
 		s.recordMRState(ctx, c.ID, observed)
 	default:
 		// KNOWN non-edge transition (merged / locked). A merge means the branch is gone ->

--- a/api/internal/forgesvc/scheduled_mr_watch_livedb_test.go
+++ b/api/internal/forgesvc/scheduled_mr_watch_livedb_test.go
@@ -1,0 +1,125 @@
+package forgesvc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// TestSyncScheduledMRStatesRecordsLiveDB exercises the board-free scheduled MR-state
+// recorder (forgesvc.SyncScheduledMRStates, PRD #908 M3) end to end against a REAL Postgres:
+// the store WRITE actually persists runs.mr_state, and the run self-evicts from
+// ListScheduledMRStateWatchCandidates once its MR reaches a terminal state. A fake forge
+// scripts the observed MR state and a fake ReworkCanceller records the merge-edge abort — the
+// wiring around them (SetReworkCanceller → cancelReworkOnClosedMR) is the same the poller runs.
+//
+//   - NULL → 'opened' bootstrap: the first observation records without acting (no cancel), and
+//     the run remains a watch candidate ('opened' is transient).
+//   - 'opened' → 'merged' terminal: the recorder cancels the (would-be) in-flight rework EXACTLY
+//     once and records 'merged'; the run then drops out of the candidate set (self-eviction).
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres; e2e/run-store-it.sh
+// (and task gate:api in CI) provide one. `go test ./...` without it SKIPs.
+func TestSyncScheduledMRStatesRecordsLiveDB(t *testing.T) {
+	ctx := context.Background()
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	q := store.New(pool)
+
+	svc := New(q, nil, time.Second, nil)
+	canceller := &fakeReworkCanceller{}
+	svc.SetReworkCanceller(canceller)
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	userID, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+	exec(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+		userID, fmt.Sprintf("sched-rec-%s@e2e", userID))
+	exec(`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+	      VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, userID, []byte{0x1})
+	exec(`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+	      VALUES ($1, $2, 1, 'g/schedrec', 'https://forge.e2e/g/schedrec', 'main', true)`, repoID, connID)
+
+	const forgeProjectID = 4242 // fakeForge ignores it; the recorder only forwards it.
+	const mrIID int64 = 9200
+	branch := "uzi/prompt-" + uuid.New().String()
+
+	// A completed prompt run (issue_iid NULL) with an mr_iid and mr_state NULL — the
+	// pre-recorder bootstrap state, so it is a scheduled watch candidate.
+	runID := uuid.New()
+	exec(`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, status)
+	      VALUES ($1, $2, $3, 'prompt', NULL, 't', 'd', $4, $5, 'completed')`,
+		runID, userID, repoID, branch, mrIID)
+
+	readState := func() pgtype.Text {
+		t.Helper()
+		var s pgtype.Text
+		if err := pool.QueryRow(ctx, `SELECT mr_state FROM runs WHERE id = $1`, runID).Scan(&s); err != nil {
+			t.Fatalf("read mr_state: %v", err)
+		}
+		return s
+	}
+	candidateIDs := func() []uuid.UUID {
+		t.Helper()
+		cands, err := q.ListScheduledMRStateWatchCandidates(ctx, repoID)
+		if err != nil {
+			t.Fatalf("ListScheduledMRStateWatchCandidates: %v", err)
+		}
+		ids := make([]uuid.UUID, len(cands))
+		for i, c := range cands {
+			ids[i] = c.ID
+		}
+		return ids
+	}
+
+	// Step 1: forge reports the MR is opened. The NULL→opened bootstrap records without acting.
+	if err := svc.SyncScheduledMRStates(ctx, repoID, forgeProjectID, &fakeForge{mr: forgeMR(mrIID, "opened")}); err != nil {
+		t.Fatalf("SyncScheduledMRStates (opened): %v", err)
+	}
+	if s := readState(); !s.Valid || s.String != "opened" {
+		t.Fatalf("after opened sync, runs.mr_state = %+v, want 'opened' persisted", s)
+	}
+	if n := len(canceller.calls); n != 0 {
+		t.Fatalf("bootstrap opened must NOT cancel a rework; canceller calls = %d", n)
+	}
+	if ids := candidateIDs(); len(ids) != 1 || ids[0] != runID {
+		t.Fatalf("run must still be a watch candidate while opened; got %v", ids)
+	}
+
+	// Step 2: forge advances to merged. The opened→merged edge cancels the in-flight rework
+	// exactly once and records the terminal state, after which the run self-evicts.
+	if err := svc.SyncScheduledMRStates(ctx, repoID, forgeProjectID, &fakeForge{mr: forgeMR(mrIID, "merged")}); err != nil {
+		t.Fatalf("SyncScheduledMRStates (merged): %v", err)
+	}
+	if s := readState(); !s.Valid || s.String != "merged" {
+		t.Fatalf("after merged sync, runs.mr_state = %+v, want 'merged' persisted", s)
+	}
+	if len(canceller.calls) != 1 || canceller.calls[0] != mrIID {
+		t.Fatalf("merge edge must cancel the rework exactly once for mr %d; got %v", mrIID, canceller.calls)
+	}
+	if ids := candidateIDs(); len(ids) != 0 {
+		t.Fatalf("a merged (terminal) MR must self-evict from the watch set; got %v", ids)
+	}
+}

--- a/api/internal/forgesvc/scheduled_mr_watch_test.go
+++ b/api/internal/forgesvc/scheduled_mr_watch_test.go
@@ -96,14 +96,19 @@ func TestSyncScheduledMRStatesDifferential(t *testing.T) {
 			wantCancel: 1,
 		},
 		{
-			// The close edge cancels only from 'opened' (default arm cancels only on merged),
-			// so a locked->closed records the terminal state WITHOUT cancelling — exact parity
-			// with the issue-lane syncOneMRState. Pinned intentionally.
+			// locked->closed is a TERMINAL edge, so it MUST cancel an in-flight rework
+			// (issue #853): a confirmed close means the rework can never land. The earlier
+			// version pinned wantCancel:0 (close cancelled only from 'opened'), which leaked
+			// the rework whenever the MR passed through 'locked' before closing — the run
+			// then self-evicted at mr_state='closed' with the rework still spending. Fixed by
+			// cancelling on any transition INTO closed/merged from a valid non-terminal state.
+			// (The issue-lane syncOneMRState still has the analogous latent leak; tracked
+			// separately as a follow-up.)
 			name:       "locked->closed",
 			stored:     strptr(forge.MRStateLocked),
 			observed:   forge.MRStateClosed,
 			wantRecord: strptr(forge.MRStateClosed),
-			wantCancel: 0,
+			wantCancel: 1,
 		},
 		{
 			name:       "unknown-state",
@@ -177,12 +182,17 @@ func TestSyncScheduledMRStatesDifferential(t *testing.T) {
 	}
 }
 
-// TestR1SelfImproveClosedNoBoardMove exercises the OTHER watcher (SyncMRStates, not the
-// board-free recorder) over a self_improve run whose stored mr_state='closed' with a
-// CACHED, open tracking issue. observed==stored='closed' is a no-transition, so no board
-// move is planned — proving the R1 entanglement (a self_improve run satisfying both
-// candidate queries) is benign: the board machinery is a no-op for the un-promoted
-// tracking issue.
+// TestR1SelfImproveClosedNoBoardMove is a defense-in-depth unit check on the OTHER watcher
+// (SyncMRStates, not the board-free recorder). The PRIMARY R1 guard is at the query level:
+// ListMRWatchCandidates now excludes kind IN ('prompt','self_improve') in its CTE, so a
+// self_improve run is never fed to syncOneMRState in production at all — proven live by
+// TestListMRWatchCandidatesLiveDB case 112 (a completed self_improve run whose OPEN tracking
+// issue is parked in Human Review with an open MR is NOT a candidate). That query exclusion,
+// not a no-transition, is what makes R1 benign — an earlier version of this test asserted the
+// opposite (that a cached, Human-Review-promoted tracking issue was safe merely because
+// observed==stored), which was vacuous for the dangerous opened->closed edge that WOULD have
+// moved the shared card. This test remains only to pin that even if a self_improve candidate
+// were somehow handed to syncOneMRState directly, a closed->closed no-transition plans no move.
 func TestR1SelfImproveClosedNoBoardMove(t *testing.T) {
 	runID, repoID := uuid.New(), uuid.New()
 	st := &fakeStore{

--- a/api/internal/forgesvc/scheduled_mr_watch_test.go
+++ b/api/internal/forgesvc/scheduled_mr_watch_test.go
@@ -25,6 +25,11 @@ import (
 //     once (issue #853) then records 'merged'.
 //   - opened->closed            → the close edge cancels exactly once then records 'closed'.
 //   - opened->locked            → locked is transient: record, NO cancel.
+//   - locked->opened            → the transient state settles back to opened: record, NO cancel.
+//   - locked->merged            → merge from the transient state still cancels exactly once.
+//   - locked->closed            → records 'closed' but does NOT cancel — the close edge only
+//     cancels from 'opened' (default arm cancels only on merged), exact parity with the
+//     issue-lane syncOneMRState. Pinned so the parity gap is intentional, not an accident.
 //   - unknown-state             → an unrecognized forge state writes nothing and cancels
 //     nothing (the baseline is preserved so a later real state still fires).
 //   - no-transition             → observed==stored: no write, no cancel.
@@ -74,6 +79,30 @@ func TestSyncScheduledMRStatesDifferential(t *testing.T) {
 			stored:     strptr(forge.MRStateOpened),
 			observed:   forge.MRStateLocked,
 			wantRecord: strptr(forge.MRStateLocked),
+			wantCancel: 0,
+		},
+		{
+			name:       "locked->opened",
+			stored:     strptr(forge.MRStateLocked),
+			observed:   forge.MRStateOpened,
+			wantRecord: strptr(forge.MRStateOpened),
+			wantCancel: 0,
+		},
+		{
+			name:       "locked->merged",
+			stored:     strptr(forge.MRStateLocked),
+			observed:   forge.MRStateMerged,
+			wantRecord: strptr(forge.MRStateMerged),
+			wantCancel: 1,
+		},
+		{
+			// The close edge cancels only from 'opened' (default arm cancels only on merged),
+			// so a locked->closed records the terminal state WITHOUT cancelling — exact parity
+			// with the issue-lane syncOneMRState. Pinned intentionally.
+			name:       "locked->closed",
+			stored:     strptr(forge.MRStateLocked),
+			observed:   forge.MRStateClosed,
+			wantRecord: strptr(forge.MRStateClosed),
 			wantCancel: 0,
 		},
 		{

--- a/api/internal/forgesvc/scheduled_mr_watch_test.go
+++ b/api/internal/forgesvc/scheduled_mr_watch_test.go
@@ -1,0 +1,171 @@
+package forgesvc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/vtmocanu/uzi/api/internal/board"
+	"github.com/vtmocanu/uzi/api/internal/forge"
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// The board-FREE scheduled MR-state recorder (SyncScheduledMRStates, PRD #908) is a
+// second implementation of syncOneMRState's observe->persist->cancel contract WITHOUT
+// the board move. These tests pin the differential/mirror contract: every fixture in
+// TestSyncScheduledMRStatesDifferential asserts recorded state, cancel-call count, AND
+// zero board moves (assertNoMove), so the recorder can never regress into moving a card.
+//
+// Which fixture proves which behavior (each is exercised — no vacuous case):
+//   - opened-first-observation  → NULL bootstrap records the first observation, cancels
+//     nothing (no rework was ever gated in for a NULL mr_state).
+//   - opened->merged            → the merged non-edge cancels an in-flight rework exactly
+//     once (issue #853) then records 'merged'.
+//   - opened->closed            → the close edge cancels exactly once then records 'closed'.
+//   - opened->locked            → locked is transient: record, NO cancel.
+//   - unknown-state             → an unrecognized forge state writes nothing and cancels
+//     nothing (the baseline is preserved so a later real state still fires).
+//   - no-transition             → observed==stored: no write, no cancel.
+//   - cancel-failure            → a cancel FAILURE leaves mr_state unadvanced (no record),
+//     with the cancel counted once, so the next tick re-observes the edge and retries.
+//
+// TestR1SelfImproveClosedNoBoardMove is a separate guard on the OTHER watcher
+// (SyncMRStates): a self_improve run whose stored mr_state='closed' with a cached open
+// tracking issue produces zero board moves, proving the R1 entanglement is benign.
+
+func strptr(s string) *string { return &s }
+
+func TestSyncScheduledMRStatesDifferential(t *testing.T) {
+	const mrIID = int64(13)
+
+	cases := []struct {
+		name       string
+		stored     *string // nil → NULL mr_state (bootstrap)
+		observed   string  // what the forge reports live
+		cancelErr  bool    // force the rework cancel to fail
+		wantRecord *string // nil → assertNoRecord; else the recorded value
+		wantCancel int     // expected CancelReworkForMR call count
+	}{
+		{
+			name:       "opened-first-observation",
+			stored:     nil,
+			observed:   forge.MRStateOpened,
+			wantRecord: strptr(forge.MRStateOpened),
+			wantCancel: 0,
+		},
+		{
+			name:       "opened->merged",
+			stored:     strptr(forge.MRStateOpened),
+			observed:   forge.MRStateMerged,
+			wantRecord: strptr(forge.MRStateMerged),
+			wantCancel: 1,
+		},
+		{
+			name:       "opened->closed",
+			stored:     strptr(forge.MRStateOpened),
+			observed:   forge.MRStateClosed,
+			wantRecord: strptr(forge.MRStateClosed),
+			wantCancel: 1,
+		},
+		{
+			name:       "opened->locked",
+			stored:     strptr(forge.MRStateOpened),
+			observed:   forge.MRStateLocked,
+			wantRecord: strptr(forge.MRStateLocked),
+			wantCancel: 0,
+		},
+		{
+			name:       "unknown-state",
+			stored:     strptr(forge.MRStateOpened),
+			observed:   "weird",
+			wantRecord: nil,
+			wantCancel: 0,
+		},
+		{
+			name:       "no-transition",
+			stored:     strptr(forge.MRStateOpened),
+			observed:   forge.MRStateOpened,
+			wantRecord: nil,
+			wantCancel: 0,
+		},
+		{
+			name:       "cancel-failure leaves unadvanced",
+			stored:     strptr(forge.MRStateOpened),
+			observed:   forge.MRStateMerged,
+			cancelErr:  true,
+			wantRecord: nil, // the retry contract: mr_state stays unadvanced
+			wantCancel: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runID, repoID := uuid.New(), uuid.New()
+			st := &fakeStore{
+				scheduledCandidates: []store.ListScheduledMRStateWatchCandidatesRow{
+					scheduledCand(runID, mrIID, tc.stored),
+				},
+			}
+			f := &fakeForge{mr: forgeMR(mrIID, tc.observed)}
+			canceller := &fakeReworkCanceller{}
+			if tc.cancelErr {
+				canceller.err = errors.New("cancel failed")
+			}
+			svc := newTestService(st)
+			svc.SetReworkCanceller(canceller)
+
+			if err := svc.SyncScheduledMRStates(context.Background(), repoID, testProjectID, f); err != nil {
+				t.Fatalf("SyncScheduledMRStates: %v", err)
+			}
+
+			// The recorder NEVER moves a board card.
+			assertNoMove(t, f)
+
+			// Recorded state.
+			if tc.wantRecord == nil {
+				assertNoRecord(t, st)
+			} else {
+				assertRecorded(t, st, runID, *tc.wantRecord)
+			}
+
+			// Cancel-call count (and identity, when it fired).
+			if len(canceller.calls) != tc.wantCancel {
+				t.Fatalf("CancelReworkForMR calls = %d, want %d: %v", len(canceller.calls), tc.wantCancel, canceller.calls)
+			}
+			for _, got := range canceller.calls {
+				if got != mrIID {
+					t.Fatalf("cancelled mrIID = %d, want %d", got, mrIID)
+				}
+			}
+
+			// Exactly one MR read per candidate.
+			if len(f.mrCalls) != 1 || f.mrCalls[0] != mrIID {
+				t.Fatalf("expected one GetMergeRequest(%d), got %v", mrIID, f.mrCalls)
+			}
+		})
+	}
+}
+
+// TestR1SelfImproveClosedNoBoardMove exercises the OTHER watcher (SyncMRStates, not the
+// board-free recorder) over a self_improve run whose stored mr_state='closed' with a
+// CACHED, open tracking issue. observed==stored='closed' is a no-transition, so no board
+// move is planned — proving the R1 entanglement (a self_improve run satisfying both
+// candidate queries) is benign: the board machinery is a no-op for the un-promoted
+// tracking issue.
+func TestR1SelfImproveClosedNoBoardMove(t *testing.T) {
+	runID, repoID := uuid.New(), uuid.New()
+	st := &fakeStore{
+		candidates: []store.ListMRWatchCandidatesRow{candidate(runID, 9, 13, mrTxt("closed"))},
+		// The shared self_improve tracking issue, cached and OPEN.
+		issue:   mrIssue(repoID, 9, "opened", board.ColumnHumanReview),
+		columns: mrCols(),
+	}
+	f := &fakeForge{mr: forgeMR(13, "closed")}
+
+	run(t, st, f)
+
+	assertNoMove(t, f)    // observed=="closed"==stored → no transition, no card move
+	assertNoRecord(t, st) // and nothing to record either
+}

--- a/api/internal/forgesvc/service.go
+++ b/api/internal/forgesvc/service.go
@@ -116,6 +116,8 @@ type IssueStore interface {
 	DeleteIssuesNotIn(ctx context.Context, arg store.DeleteIssuesNotInParams) (int64, error)
 	// Used by the MR-close watcher (mr_watch.go).
 	ListMRWatchCandidates(ctx context.Context, repoID uuid.UUID) ([]store.ListMRWatchCandidatesRow, error)
+	// Used by the board-free scheduled MR-state recorder (scheduled_mr_watch.go, PRD #908).
+	ListScheduledMRStateWatchCandidates(ctx context.Context, repoID uuid.UUID) ([]store.ListScheduledMRStateWatchCandidatesRow, error)
 	GetIssueByIID(ctx context.Context, arg store.GetIssueByIIDParams) (store.Issue, error)
 	ListBoardColumns(ctx context.Context, repoID uuid.UUID) ([]store.BoardColumn, error)
 	SetRunMRState(ctx context.Context, arg store.SetRunMRStateParams) (int64, error)

--- a/api/internal/forgesvc/sync_test.go
+++ b/api/internal/forgesvc/sync_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/vtmocanu/uzi/api/internal/forge"
 	"github.com/vtmocanu/uzi/api/internal/forge/forgetest"
@@ -410,6 +411,34 @@ func (s *fakeStore) SettlePRDLinkPatch(_ context.Context, id uuid.UUID) (int64, 
 	}
 	s.prdCandidates = kept
 	return n, nil
+}
+
+// fakeReworkCanceller is a ReworkCanceller (forgesvc/service.go) stand-in for the
+// scheduled MR-state recorder tests (PRD #908): it records the mrIIDs it was asked to
+// cancel, in order, and can be forced to fail (err) to exercise the leave-unadvanced
+// retry contract on the opened->closed / ->merged cancel path.
+type fakeReworkCanceller struct {
+	calls []int64 // mrIIDs cancelled, in order
+	err   error   // when non-nil, forces every CancelReworkForMR to fail
+}
+
+func (c *fakeReworkCanceller) CancelReworkForMR(_ context.Context, _ uuid.UUID, mrIID int64, _ string) error {
+	c.calls = append(c.calls, mrIID)
+	return c.err
+}
+
+// scheduledCand builds a ListScheduledMRStateWatchCandidates row for the board-free
+// recorder tests (PRD #908). stored==nil models a NULL mr_state (Valid=false, the
+// bootstrap case); a non-nil pointer models a stored value.
+func scheduledCand(runID uuid.UUID, mrIID int64, stored *string) store.ListScheduledMRStateWatchCandidatesRow {
+	row := store.ListScheduledMRStateWatchCandidatesRow{
+		ID:    runID,
+		MrIid: pgtype.Int8{Int64: mrIID, Valid: true},
+	}
+	if stored != nil {
+		row.MrState = pgtype.Text{String: *stored, Valid: true}
+	}
+	return row
 }
 
 // fakeLabels is a fixed LabelConfig for the sync tests.

--- a/api/internal/forgesvc/sync_test.go
+++ b/api/internal/forgesvc/sync_test.go
@@ -242,11 +242,14 @@ type fakeStore struct {
 	// MR-close watcher (PRD #24) scripting + capture.
 	candidates    []store.ListMRWatchCandidatesRow
 	candidatesErr error
-	issue         store.Issue
-	issueErr      error
-	columns       []store.BoardColumn
-	columnsErr    error
-	mrStateWrites []store.SetRunMRStateParams
+
+	scheduledCandidates    []store.ListScheduledMRStateWatchCandidatesRow
+	scheduledCandidatesErr error
+	issue                  store.Issue
+	issueErr               error
+	columns                []store.BoardColumn
+	columnsErr             error
+	mrStateWrites          []store.SetRunMRStateParams
 
 	// Pipeline sync (PRD #6) scripting + capture.
 	watchedRefs      []store.ListWatchedRunRefsForRepoRow
@@ -321,6 +324,9 @@ func (s *fakeStore) DeleteIssuesNotIn(_ context.Context, arg store.DeleteIssuesN
 }
 func (s *fakeStore) ListMRWatchCandidates(context.Context, uuid.UUID) ([]store.ListMRWatchCandidatesRow, error) {
 	return s.candidates, s.candidatesErr
+}
+func (s *fakeStore) ListScheduledMRStateWatchCandidates(context.Context, uuid.UUID) ([]store.ListScheduledMRStateWatchCandidatesRow, error) {
+	return s.scheduledCandidates, s.scheduledCandidatesErr
 }
 func (s *fakeStore) GetIssueByIID(context.Context, store.GetIssueByIIDParams) (store.Issue, error) {
 	return s.issue, s.issueErr

--- a/api/internal/poller/ci_autofix.go
+++ b/api/internal/poller/ci_autofix.go
@@ -114,14 +114,14 @@ func (d *CIAutoFix) detect(ctx context.Context, r store.ListEnabledReposWithConn
 func (d *CIAutoFix) detectOne(ctx context.Context, r store.ListEnabledReposWithConnectionsRow, f forge.Forge, cand store.ListCIAutofixCandidateRefsRow) {
 	ref := cand.Ref.String
 
-	// The candidate query already guarantees an agent MR branch, but never post on a
-	// ref that does not parse to an issue iid (defensive — the issue comment target is
-	// derived from it). An unparseable ref is skipped entirely.
+	// Scheduled-run branches (`uzi/prompt-…`, `uzi/self-improve/…`) do not parse to an
+	// issue iid, and are now PROCESSED normally (PRD #908): the ci_fix still fires — only
+	// the issue comments (start + halt) are suppressed, since there is no issue to comment
+	// on. The inbox notifications (notifyStarted / notifyHalt) still fire for both branch
+	// shapes. When !ok, iid is 0, which is fine for the notification payload. For an
+	// `agent/issue-N` branch the parse still succeeds and the comments still post
+	// (issue-run behavior unchanged).
 	iid, ok := issueIIDFromBranch(ref)
-	if !ok {
-		slog.Warn("poller: ci-autofix unparseable ref", "repo", r.PathWithNamespace, "ref", ref)
-		return
-	}
 
 	// 1. Attempt state. CARRY-FORWARD FROM M4: GetCIAutofixAttempt returns a row with
 	// attempt_count=0 for a ref that was only ever RecordCIAutofixPipeline'd (the
@@ -221,9 +221,11 @@ func (d *CIAutoFix) detectOne(ctx context.Context, r store.ListEnabledReposWithC
 				return
 			}
 			// The issue comment is the primary outward halt signal (best-effort).
-			if _, err := f.CreateIssueNote(ctx, r.ForgeProjectID, iid, haltCommentBody(reason, d.maxAttempts, cand.MrIid)); err != nil {
-				// Already PAT-redacted by the driver; the latch is set, so the comment is lost, not retried.
-				slog.Warn("poller: ci-autofix halt comment", "repo", r.PathWithNamespace, "ref", ref, "error", err)
+			if ok {
+				if _, err := f.CreateIssueNote(ctx, r.ForgeProjectID, iid, haltCommentBody(reason, d.maxAttempts, cand.MrIid)); err != nil {
+					// Already PAT-redacted by the driver; the latch is set, so the comment is lost, not retried.
+					slog.Warn("poller: ci-autofix halt comment", "repo", r.PathWithNamespace, "ref", ref, "error", err)
+				}
 			}
 			d.notifyHalt(ctx, cand, iid, haltReasonPayload(reason, d.maxAttempts))
 		} else {
@@ -265,8 +267,10 @@ func (d *CIAutoFix) detectOne(ctx context.Context, r store.ListEnabledReposWithC
 			slog.Error("poller: ci-autofix upsert attempt", "repo", r.PathWithNamespace, "ref", ref, "error", err)
 			return
 		}
-		if _, err := f.CreateIssueNote(ctx, r.ForgeProjectID, iid, startCommentBody(ref, cand.PipelineWebUrl)); err != nil {
-			slog.Warn("poller: ci-autofix start comment", "repo", r.PathWithNamespace, "ref", ref, "error", err)
+		if ok {
+			if _, err := f.CreateIssueNote(ctx, r.ForgeProjectID, iid, startCommentBody(ref, cand.PipelineWebUrl)); err != nil {
+				slog.Warn("poller: ci-autofix start comment", "repo", r.PathWithNamespace, "ref", ref, "error", err)
+			}
 		}
 		d.notifyStarted(ctx, cand, iid, run.ID)
 	case errors.Is(err, workersvc.ErrActiveFixExists), errors.Is(err, workersvc.ErrBranchInUse):

--- a/api/internal/poller/ci_autofix_test.go
+++ b/api/internal/poller/ci_autofix_test.go
@@ -492,22 +492,75 @@ func TestCIAutofixBranchInUseSwallows(t *testing.T) {
 	}
 }
 
-func TestCIAutofixUnparseableRefSkipped(t *testing.T) {
-	// The candidate query only yields agent/issue-N branches, but the detector guards
-	// against a ref it cannot attribute to an issue: skip it entirely, with no forge or
-	// store writes (not even a GetCIAutofixAttempt-driven record).
+func TestCIAutofixIssuelessBranchFiresNoComment(t *testing.T) {
+	// PRD #908 M2: a scheduled-run branch (`uzi/prompt-…`, `uzi/self-improve/…`) does not
+	// parse to an issue iid, and the detector now PROCESSES it — the ci_fix run still fires;
+	// only the issue comment (CreateIssueNote) is suppressed, since there is no issue to
+	// comment on. The started notification still fires. (The old test asserted the OPPOSITE
+	// — that an unparseable ref was skipped entirely — which M2 made semantically wrong.)
 	cand := cfCand(9001)
-	cand.Ref = pgtype.Text{String: "feature/not-an-issue", Valid: true}
+	cand.Ref = pgtype.Text{String: "uzi/prompt-" + uuid.NewString(), Valid: true}
 	st := &cfStore{candidates: []store.ListCIAutofixCandidateRefsRow{cand}}
+	runs := &cfRuns{}
+	notifier := &cfNotifier{}
+	f := &cfForge{jobs: []forge.Job{cfJob()}, logTail: "panic: boom\nexit 1"}
+
+	newCF(st, runs, notifier).detect(context.Background(), cfRepoRow(), f)
+
+	// The ci_fix run IS created for the issueless branch.
+	if len(runs.calls) != 1 {
+		t.Fatalf("issueless branch must still fire the ci_fix run, got %d creates", len(runs.calls))
+	}
+	if runs.calls[0].ref != cand.Ref.String {
+		t.Fatalf("run created for ref %q, want %q", runs.calls[0].ref, cand.Ref.String)
+	}
+	if len(st.upserts) != 1 {
+		t.Fatalf("expected the attempt ledger to advance once, got %d upserts", len(st.upserts))
+	}
+	// NO issue comment: there is no issue to comment on.
+	if len(f.notes) != 0 {
+		t.Fatalf("an issueless branch must post NO issue comment, got %+v", f.notes)
+	}
+	// The started notification still fires (issue iid 0 in the payload).
+	if len(notifier.calls) != 1 || notifier.calls[0].kind != "ci_autofix_started" || notifier.calls[0].runID == nil {
+		t.Fatalf("expected one started notification anchored to the run, got %+v", notifier.calls)
+	}
+	if notifier.calls[0].payload.IssueIID != 0 {
+		t.Fatalf("issueless branch notification IssueIID = %d, want 0", notifier.calls[0].payload.IssueIID)
+	}
+}
+
+func TestCIAutofixIssuelessBranchCapHaltsNoComment(t *testing.T) {
+	// PRD #908 M2 halt side: an issueless branch that reaches the cap halts WITHOUT an
+	// issue comment (nothing to comment on), but the halt notification still fires with no
+	// run anchor. count == maxAttempts (2) → capped; the fresh pipeline (9010) is not deduped.
+	cand := cfCand(9010)
+	cand.Ref = pgtype.Text{String: "uzi/self-improve/" + uuid.NewString(), Valid: true}
+	st := &cfStore{
+		candidates: []store.ListCIAutofixCandidateRefsRow{cand},
+		attempts: map[string]store.CiAutofixAttempt{
+			cand.Ref.String: {Ref: cand.Ref.String, AttemptCount: 2, LastPipelineID: pgtype.Int8{Int64: 9001, Valid: true}},
+		},
+	}
 	runs := &cfRuns{}
 	notifier := &cfNotifier{}
 	f := &cfForge{jobs: []forge.Job{cfJob()}, logTail: "boom"}
 
 	newCF(st, runs, notifier).detect(context.Background(), cfRepoRow(), f)
 
-	if len(runs.calls) != 0 || len(st.upserts) != 0 || len(st.records) != 0 || len(st.haltSets) != 0 || len(f.notes) != 0 || len(notifier.calls) != 0 {
-		t.Fatalf("unparseable ref must be skipped with no writes: runs=%d upserts=%d records=%d halts=%d notes=%d notifs=%d",
-			len(runs.calls), len(st.upserts), len(st.records), len(st.haltSets), len(f.notes), len(notifier.calls))
+	if len(runs.calls) != 0 {
+		t.Fatalf("capped halt must not start a run, got %d", len(runs.calls))
+	}
+	if len(st.haltSets) != 1 || st.haltSets[0].LastPipelineID.Int64 != 9010 {
+		t.Fatalf("expected SetCIAutofixHaltNotified stamping 9010, got %+v", st.haltSets)
+	}
+	// NO issue comment for an issueless branch.
+	if len(f.notes) != 0 {
+		t.Fatalf("an issueless cap-halt must post NO issue comment, got %+v", f.notes)
+	}
+	// The halt notification still fires, with no run anchor.
+	if len(notifier.calls) != 1 || notifier.calls[0].kind != "ci_autofix_halted" || notifier.calls[0].runID != nil {
+		t.Fatalf("expected one halted notification with no run anchor, got %+v", notifier.calls)
 	}
 }
 

--- a/api/internal/poller/mr_review_watch.go
+++ b/api/internal/poller/mr_review_watch.go
@@ -156,14 +156,14 @@ func (d *MRReviewWatch) detectOne(ctx context.Context, r store.ListEnabledReposW
 	ref := cand.Ref.String
 	mrIID := cand.MrIid.Int64
 
-	// The candidate query only yields agent/issue-N branches, but the halt comment
-	// targets the ISSUE (there is no MR-note write in the interface), so a ref that
-	// does not parse to an issue iid is skipped entirely (defensive).
+	// Scheduled-run branches (`uzi/prompt-…`, `uzi/self-improve/…`) do not parse to an
+	// issue iid, and that is now EXPECTED (PRD #908): the rework still fires for them —
+	// only the halt ISSUE COMMENT is suppressed, since there is no issue to comment on
+	// and the Forge interface has no MR-note write. The inbox notification carries the
+	// halt instead (notifyHalt fires for both branch shapes). When !ok, issueIID is 0,
+	// which is fine for the notification payload. For an `agent/issue-N` branch the parse
+	// still succeeds and the halt comment still posts (issue-run behavior unchanged).
 	issueIID, ok := issueIIDFromBranch(ref)
-	if !ok {
-		slog.Warn("poller: mr-rework unparseable ref", "repo", r.PathWithNamespace, "ref", ref)
-		return
-	}
 
 	// GATE 1 — GREEN HEAD PIPELINE. The head pipeline for the branch (from the cache
 	// SyncPipelines wrote this tick) must be green. A red, absent, or in-flight
@@ -247,9 +247,11 @@ func (d *MRReviewWatch) detectOne(ctx context.Context, r store.ListEnabledReposW
 				slog.Error("poller: mr-rework set halt-notified", "repo", r.PathWithNamespace, "ref", ref, "error", err)
 				return
 			}
-			if _, err := f.CreateIssueNote(ctx, r.ForgeProjectID, issueIID, mrReworkHaltCommentBody(capLimit, mrIID)); err != nil {
-				// Already PAT-redacted; the latch is set, so the comment is lost, not retried.
-				slog.Warn("poller: mr-rework halt comment", "repo", r.PathWithNamespace, "ref", ref, "error", err)
+			if ok {
+				if _, err := f.CreateIssueNote(ctx, r.ForgeProjectID, issueIID, mrReworkHaltCommentBody(capLimit, mrIID)); err != nil {
+					// Already PAT-redacted; the latch is set, so the comment is lost, not retried.
+					slog.Warn("poller: mr-rework halt comment", "repo", r.PathWithNamespace, "ref", ref, "error", err)
+				}
 			}
 			d.notifyHalt(ctx, cand, issueIID, capLimit)
 		}

--- a/api/internal/poller/mr_review_watch_test.go
+++ b/api/internal/poller/mr_review_watch_test.go
@@ -507,6 +507,69 @@ func TestMRReworkStopEvictsStaleLedger(t *testing.T) {
 	}
 }
 
+func TestMRReworkIssuelessBranchDecoupled(t *testing.T) {
+	// PRD #908 M2: an mr_rework candidate on a scheduled (self_improve) branch does not
+	// parse to an issue iid. The rework still fires below the cap, and at the cap the halt
+	// still notifies once — only the halt ISSUE COMMENT is suppressed (nothing to comment
+	// on). The existing agent/issue-N cap-halt test (TestMRReworkAtCapHaltsOnceThenSilent)
+	// remains the control that the comment DOES post for an issue branch.
+	issuelessRef := "uzi/self-improve/" + uuid.NewString()
+	issuelessCand := func() store.ListMRReworkCandidatesRow {
+		c := mrwCand("success")
+		c.Ref = pgtype.Text{String: issuelessRef, Valid: true}
+		return c
+	}
+
+	t.Run("below cap fires without a comment", func(t *testing.T) {
+		st := &mrwStore{candidates: []store.ListMRReworkCandidatesRow{issuelessCand()}}
+		runs := &mrwRuns{}
+		notifier := &mrwNotifier{}
+		// One kept comment, id 120 > high_water 0 → fire.
+		f := landedForge(mrwComment(120, landed(), mrwHeadSHA))
+
+		newMRW(st, runs, notifier, mrwSettings{enabled: true, capVal: 5}).detect(context.Background(), mrwRepoRow(), f)
+
+		if len(runs.calls) != 1 {
+			t.Fatalf("an issueless branch below cap must still fire the rework, got %d runs", len(runs.calls))
+		}
+		if runs.calls[0].ref != issuelessRef {
+			t.Fatalf("rework created for ref %q, want %q", runs.calls[0].ref, issuelessRef)
+		}
+		if len(st.upserts) != 1 || st.upserts[0].HighWater != 120 {
+			t.Fatalf("expected one ledger upsert advancing high_water to 120, got %+v", st.upserts)
+		}
+		if len(f.notes) != 0 {
+			t.Fatalf("an issueless branch must post NO issue comment, got %+v", f.notes)
+		}
+	})
+
+	t.Run("at cap halts once, no comment, still notifies", func(t *testing.T) {
+		st := &mrwStore{
+			candidates: []store.ListMRReworkCandidatesRow{issuelessCand()},
+			ledgers:    map[string]store.MrReworkLedger{issuelessRef: {Ref: issuelessRef, AttemptCount: 5, HighWater: 120}},
+		}
+		runs := &mrwRuns{}
+		notifier := &mrwNotifier{}
+		// A new comment (id 200 > high_water 120) reaches the cap gate.
+		f := landedForge(mrwComment(200, landed(), mrwHeadSHA))
+
+		newMRW(st, runs, notifier, mrwSettings{enabled: true, capVal: 5}).detect(context.Background(), mrwRepoRow(), f)
+
+		if len(runs.calls) != 0 {
+			t.Fatalf("a capped issueless MR must not start a run, got %d", len(runs.calls))
+		}
+		if len(st.haltSets) != 1 {
+			t.Fatalf("expected one SetMRReworkHaltNotified latch, got %d", len(st.haltSets))
+		}
+		if len(f.notes) != 0 {
+			t.Fatalf("an issueless cap-halt must post NO issue comment, got %+v", f.notes)
+		}
+		if len(notifier.calls) != 1 || notifier.calls[0].kind != "mr_rework_halted" || notifier.calls[0].runID != nil {
+			t.Fatalf("expected one halted notification with no run anchor, got %+v", notifier.calls)
+		}
+	})
+}
+
 func TestMRReworkBotOnlyCommentsNoFire(t *testing.T) {
 	// The only comment is uzi's OWN bot note (author == bot id): the snapshot filter
 	// drops it, leaving nothing → no fire.

--- a/api/internal/poller/poller.go
+++ b/api/internal/poller/poller.go
@@ -368,6 +368,16 @@ func (e *Engine) syncRepo(ctx context.Context, r store.ListEnabledReposWithConne
 		slog.Error("poller: sync MR states", "repo", r.PathWithNamespace, "error", err)
 	}
 
+	// Scheduled-lane MR-state recorder (PRD #908): board-free sibling of SyncMRStates for
+	// prompt/self_improve runs, so their runs.mr_state is fresh for the mr_rework detector
+	// reading candidates later this same tick. Reads live forge state (needs the forge
+	// reachable, guaranteed by the early returns above); records mr_state and cancels an
+	// in-flight rework on close/merge, but moves NO board card. Per-candidate errors are
+	// log-and-skipped inside; only a candidate-enumeration failure surfaces here.
+	if err := e.svc.SyncScheduledMRStates(ctx, r.ID, r.ForgeProjectID, f); err != nil {
+		slog.Error("poller: sync scheduled MR states", "repo", r.PathWithNamespace, "error", err)
+	}
+
 	// PRD-link patch (PRD #72 M5): once a run's MR has merged, rewrite the issue's
 	// own `prds/*.md` link to the path the run moved the file to. Placed HERE — after
 	// SyncMRStates, before the filed→close sync — because it needs a live forge

--- a/api/internal/schedsvc/scheduler.go
+++ b/api/internal/schedsvc/scheduler.go
@@ -122,9 +122,10 @@ type RunCreator interface {
 	CreatePromptRun(ctx context.Context, userID, repoID, scheduleID uuid.UUID, title, prompt string, autoApprove, waitOnLimit bool, mrReworkEnabled *bool, model *string, overrideSubagentModel bool) (store.Run, error)
 	// CreateSelfImproveRun is the self-improvement fire path's insert (PRD #590 M1): a
 	// dedicated issue-shaped, auto_approve, kind='self_improve' run against the tracking
-	// issue, threading the schedule's per-schedule model override. The per-repo unique index
-	// backs ErrActiveSelfImproveExists on a lost race.
-	CreateSelfImproveRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, title, description string, model *string, overrideSubagentModel bool) (store.Run, error)
+	// issue, threading the schedule's per-schedule model override and (PRD #908 M1) the
+	// per-schedule mr_rework override. The per-repo unique index backs
+	// ErrActiveSelfImproveExists on a lost race.
+	CreateSelfImproveRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, title, description string, mrReworkEnabled *bool, model *string, overrideSubagentModel bool) (store.Run, error)
 }
 
 // ForgeBuilder builds a forge driver from a stored (encrypted) connection — the same

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -336,15 +336,16 @@ type selfImproveCall struct {
 	userID, repoID        uuid.UUID
 	issueIID              int64
 	title, description    string
+	mrReworkEnabled       *bool
 	model                 *string
 	overrideSubagentModel bool
 }
 
-func (f *fakeRuns) CreateSelfImproveRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, title, description string, model *string, overrideSubagentModel bool) (store.Run, error) {
+func (f *fakeRuns) CreateSelfImproveRun(_ context.Context, userID, repoID uuid.UUID, issueIID int64, title, description string, mrReworkEnabled *bool, model *string, overrideSubagentModel bool) (store.Run, error) {
 	if f.err != nil {
 		return store.Run{}, f.err
 	}
-	f.selfImprove = append(f.selfImprove, selfImproveCall{userID, repoID, issueIID, title, description, model, overrideSubagentModel})
+	f.selfImprove = append(f.selfImprove, selfImproveCall{userID, repoID, issueIID, title, description, mrReworkEnabled, model, overrideSubagentModel})
 	if f.selfImproveRun.ID == (uuid.UUID{}) {
 		f.selfImproveRun = store.Run{ID: uuid.New()}
 	}

--- a/api/internal/schedsvc/scheduler_test.go
+++ b/api/internal/schedsvc/scheduler_test.go
@@ -650,6 +650,49 @@ func TestTickThreadsScheduleMrReworkEnabled(t *testing.T) {
 			t.Fatalf("a schedule with a NULL mr_rework column must thread nil (inherit), got %v", *got)
 		}
 	})
+	// The self_improve seam (CreateSelfImproveRun) is the fourth scheduled path that
+	// threads scheduleMrRework (self_improve.go). PRD #908 M1 wired it; these pin the
+	// same three-state contract as the issue/prompt seams above.
+	t.Run("self_improve explicit false", func(t *testing.T) {
+		h := newHarness()
+		s := h.selfImproveSchedule()
+		s.MrReworkEnabled = pgtype.Bool{Bool: false, Valid: true}
+		h.st.due = []store.RunSchedule{s}
+		h.sched.Boot(context.Background())
+		if len(h.runs.selfImprove) != 1 {
+			t.Fatalf("CreateSelfImproveRun calls = %d, want 1", len(h.runs.selfImprove))
+		}
+		got := h.runs.selfImprove[0].mrReworkEnabled
+		if got == nil || *got {
+			t.Fatalf("self_improve run threaded mr_rework = %v, want an explicit false", got)
+		}
+	})
+	t.Run("self_improve explicit true", func(t *testing.T) {
+		h := newHarness()
+		s := h.selfImproveSchedule()
+		s.MrReworkEnabled = pgtype.Bool{Bool: true, Valid: true}
+		h.st.due = []store.RunSchedule{s}
+		h.sched.Boot(context.Background())
+		if len(h.runs.selfImprove) != 1 {
+			t.Fatalf("CreateSelfImproveRun calls = %d, want 1", len(h.runs.selfImprove))
+		}
+		got := h.runs.selfImprove[0].mrReworkEnabled
+		if got == nil || !*got {
+			t.Fatalf("self_improve run threaded mr_rework = %v, want an explicit true", got)
+		}
+	})
+	t.Run("self_improve nil override inherits", func(t *testing.T) {
+		h := newHarness()
+		s := h.selfImproveSchedule() // MrReworkEnabled zero-value = NULL
+		h.st.due = []store.RunSchedule{s}
+		h.sched.Boot(context.Background())
+		if len(h.runs.selfImprove) != 1 {
+			t.Fatalf("CreateSelfImproveRun calls = %d, want 1", len(h.runs.selfImprove))
+		}
+		if got := h.runs.selfImprove[0].mrReworkEnabled; got != nil {
+			t.Fatalf("a self_improve schedule with a NULL mr_rework column must thread nil (inherit), got %v", *got)
+		}
+	})
 }
 
 // TestTickNonAutoIssueScheduleUsesTheScheduledSeam pins the M4-review fix: a

--- a/api/internal/schedsvc/self_improve.go
+++ b/api/internal/schedsvc/self_improve.go
@@ -186,7 +186,7 @@ func (e *Scheduler) fireSelfImprove(ctx context.Context, sched store.RunSchedule
 	// A lost unique-index race (ErrActiveSelfImproveExists) is benign — the index did its job,
 	// a cycle is already in flight — so advance. Any other error (incl. ErrRepoNotFound /
 	// ErrGuardrailBlocked from the seam) rides up unchanged so advance() classifies it.
-	run, err := e.runs.CreateSelfImproveRun(ctx, sched.UserID, sched.RepoID, issueIID, selfImproveTrackingTitle, description, scheduleModel(sched), scheduleOverrideSubagentModel(sched))
+	run, err := e.runs.CreateSelfImproveRun(ctx, sched.UserID, sched.RepoID, issueIID, selfImproveTrackingTitle, description, scheduleMrRework(sched), scheduleModel(sched), scheduleOverrideSubagentModel(sched))
 	if err != nil {
 		if errors.Is(err, workersvc.ErrActiveSelfImproveExists) {
 			e.logger.Info("scheduler: self_improve run already active (race)", "schedule", sched.ID.String())

--- a/api/internal/store/ci_autofix.sql.go
+++ b/api/internal/store/ci_autofix.sql.go
@@ -116,7 +116,7 @@ WITH per_branch AS (
     WHERE r.repo_id = $1::uuid
       AND r.branch IS NOT NULL AND r.branch <> ''
       AND r.mr_iid IS NOT NULL
-      AND r.kind IN ('issue', 'ci_fix')
+      AND r.kind IN ('issue', 'ci_fix', 'prompt', 'self_improve')
       -- issue #329: a cancelled run must never seed autofix. Before #329, mr_iid was
       -- written only by SetRunCompleted (completed-only), so a cancelled run never had
       -- one and was excluded here by construction. ReconcileRunMR now records mr_iid on
@@ -165,10 +165,13 @@ type ListCIAutofixCandidateRefsRow struct {
 // one row per branch. Three independent gates decide eligibility, and all three are
 // expressed here so the detector cannot skip one:
 //
-//  1. KIND-AWARENESS. Only issue/ci_fix runs own an agent MR branch
-//     (agent/issue-N); chat/judge/self_improve/prompt runs never do. The per_branch
-//     CTE therefore filters `r.kind IN ('issue','ci_fix')` before it picks the
-//     NEWEST run per branch (DISTINCT ON (r.branch) … ORDER BY r.branch,
+//  1. KIND-AWARENESS. issue/ci_fix runs own an agent/issue-N branch, and the
+//     scheduled lanes own uzi/prompt-… / uzi/self-improve/… branches; chat/judge
+//     runs never open one. The per_branch CTE therefore filters `r.kind IN
+//     ('issue','ci_fix','prompt','self_improve')` (PRD #908 added the two scheduled
+//     lanes — ci_autofix is pipeline-driven with NO mr_state gate, so scheduled
+//     branches already get pipeline_statuses rows and need no recorder) before it
+//     picks the NEWEST run per branch (DISTINCT ON (r.branch) … ORDER BY r.branch,
 //     r.created_at DESC, mirroring ListWatchedRunRefsForRepo). A branch with no
 //     such run produces no candidate — autofix never acts on a branch uzi does not
 //     own by construction. Cancelled runs are also excluded here (issue #329) so a

--- a/api/internal/store/ci_autofix_integration_test.go
+++ b/api/internal/store/ci_autofix_integration_test.go
@@ -79,6 +79,18 @@ func TestCIAutofixLiveDB(t *testing.T) {
 			 VALUES ($1, $2, $3, $4, 't', 'd', 'completed', $5, $6, now() - $7::interval)`,
 			owner, repoID, kind, issueIID, branch, mr, createdOffset)
 	}
+	// insertPromptRun inserts a prompt-shaped run (issue_iid = NULL, per the
+	// runs_kind_shape CHECK for kind='prompt') on a scheduled-lane branch.
+	insertPromptRun := func(owner uuid.UUID, branch string, mrIID *int64, createdOffset string) {
+		var mr any
+		if mrIID != nil {
+			mr = *mrIID
+		}
+		mustExec(ctx, t, pool,
+			`INSERT INTO runs (user_id, repo_id, kind, issue_iid, issue_title, issue_description, status, branch, mr_iid, created_at)
+			 VALUES ($1, $2, 'prompt', NULL, 't', 'd', 'completed', $3, $4, now() - $5::interval)`,
+			owner, repoID, branch, mr, createdOffset)
+	}
 	// insertPipeline caches a pipeline_status row for a ref.
 	insertPipeline := func(ref string, pipelineID int64, status string) {
 		mustExec(ctx, t, pool,
@@ -108,30 +120,69 @@ func TestCIAutofixLiveDB(t *testing.T) {
 	insertRun(u1, "issue", "agent/issue-4", 4, iid(104), "1 hour")
 	insertPipeline("agent/issue-4", 9004, "success")
 
-	// u1: kind self_improve — excluded by kind-awareness (only issue/ci_fix own agent
-	// MR branches), despite being issue-shaped with a failed pipeline + mr_iid.
-	insertRun(u1, "self_improve", "agent/issue-5", 5, iid(105), "1 hour")
-	insertPipeline("agent/issue-5", 9005, "failed")
+	// PRD #908 M4: ListCIAutofixCandidateRefs's kind filter widened to
+	// kind IN ('issue','ci_fix','prompt','self_improve'), so the scheduled lanes are now
+	// INCLUDED. Two runs owned by the eligible owner u1, each on a scheduled-lane branch
+	// with a FAILED pipeline + mr_iid, must BOTH surface as candidates.
+	//
+	// u1: a self_improve run (issue_iid set, per the runs_kind_shape CHECK for the kind) on
+	// a uzi/self-improve/<uuid> branch — previously EXCLUDED by kind-awareness, now included.
+	selfImproveBranch := "uzi/self-improve/" + uuid.New().String()
+	insertRun(u1, "self_improve", selfImproveBranch, 5, iid(105), "1 hour")
+	insertPipeline(selfImproveBranch, 9005, "failed")
 
-	// u2: opted OUT — excluded by the owner opt-in gate.
-	insertRun(u2, "issue", "agent/issue-6", 6, iid(106), "1 hour")
-	insertPipeline("agent/issue-6", 9006, "failed")
+	// u1: a prompt run (issue_iid NULL, per the shape CHECK) on a uzi/prompt-<uuid> branch.
+	promptBranch := "uzi/prompt-" + uuid.New().String()
+	insertPromptRun(u1, promptBranch, iid(108), "1 hour")
+	insertPipeline(promptBranch, 9008, "failed")
 
-	// u3: opted in but NO token — excluded by the token gate.
-	insertRun(u3, "issue", "agent/issue-7", 7, iid(107), "1 hour")
-	insertPipeline("agent/issue-7", 9007, "failed")
+	// u2: a prompt run whose owner opted OUT — still excluded by the owner opt-in gate,
+	// proving that gate is kind-INDEPENDENT (it drops a scheduled-lane run the same as an
+	// issue run).
+	u2PromptBranch := "uzi/prompt-" + uuid.New().String()
+	insertPromptRun(u2, u2PromptBranch, iid(106), "1 hour")
+	insertPipeline(u2PromptBranch, 9006, "failed")
 
-	// ── ListCIAutofixCandidateRefs: exactly the one eligible ref ──
+	// u3: a self_improve run whose owner has NO token — still excluded by the token gate,
+	// again kind-independent.
+	u3SelfImproveBranch := "uzi/self-improve/" + uuid.New().String()
+	insertRun(u3, "self_improve", u3SelfImproveBranch, 7, iid(107), "1 hour")
+	insertPipeline(u3SelfImproveBranch, 9007, "failed")
+
+	// ── ListCIAutofixCandidateRefs: the exact eligible SET ──
+	// Eligible now = agent/issue-1 (issue lane) + u1's two scheduled-lane branches. Every
+	// other seed is excluded by a specific gate (default-branch, mr_iid, green pipeline,
+	// owner opt-out, missing token). Assert the exact set by branch name — precise, not a
+	// bare count — so a stray candidate or a missing one both fail.
 	cands, err := q.ListCIAutofixCandidateRefs(ctx, repoID)
 	if err != nil {
 		t.Fatalf("ListCIAutofixCandidateRefs: %v", err)
 	}
-	if len(cands) != 1 {
-		t.Fatalf("want exactly one candidate (agent/issue-1), got %d: %+v", len(cands), cands)
+	gotRefs := make(map[string]bool, len(cands))
+	for _, cand := range cands {
+		gotRefs[cand.Ref.String] = true
 	}
-	c := cands[0]
-	if c.Ref.String != "agent/issue-1" {
-		t.Errorf("candidate ref = %q, want agent/issue-1", c.Ref.String)
+	wantRefs := []string{"agent/issue-1", selfImproveBranch, promptBranch}
+	if len(cands) != len(wantRefs) {
+		t.Fatalf("want exactly %d candidates %v, got %d: %+v", len(wantRefs), wantRefs, len(cands), cands)
+	}
+	for _, ref := range wantRefs {
+		if !gotRefs[ref] {
+			t.Errorf("expected %q to be an eligible ci-autofix candidate, got set %v", ref, gotRefs)
+		}
+	}
+
+	// The issue-lane candidate still carries the NEWEST run's mr_iid (DISTINCT-ON pick), its
+	// owner, and its failed pipeline — unchanged by the scheduled-lane widening.
+	var c store.ListCIAutofixCandidateRefsRow
+	foundIssue := false
+	for _, cand := range cands {
+		if cand.Ref.String == "agent/issue-1" {
+			c, foundIssue = cand, true
+		}
+	}
+	if !foundIssue {
+		t.Fatalf("agent/issue-1 must remain a candidate")
 	}
 	if !c.MrIid.Valid || c.MrIid.Int64 != 101 {
 		t.Errorf("candidate must carry the NEWEST run's mr_iid=101, got %+v", c.MrIid)

--- a/api/internal/store/forge.sql.go
+++ b/api/internal/store/forge.sql.go
@@ -961,7 +961,16 @@ WITH latest AS (
     SELECT DISTINCT ON (r.issue_iid)
            r.id, r.issue_iid, r.status, r.mr_iid, r.mr_state, r.created_at
     FROM runs r
+    -- Scheduled-lane runs are excluded HERE, before the per-issue collapse, so this
+    -- board-coupled watcher never owns their MR-state transitions (PRD #908 R1). A
+    -- prompt run is issue-less and already dropped by the JOIN below, but a self_improve
+    -- run carries a real tracking-issue iid whose completed run parks the card in Human
+    -- Review (runlifecycle) — so without this filter it satisfies Lane A and syncOneMRState
+    -- would move the shared tracking-issue card on an MR close/reopen edge, defeating the
+    -- board-free contract. Scheduled kinds have their own tracking-issue iids (never a real
+    -- PRD issue's), so excluding them cannot mask an issue-lane rework in the DISTINCT ON.
     WHERE r.repo_id = $1
+      AND r.kind NOT IN ('prompt', 'self_improve')
     ORDER BY r.issue_iid, r.created_at DESC
 )
 SELECT l.id, l.issue_iid, l.mr_iid, l.mr_state

--- a/api/internal/store/forge.sql.go
+++ b/api/internal/store/forge.sql.go
@@ -1022,6 +1022,9 @@ type ListMRWatchCandidatesRow struct {
 // merged/locked transition are move-free, and the edge paths skip a closed issue),
 // so it only backfills historical merged PRs and decays as each run settles to a
 // terminal state. The Go ResolveColumn check remains authoritative for board moves.
+//
+// Scheduled-lane runs (prompt/self_improve) are watched separately, board-free, by
+// ListScheduledMRStateWatchCandidates (PRD #908) — they have no board card.
 // Open-issue (Lane A) candidates first so the board-move watch is never deferred
 // behind a closed-issue backfill burst; then newest runs first so recent merges
 // record before old ones. Qualify l.created_at (not bare) — `issues` has none.
@@ -1224,6 +1227,60 @@ func (q *Queries) ListReposByConnectionForUser(ctx context.Context, arg ListRepo
 			&i.GuardrailOverrideAt,
 			&i.RequiredCapabilities,
 			&i.FoldImproveUziBacklog,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listScheduledMRStateWatchCandidates = `-- name: ListScheduledMRStateWatchCandidates :many
+SELECT id, branch, mr_iid, mr_state
+FROM runs
+WHERE repo_id = $1::uuid
+  AND kind IN ('prompt', 'self_improve')
+  AND status = 'completed'
+  AND mr_iid IS NOT NULL
+  AND (mr_state IS NULL OR mr_state IN ('opened', 'locked'))
+ORDER BY created_at DESC
+LIMIT 100
+`
+
+type ListScheduledMRStateWatchCandidatesRow struct {
+	ID      uuid.UUID   `json:"id"`
+	Branch  pgtype.Text `json:"branch"`
+	MrIid   pgtype.Int8 `json:"mr_iid"`
+	MrState pgtype.Text `json:"mr_state"`
+}
+
+// Board-FREE MR-state watch for the scheduled lanes (prompt, self_improve) — PRD #908.
+// Sibling of ListMRWatchCandidates but with NO issues JOIN and NO DISTINCT ON (issue_iid):
+// prompt runs are issue-less and self_improve runs share one tracking issue, so neither the
+// board-move machinery nor the per-issue collapse applies. Keyed on the run/branch. Populates
+// runs.mr_state via forgesvc.SyncScheduledMRStates so ListMRReworkCandidates' mr_state='opened'
+// gate, the mr_rework ledger eviction, and stop-on-close cancellation all work for these lanes.
+// Self-bounding like Lane B: poll a run only until its mr_state reaches a terminal value
+// (merged/closed), then it drops out of this set. LIMIT 100 is a hardcoded burst bound (mirrors
+// ListMRWatchCandidates), not a sqlc param, so zero Go signature change. Keep this rationale
+// ABOVE the statement — a comment trailing after the `;` is grabbed by sqlc as the NEXT query's doc.
+func (q *Queries) ListScheduledMRStateWatchCandidates(ctx context.Context, repoID uuid.UUID) ([]ListScheduledMRStateWatchCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listScheduledMRStateWatchCandidates, repoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListScheduledMRStateWatchCandidatesRow{}
+	for rows.Next() {
+		var i ListScheduledMRStateWatchCandidatesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Branch,
+			&i.MrIid,
+			&i.MrState,
 		); err != nil {
 			return nil, err
 		}

--- a/api/internal/store/mr_rework.sql.go
+++ b/api/internal/store/mr_rework.sql.go
@@ -306,8 +306,10 @@ type ListMRReworkCandidatesRow struct {
 //     ('issue','prompt','self_improve') (PRD #908 widened this from issue-only —
 //     chat/judge still out of scope). For the scheduled lanes runs.mr_state is made
 //     reliable by forgesvc.SyncScheduledMRStates (PRD #908 M3); prompt runs are
-//     issue-less and self_improve shares one tracking issue, so the board-coupled
-//     ListMRWatchCandidates never watched them. DISTINCT ON (r.branch) picks the
+//     issue-less (so the board-coupled ListMRWatchCandidates, which JOINs issues,
+//     never watched them) and self_improve shares one tracking issue (so that watcher
+//     recorded mr_state only for the newest cycle via DISTINCT ON (issue_iid) — and
+//     only when the tracking issue is cached). DISTINCT ON (r.branch) picks the
 //     NEWEST such run per branch (mirroring ListCIAutofixCandidateRefs).
 //  2. The run is completed and carries an mr_iid, and the WATCHER-OWNED mr_state is
 //     'opened' (Decision 10 — gate on runs.mr_state, which SyncMRStates set FIRST

--- a/api/internal/store/mr_rework.sql.go
+++ b/api/internal/store/mr_rework.sql.go
@@ -45,7 +45,8 @@ type CreateAutoMRReworkRunParams struct {
 
 // Queue an mr_rework run (PRD #700 M3, sibling of CreateCIFixRun). issue_iid stays
 // NULL (kind='mr_rework'); issue_title/issue_description carry the synthesized human
-// summary. pipeline_ref = agent/issue-N is written AT INSERT so the cross-kind branch
+// summary. pipeline_ref = the agent branch (agent/issue-N, uzi/prompt-…, or
+// uzi/self-improve/… — PRD #908) is written AT INSERT so the cross-kind branch
 // guard is never create-time-NULL (Decision 6). target_run_id points at the source
 // completed run whose MR is watched (mirroring judge). mr_iid is the MR the rework
 // folds onto. review_comments carries the MR review snapshot the detector built
@@ -58,7 +59,7 @@ type CreateAutoMRReworkRunParams struct {
 // The create-time CROSS-KIND branch guard (Decision 6, the most severe review finding)
 // is this query's own single atomic INSERT … WHERE NOT EXISTS. The WHERE NOT EXISTS
 // predicate is narrowed to the CROSS-KIND case only — an active ci_fix run whose
-// pipeline_ref equals the branch (agent/issue-N) means the branch is occupied by the
+// pipeline_ref equals the branch (any agent branch) means the branch is occupied by the
 // other kind. ci_fix writes pipeline_ref AT INSERT, so — unlike the old runs.branch
 // count (NULL for a run's whole active life) — a freshly-created cross-kind sibling is
 // seen. A committed ci_fix → zero rows inserted → pgx.ErrNoRows, which the caller maps
@@ -204,8 +205,9 @@ type DeleteMRReworkLedgerNotInParams struct {
 // set (a merged/closed MR, or a run branch that aged out), mirroring
 // DeleteCIAutofixAttemptsNotIn with the same keep-set semantics. This is ALSO the
 // stop-on-merge / stop-on-close cleanup: an mr_state that leaves 'opened' drops the
-// ref from the candidate set, so its ledger row evicts here and a reused agent/issue-N
-// branch never inherits a stale count. An empty keep-set clears the repo's ledger.
+// ref from the candidate set, so its ledger row evicts here and a reused agent branch
+// (agent/issue-N, uzi/prompt-…, uzi/self-improve/…) never inherits a stale count. An
+// empty keep-set clears the repo's ledger.
 func (q *Queries) DeleteMRReworkLedgerNotIn(ctx context.Context, arg DeleteMRReworkLedgerNotInParams) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteMRReworkLedgerNotIn, arg.RepoID, arg.KeepRefs)
 	if err != nil {
@@ -250,7 +252,7 @@ WITH per_branch AS (
            r.branch, r.mr_iid, r.user_id, r.id AS source_run_id, r.mr_rework_enabled
     FROM runs r
     WHERE r.repo_id = $1::uuid
-      AND r.kind = 'issue'
+      AND r.kind IN ('issue', 'prompt', 'self_improve')
       AND r.status = 'completed'
       AND r.branch IS NOT NULL AND r.branch <> ''
       AND r.mr_iid IS NOT NULL
@@ -298,10 +300,14 @@ type ListMRReworkCandidatesRow struct {
 // single atomic INSERT … WHERE NOT EXISTS is itself the create-time cross-kind
 // branch guard. Detection lives in the poller, never in forgesvc — forgesvc's
 // sync methods are shared with the manual board Refresh and must never spawn runs.
-// The completed issue runs in a repo whose OPEN MR is eligible for an automatic
-// mr_rework, one row per branch. Gates (Decision 9/10):
-//  1. Only issue runs open an MR review loop (chat/judge/self_improve are out of
-//     scope, Decision 9), so kind = 'issue'. DISTINCT ON (r.branch) picks the
+// The completed issue/prompt/self_improve runs in a repo whose OPEN MR is eligible
+// for an automatic mr_rework, one row per branch. Gates (Decision 9/10):
+//  1. issue runs plus the scheduled lanes open an MR review loop: kind IN
+//     ('issue','prompt','self_improve') (PRD #908 widened this from issue-only —
+//     chat/judge still out of scope). For the scheduled lanes runs.mr_state is made
+//     reliable by forgesvc.SyncScheduledMRStates (PRD #908 M3); prompt runs are
+//     issue-less and self_improve shares one tracking issue, so the board-coupled
+//     ListMRWatchCandidates never watched them. DISTINCT ON (r.branch) picks the
 //     NEWEST such run per branch (mirroring ListCIAutofixCandidateRefs).
 //  2. The run is completed and carries an mr_iid, and the WATCHER-OWNED mr_state is
 //     'opened' (Decision 10 — gate on runs.mr_state, which SyncMRStates set FIRST

--- a/api/internal/store/mr_rework_livedb_test.go
+++ b/api/internal/store/mr_rework_livedb_test.go
@@ -82,6 +82,53 @@ func TestMRReworkLiveDB(t *testing.T) {
 		return id
 	}
 
+	// seedScheduledRun inserts a completed scheduled-lane run (kind='prompt' or
+	// 'self_improve') with an MR on the given branch (PRD #908 widened the candidate kind
+	// filter to include these). It stamps the WATCHER-OWNED runs.mr_state (nil ⇒ SQL NULL,
+	// the pre-recorder bootstrap state) and the per-run mr_rework_enabled override (nil ⇒
+	// SQL NULL). Per the runs_kind_shape CHECK, prompt carries issue_iid NULL and
+	// self_improve a non-null issue_iid, so issueIID is threaded through as *int64. A green
+	// head pipeline is seeded so the branch is fully realistic; the candidate query LEFT
+	// JOINs it, so it is not what gates admission — runs.mr_state is.
+	seedScheduledRun := func(owner uuid.UUID, kind, branch string, mrIID int64, mrState *string, mrRework *bool, issueIID *int64) uuid.UUID {
+		t.Helper()
+		id := uuid.New()
+		exec(`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status, mr_rework_enabled)
+		      VALUES ($1, $2, $3, $4, $5, 't', 'd', $6, $7, $8, 'completed', $9)`,
+			id, owner, repoID, kind, issueIID, branch, mrIID, mrState, mrRework)
+		exec(`INSERT INTO pipeline_statuses (repo_id, ref, pipeline_id, sha, status, web_url, synced_at)
+		      VALUES ($1, $2, $3, $4, 'success', 'https://forge.e2e/p', now())`, repoID, branch, mrIID*100, "sha-"+branch)
+		return id
+	}
+	sp := func(s string) *string { return &s }
+	bp := func(b bool) *bool { return &b }
+	ip := func(n int64) *int64 { return &n }
+
+	// PRD #908 scheduled-lane candidates (owned by the opted-in inUser, opened MR, token
+	// present, no opt-out anywhere) — both must surface, proving the kind filter widened
+	// beyond issue.
+	promptCandBranch := "uzi/prompt-" + uuid.New().String()
+	srcPrompt := seedScheduledRun(inUser, "prompt", promptCandBranch, 7010, sp("opened"), nil, nil)
+	selfImpCandBranch := "uzi/self-improve/" + uuid.New().String()
+	srcSelfImp := seedScheduledRun(inUser, "self_improve", selfImpCandBranch, 7020, sp("opened"), nil, ip(7021))
+
+	// Opt-out excludes, both layers of the COALESCE(per-run, owner) chain:
+	//   - per-RUN override false (owner inUser defaults ON) → excluded.
+	promptRunOptOutBranch := "uzi/prompt-" + uuid.New().String()
+	seedScheduledRun(inUser, "prompt", promptRunOptOutBranch, 7030, sp("opened"), bp(false), nil)
+	//   - OWNER default false with a NULL run column (outUser) → excluded.
+	selfImpOwnerOptOutBranch := "uzi/self-improve/" + uuid.New().String()
+	seedScheduledRun(outUser, "self_improve", selfImpOwnerOptOutBranch, 7040, sp("opened"), nil, ip(7041))
+
+	// mr_state gate: a non-'opened' watcher-owned state must be excluded, proving the M3
+	// recorder gate matters (the scheduled lane is eligible only while its MR is opened).
+	//   - 'merged' (terminal) → excluded.
+	promptMergedBranch := "uzi/prompt-" + uuid.New().String()
+	seedScheduledRun(inUser, "prompt", promptMergedBranch, 7050, sp("merged"), nil, nil)
+	//   - NULL (pre-recorder bootstrap, mr_state = 'opened' is false for NULL) → excluded.
+	promptNullStateBranch := "uzi/prompt-" + uuid.New().String()
+	seedScheduledRun(inUser, "prompt", promptNullStateBranch, 7060, nil, nil, nil)
+
 	// Opted-in, opened MR, green pipeline → a candidate.
 	src7 := seedIssueRun(inUser, 7, "opened", "sha7")
 	// Opted-in, but the MR is CLOSED → excluded (stop-on-close, Decision 10).
@@ -95,12 +142,39 @@ func TestMRReworkLiveDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListMRReworkCandidates: %v", err)
 	}
-	if len(cands) != 1 {
-		t.Fatalf("expected exactly one candidate (opted-in + opened MR), got %d: %+v", len(cands), cands)
+	// The exact candidate SET, keyed by branch → source_run_id. Precise (not a bare count):
+	// the issue-lane candidate PLUS the two scheduled-lane candidates survive; every opt-out
+	// and non-opened-state seed is absent. A stray candidate or a missing one both fail.
+	bySrc := map[string]uuid.UUID{}
+	byRow := map[string]store.ListMRReworkCandidatesRow{}
+	for _, cand := range cands {
+		bySrc[cand.Ref.String] = cand.SourceRunID
+		byRow[cand.Ref.String] = cand
 	}
-	c := cands[0]
-	if c.Ref.String != "agent/issue-7" || c.MrIid.Int64 != 70 || c.SourceRunID != src7 {
-		t.Fatalf("candidate row wrong: %+v", c)
+	wantCands := map[string]uuid.UUID{
+		"agent/issue-7":   src7,
+		promptCandBranch:  srcPrompt,
+		selfImpCandBranch: srcSelfImp,
+	}
+	if len(cands) != len(wantCands) {
+		t.Fatalf("expected exactly %d candidates (issue-7 + prompt + self_improve), got %d: %+v", len(wantCands), len(cands), cands)
+	}
+	for ref, wantSrc := range wantCands {
+		if bySrc[ref] != wantSrc {
+			t.Errorf("candidate %q must surface via source_run_id %s, got %s (set %+v)", ref, wantSrc, bySrc[ref], bySrc)
+		}
+	}
+	for _, excluded := range []string{promptRunOptOutBranch, selfImpOwnerOptOutBranch, promptMergedBranch, promptNullStateBranch} {
+		if _, ok := bySrc[excluded]; ok {
+			t.Errorf("branch %q must be excluded (opt-out or non-opened mr_state), but it surfaced", excluded)
+		}
+	}
+
+	// The issue-lane candidate still carries its mr_iid, bot_forge_user_id, and green head
+	// pipeline — the scheduled-lane widening must not disturb it.
+	c := byRow["agent/issue-7"]
+	if c.MrIid.Int64 != 70 || c.SourceRunID != src7 {
+		t.Fatalf("issue-7 candidate row wrong: %+v", c)
 	}
 	if c.BotForgeUserID != 777 {
 		t.Fatalf("bot_forge_user_id not projected: %d", c.BotForgeUserID)

--- a/api/internal/store/mr_watch_integration_test.go
+++ b/api/internal/store/mr_watch_integration_test.go
@@ -162,6 +162,21 @@ func TestListMRWatchCandidatesLiveDB(t *testing.T) {
 	issue(111, "closed", hr)
 	run(111, 211, "completed", "closed", 1*time.Minute)
 
+	// 112 — PRD #908 R1 board-free guard: a completed SELF_IMPROVE run whose shared
+	// tracking issue (112) is OPEN and parked in Human Review by runlifecycle, with an
+	// OPEN MR. This is the exact reachable state that made the scheduled lane leak onto
+	// the board: without the `kind NOT IN ('prompt','self_improve')` filter in the CTE it
+	// satisfies Lane A (opened + Human Review) and the board-coupled syncOneMRState would
+	// move the SHARED tracking-issue card on the MR close/reopen edge — the R1 violation.
+	// The kind filter drops it here; ListScheduledMRStateWatchCandidates owns it board-free
+	// instead. Designed to FAIL on the pre-fix query (112 would appear as a 6th candidate);
+	// its exclusion plus the exact count of 5 below is the non-vacuous proof.
+	issue(112, "opened", hr)
+	mustExec(ctx, t, pool,
+		`INSERT INTO runs (user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, status, mr_iid, mr_state, created_at)
+		 VALUES ($1, $2, 'self_improve', $3, 't', 'd', $4, 'completed', $5, 'opened', $6)`,
+		userID, repoID, int64(112), "uzi/self-improve/"+uuid.New().String(), int64(212), base.Add(1*time.Minute))
+
 	rows, err := q.ListMRWatchCandidates(ctx, repoID)
 	if err != nil {
 		t.Fatalf("ListMRWatchCandidates: %v", err)
@@ -183,6 +198,7 @@ func TestListMRWatchCandidatesLiveDB(t *testing.T) {
 		107: "completed run has NULL mr_iid",
 		110: "Lane B decay: closed issue but mr_state already terminal (merged)",
 		111: "Lane B decay: closed issue, mr_state terminal (closed)",
+		112: "PRD #908 R1: self_improve run excluded from the board-coupled watcher by the CTE kind filter",
 	}
 	for iid, why := range absent {
 		if _, ok := got[iid]; ok {

--- a/api/internal/store/queries/ci_autofix.sql
+++ b/api/internal/store/queries/ci_autofix.sql
@@ -9,10 +9,13 @@
 -- one row per branch. Three independent gates decide eligibility, and all three are
 -- expressed here so the detector cannot skip one:
 --
---   1. KIND-AWARENESS. Only issue/ci_fix runs own an agent MR branch
---      (agent/issue-N); chat/judge/self_improve/prompt runs never do. The per_branch
---      CTE therefore filters `r.kind IN ('issue','ci_fix')` before it picks the
---      NEWEST run per branch (DISTINCT ON (r.branch) … ORDER BY r.branch,
+--   1. KIND-AWARENESS. issue/ci_fix runs own an agent/issue-N branch, and the
+--      scheduled lanes own uzi/prompt-… / uzi/self-improve/… branches; chat/judge
+--      runs never open one. The per_branch CTE therefore filters `r.kind IN
+--      ('issue','ci_fix','prompt','self_improve')` (PRD #908 added the two scheduled
+--      lanes — ci_autofix is pipeline-driven with NO mr_state gate, so scheduled
+--      branches already get pipeline_statuses rows and need no recorder) before it
+--      picks the NEWEST run per branch (DISTINCT ON (r.branch) … ORDER BY r.branch,
 --      r.created_at DESC, mirroring ListWatchedRunRefsForRepo). A branch with no
 --      such run produces no candidate — autofix never acts on a branch uzi does not
 --      own by construction. Cancelled runs are also excluded here (issue #329) so a
@@ -42,7 +45,7 @@ WITH per_branch AS (
     WHERE r.repo_id = @repo_id::uuid
       AND r.branch IS NOT NULL AND r.branch <> ''
       AND r.mr_iid IS NOT NULL
-      AND r.kind IN ('issue', 'ci_fix')
+      AND r.kind IN ('issue', 'ci_fix', 'prompt', 'self_improve')
       -- issue #329: a cancelled run must never seed autofix. Before #329, mr_iid was
       -- written only by SetRunCompleted (completed-only), so a cancelled run never had
       -- one and was excluded here by construction. ReconcileRunMR now records mr_iid on

--- a/api/internal/store/queries/forge.sql
+++ b/api/internal/store/queries/forge.sql
@@ -563,7 +563,16 @@ WITH latest AS (
     SELECT DISTINCT ON (r.issue_iid)
            r.id, r.issue_iid, r.status, r.mr_iid, r.mr_state, r.created_at
     FROM runs r
+    -- Scheduled-lane runs are excluded HERE, before the per-issue collapse, so this
+    -- board-coupled watcher never owns their MR-state transitions (PRD #908 R1). A
+    -- prompt run is issue-less and already dropped by the JOIN below, but a self_improve
+    -- run carries a real tracking-issue iid whose completed run parks the card in Human
+    -- Review (runlifecycle) — so without this filter it satisfies Lane A and syncOneMRState
+    -- would move the shared tracking-issue card on an MR close/reopen edge, defeating the
+    -- board-free contract. Scheduled kinds have their own tracking-issue iids (never a real
+    -- PRD issue's), so excluding them cannot mask an issue-lane rework in the DISTINCT ON.
     WHERE r.repo_id = @repo_id
+      AND r.kind NOT IN ('prompt', 'self_improve')
     ORDER BY r.issue_iid, r.created_at DESC
 )
 SELECT l.id, l.issue_iid, l.mr_iid, l.mr_state

--- a/api/internal/store/queries/forge.sql
+++ b/api/internal/store/queries/forge.sql
@@ -556,6 +556,9 @@ LIMIT 1;
 -- merged/locked transition are move-free, and the edge paths skip a closed issue),
 -- so it only backfills historical merged PRs and decays as each run settles to a
 -- terminal state. The Go ResolveColumn check remains authoritative for board moves.
+--
+-- Scheduled-lane runs (prompt/self_improve) are watched separately, board-free, by
+-- ListScheduledMRStateWatchCandidates (PRD #908) — they have no board card.
 WITH latest AS (
     SELECT DISTINCT ON (r.issue_iid)
            r.id, r.issue_iid, r.status, r.mr_iid, r.mr_state, r.created_at
@@ -590,6 +593,27 @@ WHERE l.status = 'completed'
 -- rationale ABOVE the statement — a comment trailing after the `;` is grabbed by
 -- sqlc as the leading doc of the NEXT query.
 ORDER BY (i.state = 'opened') DESC, l.created_at DESC
+LIMIT 100;
+
+-- name: ListScheduledMRStateWatchCandidates :many
+-- Board-FREE MR-state watch for the scheduled lanes (prompt, self_improve) — PRD #908.
+-- Sibling of ListMRWatchCandidates but with NO issues JOIN and NO DISTINCT ON (issue_iid):
+-- prompt runs are issue-less and self_improve runs share one tracking issue, so neither the
+-- board-move machinery nor the per-issue collapse applies. Keyed on the run/branch. Populates
+-- runs.mr_state via forgesvc.SyncScheduledMRStates so ListMRReworkCandidates' mr_state='opened'
+-- gate, the mr_rework ledger eviction, and stop-on-close cancellation all work for these lanes.
+-- Self-bounding like Lane B: poll a run only until its mr_state reaches a terminal value
+-- (merged/closed), then it drops out of this set. LIMIT 100 is a hardcoded burst bound (mirrors
+-- ListMRWatchCandidates), not a sqlc param, so zero Go signature change. Keep this rationale
+-- ABOVE the statement — a comment trailing after the `;` is grabbed by sqlc as the NEXT query's doc.
+SELECT id, branch, mr_iid, mr_state
+FROM runs
+WHERE repo_id = @repo_id::uuid
+  AND kind IN ('prompt', 'self_improve')
+  AND status = 'completed'
+  AND mr_iid IS NOT NULL
+  AND (mr_state IS NULL OR mr_state IN ('opened', 'locked'))
+ORDER BY created_at DESC
 LIMIT 100;
 
 -- name: GetIssueByIID :one

--- a/api/internal/store/queries/mr_rework.sql
+++ b/api/internal/store/queries/mr_rework.sql
@@ -12,8 +12,10 @@
 --      ('issue','prompt','self_improve') (PRD #908 widened this from issue-only —
 --      chat/judge still out of scope). For the scheduled lanes runs.mr_state is made
 --      reliable by forgesvc.SyncScheduledMRStates (PRD #908 M3); prompt runs are
---      issue-less and self_improve shares one tracking issue, so the board-coupled
---      ListMRWatchCandidates never watched them. DISTINCT ON (r.branch) picks the
+--      issue-less (so the board-coupled ListMRWatchCandidates, which JOINs issues,
+--      never watched them) and self_improve shares one tracking issue (so that watcher
+--      recorded mr_state only for the newest cycle via DISTINCT ON (issue_iid) — and
+--      only when the tracking issue is cached). DISTINCT ON (r.branch) picks the
 --      NEWEST such run per branch (mirroring ListCIAutofixCandidateRefs).
 --   2. The run is completed and carries an mr_iid, and the WATCHER-OWNED mr_state is
 --      'opened' (Decision 10 — gate on runs.mr_state, which SyncMRStates set FIRST

--- a/api/internal/store/queries/mr_rework.sql
+++ b/api/internal/store/queries/mr_rework.sql
@@ -6,10 +6,14 @@
 -- sync methods are shared with the manual board Refresh and must never spawn runs.
 
 -- name: ListMRReworkCandidates :many
--- The completed issue runs in a repo whose OPEN MR is eligible for an automatic
--- mr_rework, one row per branch. Gates (Decision 9/10):
---   1. Only issue runs open an MR review loop (chat/judge/self_improve are out of
---      scope, Decision 9), so kind = 'issue'. DISTINCT ON (r.branch) picks the
+-- The completed issue/prompt/self_improve runs in a repo whose OPEN MR is eligible
+-- for an automatic mr_rework, one row per branch. Gates (Decision 9/10):
+--   1. issue runs plus the scheduled lanes open an MR review loop: kind IN
+--      ('issue','prompt','self_improve') (PRD #908 widened this from issue-only —
+--      chat/judge still out of scope). For the scheduled lanes runs.mr_state is made
+--      reliable by forgesvc.SyncScheduledMRStates (PRD #908 M3); prompt runs are
+--      issue-less and self_improve shares one tracking issue, so the board-coupled
+--      ListMRWatchCandidates never watched them. DISTINCT ON (r.branch) picks the
 --      NEWEST such run per branch (mirroring ListCIAutofixCandidateRefs).
 --   2. The run is completed and carries an mr_iid, and the WATCHER-OWNED mr_state is
 --      'opened' (Decision 10 — gate on runs.mr_state, which SyncMRStates set FIRST
@@ -37,7 +41,7 @@ WITH per_branch AS (
            r.branch, r.mr_iid, r.user_id, r.id AS source_run_id, r.mr_rework_enabled
     FROM runs r
     WHERE r.repo_id = @repo_id::uuid
-      AND r.kind = 'issue'
+      AND r.kind IN ('issue', 'prompt', 'self_improve')
       AND r.status = 'completed'
       AND r.branch IS NOT NULL AND r.branch <> ''
       AND r.mr_iid IS NOT NULL
@@ -109,15 +113,17 @@ SET halt_notified = true,
 -- set (a merged/closed MR, or a run branch that aged out), mirroring
 -- DeleteCIAutofixAttemptsNotIn with the same keep-set semantics. This is ALSO the
 -- stop-on-merge / stop-on-close cleanup: an mr_state that leaves 'opened' drops the
--- ref from the candidate set, so its ledger row evicts here and a reused agent/issue-N
--- branch never inherits a stale count. An empty keep-set clears the repo's ledger.
+-- ref from the candidate set, so its ledger row evicts here and a reused agent branch
+-- (agent/issue-N, uzi/prompt-…, uzi/self-improve/…) never inherits a stale count. An
+-- empty keep-set clears the repo's ledger.
 DELETE FROM mr_rework_ledger
 WHERE repo_id = @repo_id::uuid AND ref <> ALL(@keep_refs::text[]);
 
 -- name: CreateAutoMRReworkRun :one
 -- Queue an mr_rework run (PRD #700 M3, sibling of CreateCIFixRun). issue_iid stays
 -- NULL (kind='mr_rework'); issue_title/issue_description carry the synthesized human
--- summary. pipeline_ref = agent/issue-N is written AT INSERT so the cross-kind branch
+-- summary. pipeline_ref = the agent branch (agent/issue-N, uzi/prompt-…, or
+-- uzi/self-improve/… — PRD #908) is written AT INSERT so the cross-kind branch
 -- guard is never create-time-NULL (Decision 6). target_run_id points at the source
 -- completed run whose MR is watched (mirroring judge). mr_iid is the MR the rework
 -- folds onto. review_comments carries the MR review snapshot the detector built
@@ -130,7 +136,7 @@ WHERE repo_id = @repo_id::uuid AND ref <> ALL(@keep_refs::text[]);
 -- The create-time CROSS-KIND branch guard (Decision 6, the most severe review finding)
 -- is this query's own single atomic INSERT … WHERE NOT EXISTS. The WHERE NOT EXISTS
 -- predicate is narrowed to the CROSS-KIND case only — an active ci_fix run whose
--- pipeline_ref equals the branch (agent/issue-N) means the branch is occupied by the
+-- pipeline_ref equals the branch (any agent branch) means the branch is occupied by the
 -- other kind. ci_fix writes pipeline_ref AT INSERT, so — unlike the old runs.branch
 -- count (NULL for a run's whole active life) — a freshly-created cross-kind sibling is
 -- seen. A committed ci_fix → zero rows inserted → pgx.ErrNoRows, which the caller maps

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -2753,10 +2753,13 @@ WHERE repo_id = @repo_id::uuid AND issue_iid = @issue_iid AND move_pending_since
 
 -- name: SetRunMRState :execrows
 -- Record the merge-request state the watcher just observed for this run. This is
--- the ONLY writer of runs.mr_state (the watcher-owned invariant, review finding
--- 11): no run-status path writes it. The run itself stays terminal — closing an
--- MR is review feedback, not a run-status event — so this touches mr_state (and
--- updated_at) only.
+-- the ONLY SQL statement that writes runs.mr_state (the watcher-owned invariant,
+-- review finding 11): no run-status path writes it. It now has TWO Go callers over
+-- DISJOINT run sets — SyncMRStates (issue runs, board-coupled) and
+-- SyncScheduledMRStates (prompt/self_improve runs, board-free) — PRD #908; each
+-- records the state for its own lane through this one statement. The run itself
+-- stays terminal — closing an MR is review feedback, not a run-status event — so
+-- this touches mr_state (and updated_at) only.
 UPDATE runs SET mr_state = @mr_state, updated_at = now()
 WHERE id = @id;
 

--- a/api/internal/store/queries/runtime.sql
+++ b/api/internal/store/queries/runtime.sql
@@ -2755,9 +2755,11 @@ WHERE repo_id = @repo_id::uuid AND issue_iid = @issue_iid AND move_pending_since
 -- Record the merge-request state the watcher just observed for this run. This is
 -- the ONLY SQL statement that writes runs.mr_state (the watcher-owned invariant,
 -- review finding 11): no run-status path writes it. It now has TWO Go callers over
--- DISJOINT run sets — SyncMRStates (issue runs, board-coupled) and
+-- near-disjoint run sets — SyncMRStates (issue runs, board-coupled) and
 -- SyncScheduledMRStates (prompt/self_improve runs, board-free) — PRD #908; each
--- records the state for its own lane through this one statement. The run itself
+-- records the state for its own lane through this one statement (they can overlap only
+-- on the newest self_improve run when its shared tracking issue is cached, which is
+-- idempotent and board-move-free — see recordMRState). The run itself
 -- stays terminal — closing an MR is review feedback, not a run-status event — so
 -- this touches mr_state (and updated_at) only.
 UPDATE runs SET mr_state = @mr_state, updated_at = now()

--- a/api/internal/store/queries/selfimprove.sql
+++ b/api/internal/store/queries/selfimprove.sql
@@ -35,10 +35,13 @@
 -- default at claim assembly) and the "apply model also to agents" opt-in
 -- (@override_subagent_model, a plain bool). The bespoke engine passes nil/false, freezing
 -- NULL/false onto its run exactly as before this column pair was threaded through.
+-- mr_rework_enabled (PRD #908 M1): the schedule-driven fire path threads the schedule's
+-- per-schedule mr_rework override the same way (sqlc.narg('mr_rework_enabled'), nil =>
+-- inherit the owner default live at read time). The bespoke engine passes nil, freezing NULL.
 INSERT INTO runs (
-    user_id, repo_id, kind, issue_iid, issue_title, issue_description, auto_approve, wait_on_limit, model, override_subagent_model, required_capabilities, trigger_source
+    user_id, repo_id, kind, issue_iid, issue_title, issue_description, auto_approve, wait_on_limit, model, override_subagent_model, mr_rework_enabled, required_capabilities, trigger_source
 ) VALUES (
-    @user_id, @repo_id::uuid, 'self_improve', @issue_iid, @issue_title, @issue_description, true, @wait_on_limit, sqlc.narg('model'), @override_subagent_model,
+    @user_id, @repo_id::uuid, 'self_improve', @issue_iid, @issue_title, @issue_description, true, @wait_on_limit, sqlc.narg('model'), @override_subagent_model, sqlc.narg('mr_rework_enabled'),
     -- required_capabilities (PRD #84 M2, issue #512 M1): a self_improve run is REPO-BEARING
     -- (it targets uzi's own repo, the likeliest to require docker to build/test), so it must
     -- inherit the repo's capability hint like every other repo-bearing path — else with

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -6043,10 +6043,13 @@ type SetRunMRStateParams struct {
 
 // MR-close watcher (PRD #24) --------------------------------------------------
 // Record the merge-request state the watcher just observed for this run. This is
-// the ONLY writer of runs.mr_state (the watcher-owned invariant, review finding
-// 11): no run-status path writes it. The run itself stays terminal — closing an
-// MR is review feedback, not a run-status event — so this touches mr_state (and
-// updated_at) only.
+// the ONLY SQL statement that writes runs.mr_state (the watcher-owned invariant,
+// review finding 11): no run-status path writes it. It now has TWO Go callers over
+// DISJOINT run sets — SyncMRStates (issue runs, board-coupled) and
+// SyncScheduledMRStates (prompt/self_improve runs, board-free) — PRD #908; each
+// records the state for its own lane through this one statement. The run itself
+// stays terminal — closing an MR is review feedback, not a run-status event — so
+// this touches mr_state (and updated_at) only.
 func (q *Queries) SetRunMRState(ctx context.Context, arg SetRunMRStateParams) (int64, error) {
 	result, err := q.db.Exec(ctx, setRunMRState, arg.MrState, arg.ID)
 	if err != nil {

--- a/api/internal/store/runtime.sql.go
+++ b/api/internal/store/runtime.sql.go
@@ -6045,9 +6045,11 @@ type SetRunMRStateParams struct {
 // Record the merge-request state the watcher just observed for this run. This is
 // the ONLY SQL statement that writes runs.mr_state (the watcher-owned invariant,
 // review finding 11): no run-status path writes it. It now has TWO Go callers over
-// DISJOINT run sets — SyncMRStates (issue runs, board-coupled) and
+// near-disjoint run sets — SyncMRStates (issue runs, board-coupled) and
 // SyncScheduledMRStates (prompt/self_improve runs, board-free) — PRD #908; each
-// records the state for its own lane through this one statement. The run itself
+// records the state for its own lane through this one statement (they can overlap only
+// on the newest self_improve run when its shared tracking issue is cached, which is
+// idempotent and board-move-free — see recordMRState). The run itself
 // stays terminal — closing an MR is review feedback, not a run-status event — so
 // this touches mr_state (and updated_at) only.
 func (q *Queries) SetRunMRState(ctx context.Context, arg SetRunMRStateParams) (int64, error) {

--- a/api/internal/store/scheduled_mr_state_livedb_test.go
+++ b/api/internal/store/scheduled_mr_state_livedb_test.go
@@ -1,0 +1,244 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// TestScheduledMRStateWatchCandidatesLiveDB pins ListScheduledMRStateWatchCandidates (PRD
+// #908) against a REAL Postgres. The board-free MR-state watch enumerates the scheduled
+// lanes (kind IN ('prompt','self_improve')) whose MR is still transient so the recorder can
+// keep runs.mr_state fresh; a run self-evicts from the set once its mr_state is terminal
+// (merged/closed). The query is:
+//
+//	SELECT id, branch, mr_iid, mr_state FROM runs
+//	WHERE repo_id=$1 AND kind IN ('prompt','self_improve') AND status='completed'
+//	  AND mr_iid IS NOT NULL AND (mr_state IS NULL OR mr_state IN ('opened','locked'))
+//	ORDER BY created_at DESC LIMIT 100
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres; the store-it sweep
+// (e2e/run-store-it.sh, task gate:api in CI) provides one. `go test ./...` without it SKIPs.
+// A package that prints `ok` with PASS=0 is INVALID, not green.
+func TestScheduledMRStateWatchCandidatesLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+
+	owner, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+	mustExec(ctx, t, pool, `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+		owner, fmt.Sprintf("sched-mrstate-%s@e2e", owner))
+	mustExec(ctx, t, pool,
+		`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+		 VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, owner, []byte{0x1})
+	mustExec(ctx, t, pool,
+		`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+		 VALUES ($1, $2, 1, 'g/sched', 'https://forge.e2e/g/sched', 'main', true)`, repoID, connID)
+
+	// seedRun inserts one completed scheduled-or-issue run. kind decides the shape:
+	// prompt/task carry issue_iid NULL, issue/self_improve a non-null issue_iid (00167
+	// runs_kind_shape). mrIID nil ⇒ SQL NULL mr_iid; mrState nil ⇒ SQL NULL mr_state.
+	seedRun := func(kind, branch string, issueIID *int64, mrIID *int64, mrState *string, status string) uuid.UUID {
+		id := uuid.New()
+		mustExec(ctx, t, pool,
+			`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status)
+			 VALUES ($1, $2, $3, $4, $5, 't', 'd', $6, $7, $8, $9)`,
+			id, owner, repoID, kind, issueIID, branch, mrIID, mrState, status)
+		return id
+	}
+	sp := func(s string) *string { return &s }
+	ip := func(n int64) *int64 { return &n }
+
+	// INCLUDED — the transient-MR scheduled runs the recorder must keep polling:
+	//   prompt, mr_iid set, mr_state NULL → the bootstrap candidate (first observation
+	//   records without acting).
+	promptBootstrap := seedRun("prompt", "uzi/prompt-"+uuid.New().String(), nil, ip(9101), nil, "completed")
+	//   self_improve, mr_iid set, mr_state='opened' → transient, included.
+	selfImpOpened := seedRun("self_improve", "uzi/self-improve/"+uuid.New().String(), ip(9102), ip(9102), sp("opened"), "completed")
+	//   prompt, mr_state='locked' → still transient (mid-merge), included.
+	promptLocked := seedRun("prompt", "uzi/prompt-"+uuid.New().String(), nil, ip(9103), sp("locked"), "completed")
+
+	// EXCLUDED — one per gate:
+	//   mr_state='merged' → terminal, self-eviction.
+	seedRun("prompt", "uzi/prompt-"+uuid.New().String(), nil, ip(9104), sp("merged"), "completed")
+	//   mr_state='closed' → terminal.
+	seedRun("self_improve", "uzi/self-improve/"+uuid.New().String(), ip(9105), ip(9105), sp("closed"), "completed")
+	//   kind='issue' with mr_iid + mr_state NULL → the kind filter drops it (issue runs are
+	//   watched by the board-coupled Lane A, not this board-free lane).
+	seedRun("issue", "agent/issue-9106", ip(9106), ip(9106), nil, "completed")
+	//   mr_iid NULL → nothing to watch.
+	seedRun("prompt", "uzi/prompt-"+uuid.New().String(), nil, nil, sp("opened"), "completed")
+	//   status='running' → the run has not completed, no MR yet.
+	seedRun("prompt", "uzi/prompt-"+uuid.New().String(), nil, ip(9108), sp("opened"), "running")
+
+	cands, err := q.ListScheduledMRStateWatchCandidates(ctx, repoID)
+	if err != nil {
+		t.Fatalf("ListScheduledMRStateWatchCandidates: %v", err)
+	}
+	byID := map[uuid.UUID]store.ListScheduledMRStateWatchCandidatesRow{}
+	for _, c := range cands {
+		byID[c.ID] = c
+	}
+	wantIDs := []uuid.UUID{promptBootstrap, selfImpOpened, promptLocked}
+	if len(cands) != len(wantIDs) {
+		t.Fatalf("want exactly %d scheduled watch candidates (NULL/opened/locked), got %d: %+v", len(wantIDs), len(cands), cands)
+	}
+	for _, id := range wantIDs {
+		if _, ok := byID[id]; !ok {
+			t.Errorf("run %s must be a scheduled MR-state watch candidate, got set %+v", id, cands)
+		}
+	}
+	// The projection carries branch/mr_iid/mr_state through untouched (the recorder needs
+	// them to read the forge and detect the transition). Spot-check the bootstrap row's NULL
+	// mr_state survives as an invalid pgtype.Text rather than being coerced.
+	if bc := byID[promptBootstrap]; bc.MrState.Valid {
+		t.Errorf("bootstrap candidate mr_state must project as NULL, got %+v", bc.MrState)
+	}
+	if oc := byID[selfImpOpened]; !oc.MrState.Valid || oc.MrState.String != "opened" || oc.MrIid.Int64 != 9102 {
+		t.Errorf("opened candidate must project mr_state='opened' + mr_iid=9102, got %+v", oc)
+	}
+}
+
+// TestScheduledBranchConcurrencyGuardsLiveDB proves the create-time cross-kind branch guard
+// and the per-MR uniqueness index BOTH hold for a SCHEDULED-lane branch (uzi/prompt-…),
+// exactly as they do for an agent/issue-N branch — PRD #908's scheduled lanes reuse the same
+// runs table, the same uq_runs_one_active_branch_ref spanning index, and the same
+// uq_runs_one_active_mr_rework (repo_id, mr_iid) index.
+//
+// Mechanism exercised (store-level, both arms):
+//
+//   - CROSS-KIND branch guard: an active ci_fix run occupies pipeline_ref=<uzi/prompt branch>,
+//     so CreateAutoMRReworkRun for that SAME ref matches zero rows through its atomic
+//     INSERT … WHERE NOT EXISTS and the generated :one returns pgx.ErrNoRows (the caller maps
+//     that to ErrBranchInUse). This is the sequential committed-path arm — no goroutine.
+//   - PER-MR uniqueness: on a DIFFERENT scheduled branch with no cross-kind occupant, the
+//     FIRST CreateAutoMRReworkRun succeeds; a SECOND for the same (repo_id, mr_iid) falls
+//     THROUGH the (cross-kind-only) WHERE NOT EXISTS and is rejected by the
+//     uq_runs_one_active_mr_rework partial unique index → pgconn 23505.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres.
+func TestScheduledBranchConcurrencyGuardsLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via e2e/run-store-it.sh for live-DB coverage")
+	}
+	ctx := context.Background()
+	if err := store.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	defer pool.Close()
+	q := store.New(pool)
+
+	owner, connID, repoID := uuid.New(), uuid.New(), uuid.New()
+	mustExec(ctx, t, pool, `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+		owner, fmt.Sprintf("sched-guard-%s@e2e", owner))
+	mustExec(ctx, t, pool,
+		`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
+		 VALUES ($1, $2, 'gitlab', 'https://forge.e2e', 'bot', 1, $3)`, connID, owner, []byte{0x1})
+	mustExec(ctx, t, pool,
+		`INSERT INTO repos (id, connection_id, forge_project_id, path_with_namespace, web_url, default_branch, enabled)
+		 VALUES ($1, $2, 1, 'g/sguard', 'https://forge.e2e/g/sguard', 'main', true)`, repoID, connID)
+
+	// A completed source prompt run (issue_iid NULL) with an opened MR on the branch, serving
+	// as target_run_id (runs_kind_shape requires an mr_rework to carry a non-null target).
+	occupiedBranch := "uzi/prompt-" + uuid.New().String()
+	const occupiedMR int64 = 8600
+	srcOccupied := uuid.New()
+	mustExec(ctx, t, pool,
+		`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status)
+		 VALUES ($1, $2, $3, 'prompt', NULL, 't', 'd', $4, $5, 'opened', 'completed')`,
+		srcOccupied, owner, repoID, occupiedBranch, occupiedMR)
+
+	// ── CROSS-KIND branch guard ──
+	// An active ci_fix run occupies the scheduled branch. Its distinct mr_iid=99 means the
+	// ONLY thing blocking the mr_rework insert is the occupied branch, not the same-MR index.
+	mustExec(ctx, t, pool,
+		`INSERT INTO runs (id, user_id, repo_id, kind, issue_title, issue_description, pipeline_id, pipeline_ref, status)
+		 VALUES ($1, $2, $3, 'ci_fix', 't', 'd', 4242, $4, 'running')`,
+		uuid.New(), owner, repoID, occupiedBranch)
+	if _, err := q.CreateAutoMRReworkRun(ctx, store.CreateAutoMRReworkRunParams{
+		UserID:           owner,
+		RepoID:           repoID,
+		IssueTitle:       "Rework scheduled MR (occupied by ci_fix)",
+		IssueDescription: "d",
+		PipelineRef:      pgtype.Text{String: occupiedBranch, Valid: true},
+		MrIid:            pgtype.Int8{Int64: occupiedMR, Valid: true},
+		TargetRunID:      pgtype.UUID{Bytes: srcOccupied, Valid: true},
+		ReviewComments:   []byte(`{"comments":[{"id":1}],"truncated":false}`),
+		WaitOnLimit:      false,
+	}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("CreateAutoMRReworkRun on a ci_fix-occupied scheduled branch: err = %v, want pgx.ErrNoRows (cross-kind WHERE NOT EXISTS → 0 rows)", err)
+	}
+
+	// ── PER-MR uniqueness ──
+	// A fresh scheduled branch with no cross-kind occupant. The first create succeeds; the
+	// second, same (repo_id, mr_iid), is rejected by uq_runs_one_active_mr_rework.
+	freeBranch := "uzi/prompt-" + uuid.New().String()
+	const freeMR int64 = 8700
+	srcFree := uuid.New()
+	mustExec(ctx, t, pool,
+		`INSERT INTO runs (id, user_id, repo_id, kind, issue_iid, issue_title, issue_description, branch, mr_iid, mr_state, status)
+		 VALUES ($1, $2, $3, 'prompt', NULL, 't', 'd', $4, $5, 'opened', 'completed')`,
+		srcFree, owner, repoID, freeBranch, freeMR)
+
+	first, err := q.CreateAutoMRReworkRun(ctx, store.CreateAutoMRReworkRunParams{
+		UserID:           owner,
+		RepoID:           repoID,
+		IssueTitle:       "Rework scheduled MR",
+		IssueDescription: "d",
+		PipelineRef:      pgtype.Text{String: freeBranch, Valid: true},
+		MrIid:            pgtype.Int8{Int64: freeMR, Valid: true},
+		TargetRunID:      pgtype.UUID{Bytes: srcFree, Valid: true},
+		ReviewComments:   []byte(`{"comments":[{"id":2}],"truncated":false}`),
+		WaitOnLimit:      false,
+	})
+	if err != nil {
+		t.Fatalf("first CreateAutoMRReworkRun on a free scheduled branch: %v", err)
+	}
+	if first.Kind != "mr_rework" || !first.AutoApprove {
+		t.Fatalf("mr_rework run shape wrong: kind=%q auto_approve=%v", first.Kind, first.AutoApprove)
+	}
+
+	_, err = q.CreateAutoMRReworkRun(ctx, store.CreateAutoMRReworkRunParams{
+		UserID:           owner,
+		RepoID:           repoID,
+		IssueTitle:       "Rework scheduled MR (duplicate)",
+		IssueDescription: "d",
+		PipelineRef:      pgtype.Text{String: freeBranch, Valid: true},
+		MrIid:            pgtype.Int8{Int64: freeMR, Valid: true},
+		TargetRunID:      pgtype.UUID{Bytes: srcFree, Valid: true},
+		ReviewComments:   []byte(`{"comments":[{"id":3}],"truncated":false}`),
+		WaitOnLimit:      false,
+	})
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
+		t.Fatalf("second CreateAutoMRReworkRun (same MR) err = %v, want a 23505 unique violation", err)
+	}
+	if pgErr.ConstraintName != "uq_runs_one_active_mr_rework" {
+		t.Fatalf("same-MR duplicate violated %q, want uq_runs_one_active_mr_rework", pgErr.ConstraintName)
+	}
+}

--- a/api/internal/store/scheduled_mr_state_livedb_test.go
+++ b/api/internal/store/scheduled_mr_state_livedb_test.go
@@ -174,8 +174,9 @@ func TestScheduledBranchConcurrencyGuardsLiveDB(t *testing.T) {
 		srcOccupied, owner, repoID, occupiedBranch, occupiedMR)
 
 	// ── CROSS-KIND branch guard ──
-	// An active ci_fix run occupies the scheduled branch. Its distinct mr_iid=99 means the
-	// ONLY thing blocking the mr_rework insert is the occupied branch, not the same-MR index.
+	// An active ci_fix run occupies the scheduled branch. It carries NO mr_iid (NULL, distinct
+	// from the mr_rework's occupiedMR), so the ONLY thing blocking the mr_rework insert is the
+	// occupied branch (the cross-kind WHERE NOT EXISTS), not the same-MR uniqueness index.
 	mustExec(ctx, t, pool,
 		`INSERT INTO runs (id, user_id, repo_id, kind, issue_title, issue_description, pipeline_id, pipeline_ref, status)
 		 VALUES ($1, $2, $3, 'ci_fix', 't', 'd', 4242, $4, 'running')`,

--- a/api/internal/store/selfimprove.sql.go
+++ b/api/internal/store/selfimprove.sql.go
@@ -34,9 +34,9 @@ func (q *Queries) CountActiveSelfImproveRunsForRepo(ctx context.Context, repoID 
 const createSelfImproveRun = `-- name: CreateSelfImproveRun :one
 
 INSERT INTO runs (
-    user_id, repo_id, kind, issue_iid, issue_title, issue_description, auto_approve, wait_on_limit, model, override_subagent_model, required_capabilities, trigger_source
+    user_id, repo_id, kind, issue_iid, issue_title, issue_description, auto_approve, wait_on_limit, model, override_subagent_model, mr_rework_enabled, required_capabilities, trigger_source
 ) VALUES (
-    $1, $2::uuid, 'self_improve', $3, $4, $5, true, $6, $7, $8,
+    $1, $2::uuid, 'self_improve', $3, $4, $5, true, $6, $7, $8, $9,
     -- required_capabilities (PRD #84 M2, issue #512 M1): a self_improve run is REPO-BEARING
     -- (it targets uzi's own repo, the likeliest to require docker to build/test), so it must
     -- inherit the repo's capability hint like every other repo-bearing path — else with
@@ -56,6 +56,7 @@ type CreateSelfImproveRunParams struct {
 	WaitOnLimit           bool        `json:"wait_on_limit"`
 	Model                 pgtype.Text `json:"model"`
 	OverrideSubagentModel bool        `json:"override_subagent_model"`
+	MrReworkEnabled       pgtype.Bool `json:"mr_rework_enabled"`
 }
 
 // Self-improvement engine (PRD #46 Decisions 9-11, M5) ------------------------
@@ -93,6 +94,9 @@ type CreateSelfImproveRunParams struct {
 // default at claim assembly) and the "apply model also to agents" opt-in
 // (@override_subagent_model, a plain bool). The bespoke engine passes nil/false, freezing
 // NULL/false onto its run exactly as before this column pair was threaded through.
+// mr_rework_enabled (PRD #908 M1): the schedule-driven fire path threads the schedule's
+// per-schedule mr_rework override the same way (sqlc.narg('mr_rework_enabled'), nil =>
+// inherit the owner default live at read time). The bespoke engine passes nil, freezing NULL.
 func (q *Queries) CreateSelfImproveRun(ctx context.Context, arg CreateSelfImproveRunParams) (Run, error) {
 	row := q.db.QueryRow(ctx, createSelfImproveRun,
 		arg.UserID,
@@ -103,6 +107,7 @@ func (q *Queries) CreateSelfImproveRun(ctx context.Context, arg CreateSelfImprov
 		arg.WaitOnLimit,
 		arg.Model,
 		arg.OverrideSubagentModel,
+		arg.MrReworkEnabled,
 	)
 	var i Run
 	err := row.Scan(

--- a/api/internal/uzidocs/embed/ci-autofix.md
+++ b/api/internal/uzidocs/embed/ci-autofix.md
@@ -25,11 +25,14 @@ user from **Admin → Users**, the same pattern as the [run judge](./judge.md).
 ## What triggers it
 
 On the same poll tick that refreshes a repo's pipeline status, uzi checks
-every watched **agent-owned MR branch** (`agent/issue-N`, the branch one of
-your issue runs pushed to). When that branch's latest pipeline is failed and
-you have the toggle on and an Anthropic token configured, uzi queues the
-same `ci_fix` run the **Fix CI** button would — auto-approved, so it skips
-the plan-approval step and starts working right away.
+every watched **agent-owned MR branch** — the branch one of your agent runs
+pushed to: an issue run's `agent/issue-N`, or a [scheduled
+run](./scheduling.md)'s `uzi/prompt-<id>` (an ad-hoc prompt job) or
+`uzi/self-improve/<id>` (self-improvement). When that branch's latest pipeline
+is failed and you have the toggle on and an Anthropic token configured, uzi
+queues the same `ci_fix` run the **Fix CI** button would — auto-approved, so it
+skips the plan-approval step and starts working right away. A scheduled run
+inherits your account-wide opt-in; there is no separate per-schedule switch.
 
 `main`, the repo's default branch, and any non-MR ref are never auto-touched
 — only a branch that is itself the product of one of your agent runs. And
@@ -46,10 +49,11 @@ A persistently red pipeline can't loop forever:
   *same* failure signature as the attempt before it, uzi halts early rather
   than spending a second identical attempt.
 
-Either way, uzi posts one comment on the backing issue (worded differently
-for "hit the attempt limit" than for "no progress") and lands an in-app
-notification, then stops trying automatically — **it does not retry on its
-own**. The manual **Fix CI** button is still there as your escape hatch any
+Either way, uzi lands an in-app notification and, on an issue-run branch, also
+posts one comment on the backing issue (worded differently for "hit the attempt
+limit" than for "no progress"); a scheduled prompt MR has no backing issue, so
+it gets the in-app notification only. uzi then stops trying automatically — **it
+does not retry on its own**. The manual **Fix CI** button is still there as your escape hatch any
 time. The attempt counter only resets once the branch's pipeline actually
 goes green.
 
@@ -71,11 +75,12 @@ hand — the manual button, or an approved CI-config plan — pushes normally.
 ## Notifications
 
 You get an in-app notification when an automatic fix starts, when it halts,
-and when a fix lands (its pipeline goes green and the run is verified). The
-start and halt notifications also post a comment on the backing
-`agent/issue-N` issue. These are in-app and issue-comment only — automatic
-CI-fix events don't currently go out as Slack DMs, unlike some other run
-notifications.
+and when a fix lands (its pipeline goes green and the run is verified). On an
+issue-run branch (`agent/issue-N`) the start and halt notifications also post a
+comment on the backing issue; a scheduled-run branch (`uzi/prompt-<id>`,
+`uzi/self-improve/<id>`) has no such issue, so those events are in-app only.
+These are in-app and issue-comment only — automatic CI-fix events don't
+currently go out as Slack DMs, unlike some other run notifications.
 
 ## Forge support
 

--- a/api/internal/uzidocs/embed/mr-review-watcher.md
+++ b/api/internal/uzidocs/embed/mr-review-watcher.md
@@ -19,8 +19,9 @@ default** for every opted-in user, which is also the default — see
 
 On the same poll tick that already watches a repo's merge requests and
 pipelines, uzi checks every open MR belonging to one of your completed
-issue runs. When all of the following are true, it queues a new
-`mr_rework` run, auto-approved so it starts working right away:
+agent runs — an issue run, or a [scheduled run](./scheduling.md) (an ad-hoc
+`prompt` job or the self-improvement job). When all of the following are true,
+it queues a new `mr_rework` run, auto-approved so it starts working right away:
 
 - the MR's head pipeline is **green**,
 - the review has **settled** (the newest comment is a few minutes old and
@@ -111,7 +112,7 @@ one-time snapshot taken when the run started; there's no live
 per-schedule re-evaluation afterward for reset to fall back to.
 
 One thing worth knowing: the per-run toggle (both the checkbox and the
-CLI verb) always targets a branch's newest issue run, so if a branch gets
+CLI verb) always targets a branch's newest run, so if a branch gets
 reused by a re-run, it's that newest run's setting that decides whether
 the branch's MR gets auto-reworked.
 
@@ -124,9 +125,11 @@ out in Settings.
 
 A merge request can't be reworked forever. uzi tracks, per MR, how many
 automatic rework cycles it has spent and stops after a cap — **5 by
-default**, admin-configurable (`mr_rework_cap`). Past the cap, uzi posts
-one comment on the issue naming the limit and lands an in-app notification,
-then stops trying automatically; it doesn't retry on its own. Addressing
+default**, admin-configurable (`mr_rework_cap`). Past the cap, uzi lands an
+in-app notification and, on an issue-run MR, also posts one comment on the
+issue naming the limit; a scheduled prompt MR has no backing issue, so it gets
+the in-app notification only. uzi then stops trying automatically; it doesn't
+retry on its own. Addressing
 the remaining comments yourself (or pushing more changes to the branch) is
 the escape hatch from there.
 

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -366,6 +366,35 @@ never blocks it, including when the check itself can't reach the forge (an
 expired token, a rate limit, an outage) — it just means the sweep won't match
 anything until the label exists.
 
+## Automatic fixes on scheduled-run MRs
+
+The merge requests a schedule opens — both the **ad-hoc prompt** jobs (docs
+hygiene, test improvement, bug hunt, feature bingo, refactor scout, and any
+custom prompt schedule) and the [self-improvement](#self-improvement) job —
+participate in uzi's two unattended autofix lanes, exactly like the MRs your
+issue runs open:
+
+- **[MR review rework](./mr-review-watcher.md)** folds new review comments on a
+  green, still-open MR back onto the branch. It is **on by default** with a
+  four-layer opt-out; the per-schedule **"Auto-rework MR review comments"**
+  control (a three-way Inherit/On/Off choice in the schedule modal, or
+  `--mr-rework` / `--mr-rework=false` on `uzi schedule create`/`edit` and
+  `--clear-mr-rework` to return to Inherit) is where you turn it off for a given
+  schedule's runs. See [that page's Enablement
+  section](./mr-review-watcher.md#enablement) for the full resolution order.
+- **[Automatic CI fixes](./ci-autofix.md)** react to a failed head pipeline on a
+  scheduled-run MR branch. This lane stays **opt-in, off by default**, on the
+  same account-wide **Settings → Automatic CI fixes** toggle your issue runs use
+  — a scheduled run inherits the owner's opt-in; there is no separate
+  per-schedule switch for it.
+
+Both lanes act only on a **still-open** MR and spend the schedule owner's own
+Anthropic token, the same as any other run. A prompt schedule's MR has no
+backing issue, so the start/halt notices these lanes would post as an issue
+comment on an issue-run MR arrive as an **in-app notification only** for a
+prompt MR; a self-improvement MR's shared tracking issue is likewise left
+untouched.
+
 ## Restarts and missed fires
 
 A recurring schedule survives an api restart: its next fire time is stored,

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -390,10 +390,10 @@ issue runs open:
 
 Both lanes act only on a **still-open** MR and spend the schedule owner's own
 Anthropic token, the same as any other run. A prompt schedule's MR has no
-backing issue, so the start/halt notices these lanes would post as an issue
-comment on an issue-run MR arrive as an **in-app notification only** for a
-prompt MR; a self-improvement MR's shared tracking issue is likewise left
-untouched.
+backing issue, so the notices these lanes post as an issue comment on an
+issue-run MR (ci_autofix's start and halt; mr_rework's per-MR cap halt) arrive
+as an **in-app notification only** for a prompt MR; a self-improvement MR's
+shared tracking issue is likewise left untouched.
 
 ## Restarts and missed fires
 

--- a/api/internal/workersvc/guardrail_test.go
+++ b/api/internal/workersvc/guardrail_test.go
@@ -122,7 +122,7 @@ func TestCreateSelfImproveRunGuardrailBlocksBeforeInsert(t *testing.T) {
 	svc := New(fs, newBox(t), testParams())
 	svc.SetRepoGuard(guard)
 
-	_, err := svc.CreateSelfImproveRun(context.Background(), user, repo, 7, "t", "d", nil, false)
+	_, err := svc.CreateSelfImproveRun(context.Background(), user, repo, 7, "t", "d", nil, nil, false)
 	assertGuardrailBlocked(t, err, wantMsgs)
 	if guard.called != 1 {
 		t.Fatalf("guard called %d times, want 1", guard.called)

--- a/api/internal/workersvc/limitpark_test.go
+++ b/api/internal/workersvc/limitpark_test.go
@@ -968,7 +968,7 @@ func TestPollerCreatedRunsInheritTheOwnerWaitOnLimitDefault(t *testing.T) {
 	t.Run("self_improve", func(t *testing.T) {
 		fs := &fakeStore{userByID: optedIn}
 		svc := New(fs, newBox(t), testParams())
-		if _, err := svc.CreateSelfImproveRun(context.Background(), owner, uuid.New(), 7, "t", "d", nil, false); err != nil {
+		if _, err := svc.CreateSelfImproveRun(context.Background(), owner, uuid.New(), 7, "t", "d", nil, nil, false); err != nil {
 			t.Fatalf("CreateSelfImproveRun: %v", err)
 		}
 		if fs.selfImproveParams == nil || !fs.selfImproveParams.WaitOnLimit {

--- a/api/internal/workersvc/self_improve.go
+++ b/api/internal/workersvc/self_improve.go
@@ -28,7 +28,12 @@ var ErrActiveSelfImproveExists = errors.New("a self-improvement run is already a
 // title/description directly (issue_description carries the accumulated improve_uzi
 // backlog, which the worker frames as untrusted data). A second active run is
 // rejected by the partial unique index → ErrActiveSelfImproveExists.
-func (s *Service) CreateSelfImproveRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, title, description string, model *string, overrideSubagentModel bool) (store.Run, error) {
+//
+// mrReworkEnabled threads the schedule's per-schedule mr_rework override (PRD #908),
+// same shape as the model override: nil ⇒ NULL ⇒ the run inherits the owner default
+// live at read time; true/false stamp an explicit per-run override. The bespoke engine
+// passes nil.
+func (s *Service) CreateSelfImproveRun(ctx context.Context, userID, repoID uuid.UUID, issueIID int64, title, description string, mrReworkEnabled *bool, model *string, overrideSubagentModel bool) (store.Run, error) {
 	row, err := s.q.GetRepoForUser(ctx, store.GetRepoForUserParams{ID: repoID, UserID: userID})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -55,6 +60,9 @@ func (s *Service) CreateSelfImproveRun(ctx context.Context, userID, repoID uuid.
 		// nil/false, freezing NULL/false onto its run exactly as before.
 		Model:                 pgconv.TextPtr(model),
 		OverrideSubagentModel: overrideSubagentModel,
+		// PRD #908 M1: the schedule's mr_rework override, stamped THROUGH live-inherit —
+		// nil ⇒ NULL ⇒ the run follows the owner default at read time.
+		MrReworkEnabled: pgconv.BoolPtr(mrReworkEnabled),
 	})
 	if err != nil {
 		if isUniqueViolation(err) {

--- a/docs/ci-autofix.md
+++ b/docs/ci-autofix.md
@@ -25,11 +25,14 @@ user from **Admin → Users**, the same pattern as the [run judge](./judge.md).
 ## What triggers it
 
 On the same poll tick that refreshes a repo's pipeline status, uzi checks
-every watched **agent-owned MR branch** (`agent/issue-N`, the branch one of
-your issue runs pushed to). When that branch's latest pipeline is failed and
-you have the toggle on and an Anthropic token configured, uzi queues the
-same `ci_fix` run the **Fix CI** button would — auto-approved, so it skips
-the plan-approval step and starts working right away.
+every watched **agent-owned MR branch** — the branch one of your agent runs
+pushed to: an issue run's `agent/issue-N`, or a [scheduled
+run](./scheduling.md)'s `uzi/prompt-<id>` (an ad-hoc prompt job) or
+`uzi/self-improve/<id>` (self-improvement). When that branch's latest pipeline
+is failed and you have the toggle on and an Anthropic token configured, uzi
+queues the same `ci_fix` run the **Fix CI** button would — auto-approved, so it
+skips the plan-approval step and starts working right away. A scheduled run
+inherits your account-wide opt-in; there is no separate per-schedule switch.
 
 `main`, the repo's default branch, and any non-MR ref are never auto-touched
 — only a branch that is itself the product of one of your agent runs. And
@@ -46,10 +49,11 @@ A persistently red pipeline can't loop forever:
   *same* failure signature as the attempt before it, uzi halts early rather
   than spending a second identical attempt.
 
-Either way, uzi posts one comment on the backing issue (worded differently
-for "hit the attempt limit" than for "no progress") and lands an in-app
-notification, then stops trying automatically — **it does not retry on its
-own**. The manual **Fix CI** button is still there as your escape hatch any
+Either way, uzi lands an in-app notification and, on an issue-run branch, also
+posts one comment on the backing issue (worded differently for "hit the attempt
+limit" than for "no progress"); a scheduled prompt MR has no backing issue, so
+it gets the in-app notification only. uzi then stops trying automatically — **it
+does not retry on its own**. The manual **Fix CI** button is still there as your escape hatch any
 time. The attempt counter only resets once the branch's pipeline actually
 goes green.
 
@@ -71,11 +75,12 @@ hand — the manual button, or an approved CI-config plan — pushes normally.
 ## Notifications
 
 You get an in-app notification when an automatic fix starts, when it halts,
-and when a fix lands (its pipeline goes green and the run is verified). The
-start and halt notifications also post a comment on the backing
-`agent/issue-N` issue. These are in-app and issue-comment only — automatic
-CI-fix events don't currently go out as Slack DMs, unlike some other run
-notifications.
+and when a fix lands (its pipeline goes green and the run is verified). On an
+issue-run branch (`agent/issue-N`) the start and halt notifications also post a
+comment on the backing issue; a scheduled-run branch (`uzi/prompt-<id>`,
+`uzi/self-improve/<id>`) has no such issue, so those events are in-app only.
+These are in-app and issue-comment only — automatic CI-fix events don't
+currently go out as Slack DMs, unlike some other run notifications.
 
 ## Forge support
 

--- a/docs/mr-review-watcher.md
+++ b/docs/mr-review-watcher.md
@@ -19,8 +19,9 @@ default** for every opted-in user, which is also the default — see
 
 On the same poll tick that already watches a repo's merge requests and
 pipelines, uzi checks every open MR belonging to one of your completed
-issue runs. When all of the following are true, it queues a new
-`mr_rework` run, auto-approved so it starts working right away:
+agent runs — an issue run, or a [scheduled run](./scheduling.md) (an ad-hoc
+`prompt` job or the self-improvement job). When all of the following are true,
+it queues a new `mr_rework` run, auto-approved so it starts working right away:
 
 - the MR's head pipeline is **green**,
 - the review has **settled** (the newest comment is a few minutes old and
@@ -111,7 +112,7 @@ one-time snapshot taken when the run started; there's no live
 per-schedule re-evaluation afterward for reset to fall back to.
 
 One thing worth knowing: the per-run toggle (both the checkbox and the
-CLI verb) always targets a branch's newest issue run, so if a branch gets
+CLI verb) always targets a branch's newest run, so if a branch gets
 reused by a re-run, it's that newest run's setting that decides whether
 the branch's MR gets auto-reworked.
 
@@ -124,9 +125,11 @@ out in Settings.
 
 A merge request can't be reworked forever. uzi tracks, per MR, how many
 automatic rework cycles it has spent and stops after a cap — **5 by
-default**, admin-configurable (`mr_rework_cap`). Past the cap, uzi posts
-one comment on the issue naming the limit and lands an in-app notification,
-then stops trying automatically; it doesn't retry on its own. Addressing
+default**, admin-configurable (`mr_rework_cap`). Past the cap, uzi lands an
+in-app notification and, on an issue-run MR, also posts one comment on the
+issue naming the limit; a scheduled prompt MR has no backing issue, so it gets
+the in-app notification only. uzi then stops trying automatically; it doesn't
+retry on its own. Addressing
 the remaining comments yourself (or pushing more changes to the branch) is
 the escape hatch from there.
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -366,6 +366,35 @@ never blocks it, including when the check itself can't reach the forge (an
 expired token, a rate limit, an outage) — it just means the sweep won't match
 anything until the label exists.
 
+## Automatic fixes on scheduled-run MRs
+
+The merge requests a schedule opens — both the **ad-hoc prompt** jobs (docs
+hygiene, test improvement, bug hunt, feature bingo, refactor scout, and any
+custom prompt schedule) and the [self-improvement](#self-improvement) job —
+participate in uzi's two unattended autofix lanes, exactly like the MRs your
+issue runs open:
+
+- **[MR review rework](./mr-review-watcher.md)** folds new review comments on a
+  green, still-open MR back onto the branch. It is **on by default** with a
+  four-layer opt-out; the per-schedule **"Auto-rework MR review comments"**
+  control (a three-way Inherit/On/Off choice in the schedule modal, or
+  `--mr-rework` / `--mr-rework=false` on `uzi schedule create`/`edit` and
+  `--clear-mr-rework` to return to Inherit) is where you turn it off for a given
+  schedule's runs. See [that page's Enablement
+  section](./mr-review-watcher.md#enablement) for the full resolution order.
+- **[Automatic CI fixes](./ci-autofix.md)** react to a failed head pipeline on a
+  scheduled-run MR branch. This lane stays **opt-in, off by default**, on the
+  same account-wide **Settings → Automatic CI fixes** toggle your issue runs use
+  — a scheduled run inherits the owner's opt-in; there is no separate
+  per-schedule switch for it.
+
+Both lanes act only on a **still-open** MR and spend the schedule owner's own
+Anthropic token, the same as any other run. A prompt schedule's MR has no
+backing issue, so the start/halt notices these lanes would post as an issue
+comment on an issue-run MR arrive as an **in-app notification only** for a
+prompt MR; a self-improvement MR's shared tracking issue is likewise left
+untouched.
+
 ## Restarts and missed fires
 
 A recurring schedule survives an api restart: its next fire time is stored,

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -390,10 +390,10 @@ issue runs open:
 
 Both lanes act only on a **still-open** MR and spend the schedule owner's own
 Anthropic token, the same as any other run. A prompt schedule's MR has no
-backing issue, so the start/halt notices these lanes would post as an issue
-comment on an issue-run MR arrive as an **in-app notification only** for a
-prompt MR; a self-improvement MR's shared tracking issue is likewise left
-untouched.
+backing issue, so the notices these lanes post as an issue comment on an
+issue-run MR (ci_autofix's start and halt; mr_rework's per-MR cap halt) arrive
+as an **in-app notification only** for a prompt MR; a self-improvement MR's
+shared tracking issue is likewise left untouched.
 
 ## Restarts and missed fires
 

--- a/prds/done/908-mr-rework-scheduled-runs-design.md
+++ b/prds/done/908-mr-rework-scheduled-runs-design.md
@@ -2,7 +2,7 @@
 
 > Anchors re-verified against main at fcfd8aa on 2026-09-03, after the epic #915 file splits and the pgconv consolidation.
 
-**Status**: Proposed (design for review) — companion to `prds/908-mr-rework-scheduled-runs.md`
+**Status**: Implemented — companion to `prds/done/908-mr-rework-scheduled-runs.md`
 **Author**: architect
 **Scope**: `api/` + `docs/` only. **No `agent/` change, no `web/` code change, no new migration.**
 

--- a/prds/done/908-mr-rework-scheduled-runs.md
+++ b/prds/done/908-mr-rework-scheduled-runs.md
@@ -3,9 +3,11 @@
 > Anchors re-verified against main at fcfd8aa on 2026-09-03, after the epic #915 file splits and the pgconv consolidation.
 
 **Issue**: #908
-**Status**: Draft — ready for implementation
+**Status**: Implemented (api/ + docs/ landed; offline + `*LiveDB` validation green). The
+one-per-lane **live-forge** end-to-end is the post-merge acceptance step, outside the branch
+diff by design (see the workflow-scope note) — not run in-branch.
 **Priority**: Medium
-**Design companion**: `prds/908-mr-rework-scheduled-runs-design.md` (the board-free recorder decision, mechanism, contracts, and risks — read it for the MR-rework half's deep design).
+**Design companion**: `prds/done/908-mr-rework-scheduled-runs-design.md` (the board-free recorder decision, mechanism, contracts, and risks — read it for the MR-rework half's deep design).
 **Related**: #914 — CI autofix on by default (split out from this PRD's former Part B). The two share edits to `ci_autofix.sql` (this PRD's M4 widens its kind filter; #914 changes its user gate), so land #914 **after** this one to avoid a conflict.
 **Scope**: `api/` + `docs/` only. No `agent/` change, no `web/` code change, **no new migration**.
 
@@ -114,21 +116,21 @@ invariant reasoning are in the companion §1.
 Dependency-ordered. **Offline** = unit-testable with in-memory fakes. **LiveDB** = needs
 `./e2e/run-store-it.sh`. **Live forge** = end-to-end against a real MR (post-merge validation).
 
-- [ ] **M1 — Thread the per-schedule mr-rework toggle through self_improve.** *(Offline; mr_rework)*
+- [x] **M1 — Thread the per-schedule mr-rework toggle through self_improve.** *(Offline; mr_rework)*
   Add an `mrReworkEnabled *bool` param to `CreateSelfImproveRun` (`workersvc/self_improve.go`),
   add `mr_rework_enabled = sqlc.narg('mr_rework_enabled')` to the `selfimprove.sql` INSERT, extend
   the `schedsvc` interface signature (`scheduler.go:127`) and its test fake
   (`scheduler_test.go:343`), and pass `scheduleMrRework(sched)` at the fire site
   (`schedsvc/self_improve.go:189`) — mirroring the prompt path. Regenerate sqlc.
 
-- [ ] **M2 — Decouple both detectors from `agent/issue-N`.** *(Offline; both lanes)*
+- [x] **M2 — Decouple both detectors from `agent/issue-N`.** *(Offline; both lanes)*
   In `poller/mr_review_watch.go` and `poller/ci_autofix.go`, stop returning early when
   `issueIIDFromBranch(ref)` fails. Make every issue-comment post conditional on the branch
   parsing to an issue IID (mr_rework cap-halt `:250`; ci_autofix start `:268` + halt `:224`);
   otherwise skip the comment and keep the inbox notification (`notifyHalt` tolerating a zero IID).
   Issue-run behavior is unchanged (the `agent/issue-N` parse still succeeds and still comments).
 
-- [ ] **M3 — Board-free scheduled MR-state recorder.** *(Offline + LiveDB; mr_rework)*
+- [x] **M3 — Board-free scheduled MR-state recorder.** *(Offline + LiveDB; mr_rework)*
   Add `ListScheduledMRStateWatchCandidates` (runs-only, `kind IN ('prompt','self_improve')`,
   `status='completed'`, `mr_iid` set, `mr_state` non-terminal, no issues JOIN, no `DISTINCT ON`,
   `LIMIT 100`) to `forge.sql`. Add `forgesvc.SyncScheduledMRStates(ctx, repoID, forgeProjectID,
@@ -139,7 +141,7 @@ Dependency-ordered. **Offline** = unit-testable with in-memory fakes. **LiveDB**
   disjoint run sets" (wording only — `TestMRStateIsWatcherOwned` still passes). See companion §3–§4
   for the exact contract and the differential-test requirement.
 
-- [ ] **M4 — Widen both candidate-query kind filters.** *(Offline build; LiveDB to validate)*
+- [x] **M4 — Widen both candidate-query kind filters.** *(Offline build; LiveDB to validate)*
   `ListMRReworkCandidates` (`mr_rework.sql`): `r.kind = 'issue'` → `r.kind IN
   ('issue','prompt','self_improve')`, keeping `mr_state='opened'` and `DISTINCT ON (r.branch)`.
   `ListCIAutofixCandidateRefs` (`ci_autofix.sql`): `r.kind IN ('issue','ci_fix')` → add
@@ -148,7 +150,7 @@ Dependency-ordered. **Offline** = unit-testable with in-memory fakes. **LiveDB**
   the `CreateAutoMRReworkRun` "pipeline_ref = agent/issue-N" comment (now any agent branch).
   Regenerate sqlc and confirm the generated consts moved.
 
-- [ ] **M5 — Tests.** *(LiveDB + live forge)*
+- [x] **M5 — Tests.** *(LiveDB done in-branch; live forge is the post-merge step)*
   Recorder differential/mirror contract vs `syncOneMRState` (companion §4: seven fixture cases,
   each proven exercised), incl. the R1 no-board-move guard (a self_improve run the recorder marks
   `closed`, with a cached tracking issue, produces zero `AutoMove`). Detector decoupling for both
@@ -159,7 +161,7 @@ Dependency-ordered. **Offline** = unit-testable with in-memory fakes. **LiveDB**
   per-MR uniqueness hold for the new branches. One live-forge end-to-end per lane (a landed review
   comment → rework; a red pipeline → ci_fix), and the mr_rework schedule toggle Off suppressing it.
 
-- [ ] **M6 — Docs.** *(Offline)*
+- [x] **M6 — Docs.** *(Offline)*
   Update `docs/scheduling.md`: prompt and self_improve MRs now participate in both autofix lanes;
   mr_rework default-on with the four-layer opt-out (per-schedule toggle in the web ScheduleModal +
   CLI `--mr-rework`), ci_autofix user opt-in default-off. `npm run build`'s `check-docs.mjs` passes.


### PR DESCRIPTION
Implements issue #908.

Closes #908

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-908`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scheduled prompt and self-improvement merge requests now support automatic review rework and CI fixes.
  - Added per-schedule controls for merge-request rework, including inherited defaults.
  - Scheduled merge-request state changes are tracked automatically.
  - Scheduled runs receive in-app notifications without issue comments when no issue is associated.

- **Bug Fixes**
  - Scheduled merge requests are excluded from board-coupled monitoring while remaining eligible for state tracking and automation.

- **Documentation**
  - Updated guidance for scheduled merge-request automation, notifications, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->