### PR TITLE
judge-runner extractJsonObject: scan later balanced candidates when the first brace object fails to parse

### DIFF
--- a/agent/src/judge-runner.ts
+++ b/agent/src/judge-runner.ts
@@ -547,19 +547,37 @@ export function calibrateReview(review: ReviewRequest, failureClass: string | nu
   return { ...review, recommendations };
 }
 
-// extractJsonObject pulls the first balanced {...} object out of the model text
-// (tolerating a ```json fence or surrounding prose). Exported for reuse by the inline
-// summary runner (PRD #362 M3a), which parses the same fenced/prose-wrapped JSON shape.
+// extractJsonObject pulls a balanced {...} object out of the model text (tolerating a
+// ```json fence or surrounding prose). Exported for reuse by the inline summary runner
+// (PRD #362 M3a) and the task review runner, which parse the same fenced/prose-wrapped
+// JSON shape. The FIRST balanced candidate is not always the JSON: a brace example in
+// prose before it (e.g. `Use {verdict, summary} here`, possibly inside the fence) slices
+// first but does not parse. So on a JSON.parse failure we advance past that candidate and
+// try the next one, keeping the throw (→ caller's deterministic fallback) only when no
+// balanced candidate parses.
 export function extractJsonObject(text: string): unknown {
   const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
   const inner = fence ? fence[1]! : text;
-  const candidate = sliceFirstObject(inner);
-  if (!candidate) throw new Error("no JSON object found in the model output");
-  return JSON.parse(candidate);
+  let from = 0;
+  let sawCandidate = false;
+  let lastErr: unknown;
+  for (;;) {
+    const candidate = sliceFirstObject(inner, from);
+    if (!candidate) break;
+    sawCandidate = true;
+    try {
+      return JSON.parse(candidate.slice);
+    } catch (err) {
+      lastErr = err;
+      from = candidate.start + 1; // skip this '{' and look for the next balanced candidate
+    }
+  }
+  if (!sawCandidate) throw new Error("no JSON object found in the model output");
+  throw new Error(`no parseable JSON object found in the model output: ${errMessage(lastErr)}`);
 }
 
