### PR TITLE
bug: Schedule.next_fires is string[] but wire sends null for once-schedules (guard 2 index sites, widen type, drop the deferred @ts-expect-error #982)

### DIFF
--- a/fixtures/api-contract/README.md
+++ b/fixtures/api-contract/README.md
@@ -95,9 +95,10 @@ the directive — the same-line caveat M1 documents for `_runExtra`.
 | `Worker` / `AdminWorker` | `docker?: boolean` | `boolPtrValue(w.DockerEnabled)` is nil for an EXTERNAL worker (`handler/workers.go:120` / `:169`) | `error TS2322: Type '{ … docker: null; … }' is not assignable to type 'ZeroOf<Worker, "capabilities">'. Types of property 'docker' are incompatible.` |
 | `Schedule` | `next_fires: string[]` | the mapper only sets `NextFires` for a recurring+valid-cron schedule (`handler/schedules_dto.go:125-126`); a once schedule leaves it nil (→ `null`) | `error TS2322: Type '{ … next_fires: null; … }' is not assignable to type 'ZeroOf<Schedule, "override_subagent_model">'. Types of property 'next_fires' are incompatible.` |
 
-M4 reconciliation (type-only): `Worker.docker` → `docker?: boolean | null`; `Schedule.next_fires`
-→ `next_fires: string[] | null` (or, out of scope for a type-only PRD, the Go mapper normalizes
-`next_fires` to `[]`).
+M4 reconciliation (type-only): `Worker.docker` → `docker?: boolean | null`. `Schedule.next_fires`
+was reconciled later by issue #1003: the type widened `string[]` → `string[] | null` and both
+`next_fires[0]` index sites (`components/DefaultJobs.tsx:400`, `pages/Schedules.tsx:1014`) were
+guarded with `?.`, so its `@ts-expect-error` is gone.
 
 M3 adds the handler-package hot set (the DTOs are UNEXPORTED, served by cookie-only
 routes, so their Go half is `api/internal/handler/contract_test.go`, an in-package test):
@@ -194,14 +195,12 @@ cli-tokens` CLI; the web's `CliTokens.tsx` reads the per-user `GET /me/cli-token
 `CliToken`). So `AdminCliToken` was added for the contract pin, no production fetch changed,
 and no mock fixture needed editing.
 
-**The `next_fires` directive is the ONE that REMAINS** (every other `@ts-expect-error #982`
-is gone). `Schedule.next_fires` is `null` on the wire for a once/invalid-cron schedule, but
-widening `string[]` → `string[] | null` would surface two UNGUARDED `next_fires[0]` index
-sites (`DefaultJobs.tsx:383`, `Schedules.tsx:855`) as a red gate — a latent
-crash-on-once-schedule. That is a BEHAVIOUR fix that needs its own regression test (filed as
-its own bug), out of scope for this type-only PRD, so its directive stays with a reason
-naming the deferral. `Worker.docker` was reconciled (no unguarded index site), so only
-`next_fires` remains.
+**The `next_fires` directive has since been reconciled by issue #1003** (every `@ts-expect-error #982`
+is now gone). `Schedule.next_fires` is `null` on the wire for a once/invalid-cron schedule; #1003
+widened `string[]` → `string[] | null` and guarded both `next_fires[0]` index sites
+(`components/DefaultJobs.tsx:400`, `pages/Schedules.tsx:1014`) with `?.`, adding a render
+regression test per site so the crash-on-once-schedule can't return. `Worker.docker` was
+reconciled in M4 (no unguarded index site).
 
 ## What the TS half pins (three compile-time assertions per DTO)
 

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -23621,16 +23621,15 @@ the exemption table, what the contract cannot catch).
   retyped). A field-anchored grep over `web/src` found **zero** consumer hits for the 7 `Run` fields
   and `selector_kind`, so the reconciliation is purely additive; the two `docker` consumers already
   read `w.docker === true`, which is null-safe. Every `@ts-expect-error #982` directive this landed