-function sliceFirstObject(text: string): string | null {
-  const start = text.indexOf("{");
+function sliceFirstObject(text: string, from = 0): { start: number; slice: string } | null {
+  const start = text.indexOf("{", from);
   if (start < 0) return null;
   let depth = 0;
   let inStr = false;
@@ -576,7 +594,7 @@ function sliceFirstObject(text: string): string | null {
     else if (c === "{") depth++;
     else if (c === "}") {
       depth--;
-      if (depth === 0) return text.slice(start, i + 1);
+      if (depth === 0) return { start, slice: text.slice(start, i + 1) };
     }
   }
   return null;

--- a/agent/src/judge-runner.ts
+++ b/agent/src/judge-runner.ts
@@ -552,8 +552,9 @@ export function calibrateReview(review: ReviewRequest, failureClass: string | nu
 // (PRD #362 M3a) and the task review runner, which parse the same fenced/prose-wrapped
 // JSON shape. The FIRST balanced candidate is not always the JSON: a brace example in
 // prose before it (e.g. `Use {verdict, summary} here`, possibly inside the fence) slices
-// first but does not parse. So on a JSON.parse failure we advance past that candidate and
-// try the next one, keeping the throw (→ caller's deterministic fallback) only when no
+// first but does not parse. So on a JSON.parse failure we advance past that WHOLE candidate
+// (not just its opening brace, which would re-enter a valid object nested inside the bad one)
+// and try the next one, keeping the throw (→ caller's deterministic fallback) only when no
 // balanced candidate parses.
 export function extractJsonObject(text: string): unknown {
   const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
@@ -569,7 +570,10 @@ export function extractJsonObject(text: string): unknown {
       return JSON.parse(candidate.slice);
     } catch (err) {
       lastErr = err;
-      from = candidate.start + 1; // skip this '{' and look for the next balanced candidate
+      // Skip the ENTIRE rejected candidate, not just its opening '{': candidate.start +
+      // candidate.slice.length is the offset one past its closing brace, so a valid object
+      // NESTED inside the rejected one is not mistaken for the real later JSON.
+      from = candidate.start + candidate.slice.length;
     }
   }
   if (!sawCandidate) throw new Error("no JSON object found in the model output");

--- a/agent/test/judge-runner.test.ts
+++ b/agent/test/judge-runner.test.ts
@@ -386,6 +386,18 @@ describe("parseReview", () => {
     assert.equal(r.verdict, "ok");
   });
 
+  it("skips a malformed candidate that CONTAINS a nested valid object, then parses the real JSON", () => {
+    // The first balanced candidate is malformed (unquoted `example:`) yet contains a nested
+    // valid object. Advancing past the whole rejected candidate (not just its '{') must skip
+    // that nested object and reach the real, later JSON — otherwise the wrong verdict wins.
+    const text =
+      'Use {example: {"verdict":"ok","summary":"wrong","recommendations":[]}} here\n' +
+      '{"verdict":"issues","summary":"right","recommendations":[]}';
+    const r = parseReview(text, "haiku");
+    assert.equal(r.verdict, "issues");
+    assert.equal(r.summary, "right");
+  });
+
   it("parses JSON embedded in prose and drops unknown categories", () => {
     const text =
       'Here is my assessment: {"verdict":"issues","summary":"s","recommendations":[' +

--- a/agent/test/judge-runner.test.ts
+++ b/agent/test/judge-runner.test.ts
@@ -373,6 +373,19 @@ describe("parseReview", () => {
     assert.equal(r.verdict, "ok");
   });
 
+  it("skips a brace example in prose before the real JSON (scans later candidates)", () => {
+    const text = 'Use {verdict, summary} here\n{"verdict":"ok","summary":"s","recommendations":[]}';
+    const r = parseReview(text, "haiku");
+    assert.equal(r.verdict, "ok");
+  });
+
+  it("skips a brace example inside the fence before the real JSON", () => {
+    const text =
+      '```json\nUse {verdict, summary} here\n{"verdict":"ok","summary":"s","recommendations":[]}\n```';
+    const r = parseReview(text, "haiku");
+    assert.equal(r.verdict, "ok");
+  });
+
   it("parses JSON embedded in prose and drops unknown categories", () => {
     const text =
       'Here is my assessment: {"verdict":"issues","summary":"s","recommendations":[' +

--- a/agent/test/review-runner.test.ts
+++ b/agent/test/review-runner.test.ts
@@ -232,6 +232,16 @@ describe("parseTaskReview", () => {
     assert.equal(review.summary, "s");
   });
 
+  it("skips a brace example in prose before the real JSON (scans later candidates)", () => {
+    const text =
+      "Use {file, severity} here.\n" +
+      JSON.stringify({ summary: "s", findings: [{ file: "a.ts", severity: "warning", summary: "x", rationale: "y" }] });
+    const review = parseTaskReview(text);
+    assert.equal(review.summary, "s");
+    assert.equal(review.findings.length, 1);
+    assert.equal(review.findings[0]?.file, "a.ts");
+  });
+
   it("throws on output with no JSON object", () => {
     assert.throws(() => parseTaskReview("nothing here"));
   });

--- a/agent/test/summary-runner.test.ts
+++ b/agent/test/summary-runner.test.ts
@@ -149,6 +149,17 @@ describe("SummaryRunner.generatePlanSummary", () => {
     );
   });
 
+  it("skips a brace example in prose before the real JSON (scans later candidates)", async () => {
+    const json = JSON.stringify({ summary: "Plan looks fine.", deltas: [{ kind: "added", text: "a change" }] });
+    const { runner } = await makeRunner(
+      replyingQueryFn("Use {summary, deltas} here.\n```json\n" + json + "\n```"),
+    );
+    const out = await runner.generatePlanSummary(planInput);
+    assert.ok(out);
+    assert.equal(out.summary, "Plan looks fine.");
+    assert.deepEqual(out.deltas, [{ kind: "added", text: "a change" }]);
+  });
+
   it("degrades a non-array deltas to an empty list, keeping the summary", async () => {
     const json = JSON.stringify({ summary: "Plan looks fine.", deltas: "nope" });
     const { runner } = await makeRunner(replyingQueryFn(json));

--- a/agent/test/summary-runner.test.ts
+++ b/agent/test/summary-runner.test.ts
@@ -152,7 +152,7 @@ describe("SummaryRunner.generatePlanSummary", () => {
   it("skips a brace example in prose before the real JSON (scans later candidates)", async () => {
     const json = JSON.stringify({ summary: "Plan looks fine.", deltas: [{ kind: "added", text: "a change" }] });
     const { runner } = await makeRunner(
-      replyingQueryFn("Use {summary, deltas} here.\n```json\n" + json + "\n```"),
+      replyingQueryFn("```json\nUse {summary, deltas} here.\n" + json + "\n```"),
     );
     const out = await runner.generatePlanSummary(planInput);
     assert.ok(out);


### PR DESCRIPTION
Implements issue #911.

Closes #911

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-911`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review and summary parsing when responses include brace-like examples or malformed JSON before the valid result.
  * The system now continues searching for later valid JSON instead of failing on the first invalid candidate.

* **Tests**
  * Added coverage for prose and fenced responses containing misleading brace-like content before valid JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->