-  is now gone except one.
-- **`Schedule.next_fires` is the one directive left, deliberately deferred, not reconciled.** The wire
-  sends `null` for a once/invalid-cron schedule (the mapper only sets `NextFires` for
-  recurring+valid-cron), so the TS type is drifted the same way `docker` was — but widening
-  `next_fires: string[]` to `string[] | null` surfaces two **unguarded** `next_fires[0]` index sites
-  (`DefaultJobs.tsx:383`, `Schedules.tsx:855`) as a red gate: a latent crash-on-once-schedule. That is
-  a **behaviour** fix needing its own regression test, out of scope for a type-only PRD, so it was
-  filed as its own bug and the directive stays, its reason rewritten to name the deferral rather than
-  "reconciled in M4". Do not read this PRD as having closed `next_fires` — it is the one documented
-  exception.
+  is now gone. (AI-synced 2026-09-05: the last one, `next_fires`, was reconciled by issue #1003; see below.)
+- **`Schedule.next_fires` was the one directive #982 deliberately deferred; issue #1003 reconciled it
+  (AI-synced 2026-09-05).** The wire sends `null` for a once/invalid-cron schedule (the mapper only
+  sets `NextFires` for recurring+valid-cron), so the TS type drifted the same way `docker` did. #982
+  left it because widening `next_fires: string[]` to `string[] | null` surfaced two **unguarded**
+  `next_fires[0]` index sites (a latent crash-on-once-schedule) — a **behaviour** fix out of scope for
+  a type-only PRD. #1003 widened the type to `string[] | null` and guarded both sites with `?.`
+  (`components/DefaultJobs.tsx:400`, `pages/Schedules.tsx:1014`), removed the `@ts-expect-error #982`
+  directive, and added failing-first render regression tests for the `next_fires: null` payload.
 
 Cross-refs: `fixtures/run-usage`/`fixtures/judge-fidelity` precedent for the differential-fixture shape
 and the "recorded, not authored, no `-update` flag" house rule (`.claude/rules/go.md`); PRD #700 MR

--- a/web/src/components/DefaultJobs.test.tsx
+++ b/web/src/components/DefaultJobs.test.tsx
@@ -434,3 +434,19 @@ describe("DefaultJobs — pause-all Next-run note (PRD #1093)", () => {
     expect(screen.queryByText(/paused until/)).toBeNull();
   });
 });
+
+// issue #1003: a once/invalid-cron schedule ships `next_fires: null` on the wire, and the
+// SubRow's `s.next_fires?.[0]` nextFire read (DefaultJobs.tsx:400) must not crash on it.
+describe("DefaultJobs — next_fires null (issue #1003)", () => {
+  it("renders a sub-row whose schedule has next_fires: null without crashing", () => {
+    renderTab({
+      schedules: [defRow({ id: "sch-uzi", repo_id: "repo-uzi", repo_path: "vtmocanu/uzi", next_fires: null })],
+    });
+    // Expand the group so its per-repo SubRow mounts (children render only while expanded),
+    // which is what exercises the DefaultJobs.tsx:400 nextFire read on a null next_fires.
+    fireEvent.click(screen.getByRole("button", { name: "Show repos for Bug triage sweep" }));
+    // The SubRow mounted (its per-repo Run-now action carries the repo path), which means the
+    // DefaultJobs.tsx:400 nextFire read ran on a null next_fires without throwing.
+    expect(screen.getByRole("button", { name: "Run now on vtmocanu/uzi" })).toBeTruthy();
+  });
+});

--- a/web/src/components/DefaultJobs.tsx
+++ b/web/src/components/DefaultJobs.tsx
@@ -397,7 +397,7 @@ function SubRow({
 }) {
   const demo = useDemoMode();
   const repoPath = maskRepoPath(s.repo_path, demo);
-  const nextFire = s.next_fires[0] ?? s.next_fire_at;
+  const nextFire = s.next_fires?.[0] ?? s.next_fire_at;
   const [expanded, setExpanded] = useState(false);
   const panelId = `last-fire-${s.id}`;
   return (

--- a/web/src/lib/apiContract.test.ts
+++ b/web/src/lib/apiContract.test.ts
@@ -199,19 +199,15 @@ type ZeroOf<T, NeverNull extends keyof T = never> = {
 // sets (handler/schedules.go:1598-1600, "plain bool column ... so always set it"),
 // so the wire is a real boolean though the *bool zero marshals null.
 //
-// 🔴 DISCOVERED DRIFT (not in the M2 plan): schedule.next_fires. The mapper only sets
-// NextFires for a recurring schedule with a valid cron (handler/schedules.go:1612-1614);
-// a once (or invalid-cron) schedule leaves it nil, so the wire emits `null`, but TS
-// types it `next_fires: string[]` (never-null). This is the ONE directive M4 deliberately
-// KEEPS (every other #982 directive is removed): widening to `string[] | null` would
-// surface two UNGUARDED `next_fires[0]` index sites (DefaultJobs.tsx / Schedules.tsx) as a
-// red gate — a latent crash-on-once-schedule that is a BEHAVIOUR fix needing its own
-// regression test (filed as its own bug), out of scope for this type-only PRD. labels is
-// already typed `string[] | null` in TS, so it needs NO exemption.
+// schedule.next_fires reconciliation (issue #1003): the mapper only sets NextFires for a
+// recurring schedule with a valid cron (handler/schedules.go:1612-1614); a once (or
+// invalid-cron) schedule leaves it nil, so the wire emits `null`. The type is now widened
+// to `string[] | null` and both `next_fires[0]` index sites (components/DefaultJobs.tsx,
+// pages/Schedules.tsx) are guarded with `?.`, so `_scheduleZero` type-checks positively
+// against the fixture with no directive. labels is likewise typed `string[] | null`.
 {
   const _scheduleMissing: never = null as unknown as Exclude<keyof Schedule, keyof typeof scheduleFull>;
   const _scheduleExtra: never = null as unknown as Exclude<keyof typeof scheduleFull, keyof Schedule>;
-  // @ts-expect-error #982: next_fires is null on the wire for once/invalid-cron schedules; widening to string[] | null is deferred to its own bug (two unguarded next_fires[0] index sites, DefaultJobs.tsx / Schedules.tsx, would crash — a behaviour fix with a regression test, not this type-only PRD)
   const _scheduleZero: ZeroOf<Schedule, "override_subagent_model"> = scheduleZero;
   const _scheduleFull: Widen<Schedule> = scheduleFull;
   void _scheduleMissing;

--- a/web/src/lib/apiContract.test.ts
+++ b/web/src/lib/apiContract.test.ts
@@ -200,7 +200,7 @@ type ZeroOf<T, NeverNull extends keyof T = never> = {
 // so the wire is a real boolean though the *bool zero marshals null.
 //
 // schedule.next_fires reconciliation (issue #1003): the mapper only sets NextFires for a
-// recurring schedule with a valid cron (handler/schedules.go:1612-1614); a once (or
+// recurring schedule with a valid cron (handler/schedules_dto.go:125-126); a once (or
 // invalid-cron) schedule leaves it nil, so the wire emits `null`. The type is now widened
 // to `string[] | null` and both `next_fires[0]` index sites (components/DefaultJobs.tsx,
 // pages/Schedules.tsx) are guarded with `?.`, so `_scheduleZero` type-checks positively

--- a/web/src/lib/apiTypes.ts
+++ b/web/src/lib/apiTypes.ts
@@ -1359,7 +1359,7 @@ export interface Schedule {
   updated_at: string;
   // The live "next N fires" preview (up to 3), computed server-side from the same
   // cron logic the modal preview uses so the list and the modal agree.
-  next_fires: string[];
+  next_fires: string[] | null;
 }
 
 // A schedule's provenance (PRD #589): owner-authored vs enabled from the catalog.

--- a/web/src/pages/Schedules.test.tsx
+++ b/web/src/pages/Schedules.test.tsx
@@ -126,6 +126,24 @@ describe("Schedules list", () => {
     expect(screen.getByText("paused")).toBeTruthy();
   });
 
+  it("renders a sibling sub-row whose next_fires is null without crashing (issue #1003)", async () => {
+    // A once/invalid-cron schedule ships `next_fires: null` on the wire. The per-repo
+    // sibling sub-row (MyScheduleSubRow, Schedules.tsx:1014) reads `s.next_fires?.[0]` and
+    // must tolerate it. Two siblings sharing a group id form the expandable group whose
+    // expansion mounts that sub-row.
+    mockApi.listSchedules.mockResolvedValue([
+      sched({ id: "g1", sibling_group_id: "grp-1003", repo_id: "repo-uzi", repo_path: "vtmocanu/uzi", target: "prompt", prompt: "grouped null next_fires", next_fires: null }),
+      sched({ id: "g2", sibling_group_id: "grp-1003", repo_id: "repo-atlas", repo_path: "vtmocanu/atlas", target: "prompt", prompt: "grouped null next_fires", next_fires: null }),
+    ]);
+    renderPage();
+    // The group summary paints; expanding it mounts the MyScheduleSubRow per sibling.
+    await waitFor(() => expect(screen.getByText("Prompt: grouped null next_fires")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Show repos for Prompt: grouped null next_fires" }));
+    // The sub-rows rendered (their repo labels appear), so the Schedules.tsx:1014 nextFire
+    // read ran on a null next_fires without throwing.
+    expect(screen.getByText("vtmocanu/uzi")).toBeTruthy();
+  });
+
   it("suppresses the auto-approve chip for a self_improve row (PRD #590 follow-up 2)", async () => {
     // A self_improve run is always server-forced to auto_approve, so the chip is not a
     // user option: with wait_on_limit off, the row falls back to "defaults", not a chip.

--- a/web/src/pages/Schedules.tsx
+++ b/web/src/pages/Schedules.tsx
@@ -1011,7 +1011,7 @@ function MyScheduleSubRow({
 }) {
   const demo = useDemoMode();
   const repoLabel = s.repo_path ? maskRepoPath(s.repo_path, demo) : "repo unavailable";
-  const nextFire = s.next_fires[0] ?? s.next_fire_at;
+  const nextFire = s.next_fires?.[0] ?? s.next_fire_at;
   const [expanded, setExpanded] = useState(false);
   const panelId = `last-fire-${s.id}`;
   return (


### PR DESCRIPTION
Implements issue #1003.

Closes #1003

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1003`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schedule views that could crash when upcoming run times are unavailable.
  * Schedule details now fall back to the next available run time for one-time or invalid-cron schedules.
  * Improved handling of grouped and default schedules when no upcoming runs are returned.

* **Tests**
  * Added regression coverage for schedules with unavailable upcoming run times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->