### PR TITLE
PRD: CI autofix on by default (mirror mr_rework: admin global + user tri-state)

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -536,10 +536,11 @@ func run() error {
 	// CI-autofix (PRD #71 M6): the poller's post-pipeline-sync detector turns an
 	// eligible failing agent-MR branch into an automatic ci_fix run (or one halt
 	// comment), through the same workersvc create path the manual "Fix CI" button uses
-	// and the M4 loop-guard ledger. Wired unconditionally — the instance kill-switch is
-	// simply NOT wiring it; per-user ci_autofix_enabled (default-OFF) and the
-	// pipelineMaxRefs>0 gate control activation. notifier lands the inbox rows.
-	engine.SetCIAutoFix(poller.NewCIAutoFix(q, wsvc, notifier, cfg.CIFixMaxJobs, cfg.CIFixLogTailBytes, cfg.CIAutofixMaxAttempts, cfg.CIAutofixConfigPaths))
+	// and the M4 loop-guard ledger. Activation is gated by an admin global kill-switch
+	// (settings ci_autofix_enabled, default ON), read fail-closed inside the detector
+	// (PRD #914), plus the per-user opt-in (users.ci_autofix_enabled) and the
+	// pipelineMaxRefs>0 gate. notifier lands the inbox rows.
+	engine.SetCIAutoFix(poller.NewCIAutoFix(q, wsvc, notifier, settingsCache, cfg.CIFixMaxJobs, cfg.CIFixLogTailBytes, cfg.CIAutofixMaxAttempts, cfg.CIAutofixConfigPaths))
 	// MR review watcher (PRD #700 M3): the poller's post-SyncMRStates detector turns an
 	// opted-in completed run's MR that gained new review comments on a green head
 	// pipeline into an automatic mr_rework run, through the workersvc create path and

--- a/api/internal/apitypes/user.go
+++ b/api/internal/apitypes/user.go
@@ -30,10 +30,12 @@ type UserDTO struct {
 	// Decision 7). Default false; the user toggles their own from Settings, and an
 	// admin can force-toggle any user's from the admin users surface.
 	JudgeEnabled bool `json:"judge_enabled"`
-	// CIAutofixEnabled is the user's per-user opt-in to automatic CI fixes (PRD
-	// #71). Default false; the user toggles their own from Settings, and an admin
-	// can force-toggle any user's from the admin users surface.
-	CIAutofixEnabled bool `json:"ci_autofix_enabled"`
+	// CIAutofixEnabled is the user's per-user tri-state opt for automatic CI fixes
+	// (PRD #71, tri-state per #914): nil = inherit the admin global default (which is
+	// ON), true = explicit on, false = explicit off. Serializes as JSON null / true /
+	// false. The user toggles their own from Settings, and an admin can force-toggle
+	// any user's from the admin users surface.
+	CIAutofixEnabled *bool `json:"ci_autofix_enabled"`
 	// AttributionEnabled is the user's opt-out for AI attribution in worker commits
 	// (issue #916). Default true (current behavior); when false the worker suppresses
 	// the SDK's Co-Authored-By: Claude commit trailer.

--- a/api/internal/handler/ci_autofix_toggle.go
+++ b/api/internal/handler/ci_autofix_toggle.go
@@ -13,8 +13,12 @@ import (
 	"github.com/vtmocanu/uzi/api/internal/store"
 )
 
+// setCIAutofixRequest carries the tri-state CI-autofix opt-in (PRD #914 M3).
+// Enabled is a pointer so the three wire shapes stay distinct: `true` = explicit
+// on, `false` = explicit off, and omitted/`null` (a nil pointer) = clear to
+// inherit — i.e. SET NULL, falling back to the admin global default (on).
 type setCIAutofixRequest struct {
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 }
 
 // SetCIAutofixEnabled flips the CURRENT user's automatic CI-fix opt-in (PRD #71).
@@ -35,7 +39,7 @@ func (h *Handler) SetCIAutofixEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := h.q.SetUserCIAutofixEnabled(r.Context(), store.SetUserCIAutofixEnabledParams{
 		ID:               user.ID,
-		CiAutofixEnabled: pgtype.Bool{Bool: req.Enabled, Valid: true},
+		CiAutofixEnabled: pgtype.Bool{Valid: req.Enabled != nil, Bool: req.Enabled != nil && *req.Enabled},
 	})
 	if err != nil {
 		slog.Error("set ci autofix enabled", "error", err)
@@ -63,7 +67,7 @@ func (h *Handler) SetUserCIAutofixEnabled(w http.ResponseWriter, r *http.Request
 	}
 	updated, err := h.q.SetUserCIAutofixEnabled(r.Context(), store.SetUserCIAutofixEnabledParams{
 		ID:               id,
-		CiAutofixEnabled: pgtype.Bool{Bool: req.Enabled, Valid: true},
+		CiAutofixEnabled: pgtype.Bool{Valid: req.Enabled != nil, Bool: req.Enabled != nil && *req.Enabled},
 	})
 	if err != nil {
 		// A no-op UPDATE (unknown id) returns no row → 404; anything else is a real

--- a/api/internal/handler/ci_autofix_toggle.go
+++ b/api/internal/handler/ci_autofix_toggle.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/vtmocanu/uzi/api/internal/httpx"
 	mw "github.com/vtmocanu/uzi/api/internal/middleware"
@@ -34,7 +35,7 @@ func (h *Handler) SetCIAutofixEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := h.q.SetUserCIAutofixEnabled(r.Context(), store.SetUserCIAutofixEnabledParams{
 		ID:               user.ID,
-		CiAutofixEnabled: req.Enabled,
+		CiAutofixEnabled: pgtype.Bool{Bool: req.Enabled, Valid: true},
 	})
 	if err != nil {
 		slog.Error("set ci autofix enabled", "error", err)
@@ -62,7 +63,7 @@ func (h *Handler) SetUserCIAutofixEnabled(w http.ResponseWriter, r *http.Request
 	}
 	updated, err := h.q.SetUserCIAutofixEnabled(r.Context(), store.SetUserCIAutofixEnabledParams{
 		ID:               id,
-		CiAutofixEnabled: req.Enabled,
+		CiAutofixEnabled: pgtype.Bool{Bool: req.Enabled, Valid: true},
 	})
 	if err != nil {
 		// A no-op UPDATE (unknown id) returns no row → 404; anything else is a real

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -474,7 +474,7 @@ func toDTO(u store.User) apitypes.UserDTO {
 		WaitOnLimit:             u.WaitOnLimit,
 		NotifyEarlyLimitReset:   u.NotifyEarlyLimitReset,
 		JudgeEnabled:            u.JudgeEnabled,
-		CIAutofixEnabled:        u.CiAutofixEnabled,
+		CIAutofixEnabled:        boolPtrValue(u.CiAutofixEnabled),
 		AttributionEnabled:      u.AttributionEnabled,
 		EphemeralWorkersEnabled: u.EphemeralWorkersEnabled,
 		CreatedAt:               u.CreatedAt.Time,

--- a/api/internal/poller/ci_autofix.go
+++ b/api/internal/poller/ci_autofix.go
@@ -50,6 +50,13 @@ type CIAutofixNotifier interface {
 	Notify(ctx context.Context, n notifysvc.Notification) (store.Notification, error)
 }
 
+// CIAutofixSettings resolves the admin kill-switch (PRD #914). *settings.Cache
+// satisfies it. CiAutofixEnabled is three-state and error-propagating (see its doc);
+// the detector maps a non-nil error to OFF (fail closed).
+type CIAutofixSettings interface {
+	CiAutofixEnabled(ctx context.Context) (bool, error)
+}
+
 // CIAutoFix is the poller's post-pipeline-sync CI-autofix detector (PRD #71 M6),
 // the sibling of the autopilot detector. It is stateless and safe for concurrent
 // use across the per-repo sync goroutines: it only reads its injected collaborators
@@ -60,6 +67,7 @@ type CIAutoFix struct {
 	q        ciAutofixStore
 	runs     CIAutoFixRunStarter
 	notifier CIAutofixNotifier
+	set      CIAutofixSettings
 
 	maxJobs      int
 	logTailBytes int
@@ -68,14 +76,15 @@ type CIAutoFix struct {
 }
 
 // NewCIAutoFix builds a detector. q is the store, runs creates the automatic ci_fix
-// runs (workersvc), notifier lands the inbox rows (notifysvc, nil-safe). maxJobs /
-// logTailBytes bound the failure snapshot; maxAttempts is the auto-fix cap;
-// configPaths is the guard's default CI-config watch set.
-func NewCIAutoFix(q ciAutofixStore, runs CIAutoFixRunStarter, notifier CIAutofixNotifier, maxJobs, logTailBytes, maxAttempts int, configPaths []string) *CIAutoFix {
+// runs (workersvc), notifier lands the inbox rows (notifysvc, nil-safe), set resolves
+// the admin kill-switch (settings). maxJobs / logTailBytes bound the failure snapshot;
+// maxAttempts is the auto-fix cap; configPaths is the guard's default CI-config watch set.
+func NewCIAutoFix(q ciAutofixStore, runs CIAutoFixRunStarter, notifier CIAutofixNotifier, set CIAutofixSettings, maxJobs, logTailBytes, maxAttempts int, configPaths []string) *CIAutoFix {
 	return &CIAutoFix{
 		q:            q,
 		runs:         runs,
 		notifier:     notifier,
+		set:          set,
 		maxJobs:      maxJobs,
 		logTailBytes: logTailBytes,
 		maxAttempts:  maxAttempts,
@@ -93,6 +102,19 @@ func NewCIAutoFix(q ciAutofixStore, runs CIAutoFixRunStarter, notifier CIAutofix
 // blip or a DB error on one ref must not stall the tick or the other refs, and an
 // unrecorded pipeline simply re-evaluates next tick.
 func (d *CIAutoFix) detect(ctx context.Context, r store.ListEnabledReposWithConnectionsRow, f forge.Forge) {
+	// PRD #914 fail-closed admin gate: CiAutofixEnabled propagates its store error
+	// (three-state read), and the detector — the caller that owns the fail-closed
+	// decision — maps a non-nil error to OFF. Absent → ON is resolved inside
+	// CiAutofixEnabled.
+	enabled, err := d.set.CiAutofixEnabled(ctx)
+	if err != nil {
+		slog.Error("poller: ci-autofix admin gate read", "repo", r.PathWithNamespace, "error", err)
+		return // fail closed
+	}
+	if !enabled {
+		return
+	}
+
 	cands, err := d.q.ListCIAutofixCandidateRefs(ctx, r.ID)
 	if err != nil {
 		slog.Error("poller: list ci-autofix candidates", "repo", r.PathWithNamespace, "error", err)

--- a/api/internal/poller/ci_autofix_test.go
+++ b/api/internal/poller/ci_autofix_test.go
@@ -35,6 +35,11 @@ type cfStore struct {
 	candidates []store.ListCIAutofixCandidateRefsRow
 	candErr    error
 
+	// listed records whether ListCIAutofixCandidateRefs was ever called, so a test
+	// can prove the detector's PRD #914 admin gate returns BEFORE enumerating
+	// candidates (not merely that nothing downstream fired).
+	listed bool
+
 	attempts map[string]store.CiAutofixAttempt
 
 	// activeTarget[ref] = the target pipeline id of an active ci_fix run on the ref.
@@ -54,6 +59,7 @@ type cfStore struct {
 }
 
 func (s *cfStore) ListCIAutofixCandidateRefs(context.Context, uuid.UUID) ([]store.ListCIAutofixCandidateRefsRow, error) {
+	s.listed = true
 	return s.candidates, s.candErr
 }
 
@@ -253,15 +259,67 @@ func cfJob() forge.Job {
 	return forge.Job{ID: 1, Name: "build", Stage: "build", Status: "failed", WebURL: "https://forge/job/1"}
 }
 
+// cfSettings is a CIAutofixSettings stub whose admin kill-switch read is
+// parameterized: enabled is the value returned and enabledErr the (three-state)
+// store error, so a test can exercise the detector's PRD #914 fail-closed gate in
+// all three states. The zero value reads OFF; newCF constructs it ON.
+type cfSettings struct {
+	enabled    bool
+	enabledErr error
+}
+
+func (s cfSettings) CiAutofixEnabled(context.Context) (bool, error) { return s.enabled, s.enabledErr }
+
 func newCF(st *cfStore, runs *cfRuns, notifier *cfNotifier) *CIAutoFix {
+	return newCFSet(st, runs, notifier, cfSettings{enabled: true})
+}
+
+// newCFSet is newCF with an explicit settings stub, for the admin-gate tests.
+func newCFSet(st *cfStore, runs *cfRuns, notifier *cfNotifier, set cfSettings) *CIAutoFix {
 	var n CIAutofixNotifier
 	if notifier != nil {
 		n = notifier
 	}
-	return NewCIAutoFix(st, runs, n, 5, 4096, 2, []string{".gitlab-ci.yml"})
+	return NewCIAutoFix(st, runs, n, set, 5, 4096, 2, []string{".gitlab-ci.yml"})
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
+
+func TestCIAutofixAdminGateOffNoFire(t *testing.T) {
+	// PRD #914: the admin kill-switch is off, so the detector returns before it even
+	// lists candidates — a full no-op (no candidate query, no run, no ledger write).
+	var ops []string
+	st := &cfStore{candidates: []store.ListCIAutofixCandidateRefsRow{cfCand(9001)}, ops: &ops}
+	runs := &cfRuns{ops: &ops}
+	f := &cfForge{jobs: []forge.Job{cfJob()}, logTail: "panic: boom\nexit 1", ops: &ops}
+
+	newCFSet(st, runs, nil, cfSettings{enabled: false}).detect(context.Background(), cfRepoRow(), f)
+
+	if st.listed {
+		t.Fatalf("admin gate off must return before listing candidates")
+	}
+	if len(runs.calls) != 0 || len(st.upserts) != 0 {
+		t.Fatalf("admin gate off must be a full no-op: runs=%d upserts=%d", len(runs.calls), len(st.upserts))
+	}
+}
+
+func TestCIAutofixAdminGateErrorFailsClosed(t *testing.T) {
+	// PRD #914 Decision-5 mirror: a genuine settings READ ERROR disables rather than
+	// enables (fail closed), so the detector never lists candidates or fires.
+	var ops []string
+	st := &cfStore{candidates: []store.ListCIAutofixCandidateRefsRow{cfCand(9001)}, ops: &ops}
+	runs := &cfRuns{ops: &ops}
+	f := &cfForge{jobs: []forge.Job{cfJob()}, logTail: "panic: boom\nexit 1", ops: &ops}
+
+	newCFSet(st, runs, nil, cfSettings{enabled: true, enabledErr: context.DeadlineExceeded}).detect(context.Background(), cfRepoRow(), f)
+
+	if st.listed {
+		t.Fatalf("a settings read error must fail closed before listing candidates")
+	}
+	if len(runs.calls) != 0 {
+		t.Fatalf("a settings read error must fail closed (no fire), got %d runs", len(runs.calls))
+	}
+}
 
 func TestCIAutofixProceedStartsRun(t *testing.T) {
 	var ops []string

--- a/api/internal/settings/keys.go
+++ b/api/internal/settings/keys.go
@@ -223,6 +223,12 @@ const (
 	// opt-in lives on users.mr_rework_enabled, not here.
 	KeyMrReworkEnabled = "mr_rework_enabled"
 	KeyMrReworkCap     = "mr_rework_cap"
+	// CI-autofix admin gate (PRD #914). ci_autofix_enabled is the instance-wide admin
+	// kill-switch for CI autofix (text "true"/"false"): a THREE-STATE, error-propagating
+	// read (present-true / present-false / absent → the default) that ships ON — a
+	// settings blip must not silently disable a default-on feature. The per-user opt-in
+	// lives on users.ci_autofix_enabled, not here.
+	KeyCiAutofixEnabled = "ci_autofix_enabled"
 )
 
 // Compiled-in defaults, used when a row is absent so a fresh or partially
@@ -338,6 +344,9 @@ const (
 	// (also default-on) lives on users.mr_rework_enabled.
 	DefaultMrReworkEnabled = "true"
 	DefaultMrReworkCap     = "5"
+	// PRD #914. CI autofix ships ON: an admin global kill-switch (default true), the
+	// admin-side gate. The per-user opt-in (users.ci_autofix_enabled) is separate.
+	DefaultCiAutofixEnabled = "true"
 )
 
 // Defaults maps every known key to its compiled-in default. This is the single
@@ -448,6 +457,10 @@ var Defaults = map[string]string{
 	// surface them to the settings page on every instance and no migration seeds them.
 	KeyMrReworkEnabled: DefaultMrReworkEnabled,
 	KeyMrReworkCap:     DefaultMrReworkCap,
+	// PRD #914 CI-autofix admin kill-switch. Same no-seeded-row pattern as the judge
+	// keys: an absent row synthesizes to the default (true), so All/AdminView surface it
+	// to the settings page on every instance and no migration seeds it.
+	KeyCiAutofixEnabled: DefaultCiAutofixEnabled,
 }
 
 // SecretKeys is the set of settings whose values are secrets (PRD #25): sealed

--- a/api/internal/settings/settings.go
+++ b/api/internal/settings/settings.go
@@ -375,6 +375,7 @@ func Validate(key, value string) error {
 	case KeySlackEnabled, KeyJudgeEnabled, KeyJudgeEnforceAll, KeyHealthEnabled,
 		KeyCapabilityAwareScheduling, KeyGithubProjectSyncEnabled,
 		KeyEphemeralWorkersEnabled, KeyAgentSourceEnabled, KeyMrReworkEnabled,
+		KeyCiAutofixEnabled,
 		KeyReleaseCheckEnabled, KeyReleaseCheckBannerEnabled,
 		KeyAppLogoKeepName, KeyBrandPlaque:
 		return validateBool(value)

--- a/api/internal/settings/settings_ci_autofix.go
+++ b/api/internal/settings/settings_ci_autofix.go
@@ -1,0 +1,24 @@
+package settings
+
+// This file holds the CI-autofix admin-gate accessor (PRD #914), mirroring the
+// MR-rework accessor in settings_mr_rework.go.
+
+import "context"
+
+// CiAutofixEnabled reports whether the CI-autofix feature is enabled instance-wide
+// (PRD #914): the admin global kill-switch. Stored as the text "true"/"false"; any
+// OTHER value falls back to the compiled-in default (true). This feature ships ON —
+// like MrReworkEnabled and the opposite of JudgeEnabled — so a malformed row never
+// silently turns a default-on feature off.
+//
+// The read is DELIBERATELY three-state and error-propagating, not the best-effort
+// swallow the other bool readers use. Reconciling default-ON with fail-closed means
+// distinguishing present-true / present-false / absent (all a value) from a store
+// READ ERROR: absent → ON (the default), but a genuine error must NOT be misread as
+// absent→ON, which fails OPEN. So this reader PROPAGATES its error to the caller and
+// must not collapse it to false itself; the CALLER (the detector) is the one that maps
+// a non-nil error to OFF (fail closed). Do not "helpfully" swallow the error to false
+// here — that would move the fail-closed decision away from the caller that owns it.
+func (c *Cache) CiAutofixEnabled(ctx context.Context) (bool, error) {
+	return c.boolSetting(ctx, KeyCiAutofixEnabled)
+}

--- a/api/internal/settings/settings_test.go
+++ b/api/internal/settings/settings_test.go
@@ -299,6 +299,78 @@ func TestMrReworkValidation(t *testing.T) {
 	}
 }
 
+// TestCiAutofixAccessors pins the PRD #914 admin global kill-switch (mirrors
+// MrRework): the switch defaults ON (the OPPOSITE of the judge's default-off), a
+// stored value is honored, and a junk bool row falls back to the default ON — a
+// malformed row never silently turns a default-on feature off.
+func TestCiAutofixAccessors(t *testing.T) {
+	ctx := context.Background()
+
+	// Empty table → compiled-in default: ON (absent → ON).
+	c := New(&fakeStore{}, time.Minute)
+	if got, err := c.CiAutofixEnabled(ctx); err != nil || got != true {
+		t.Fatalf("CiAutofixEnabled default = %v, %v; want true (absent → ON)", got, err)
+	}
+	// Pin the literal default so an accidental flip is caught: default-ON is an
+	// announced behavior change, and a silent flip to off would be a regression.
+	if DefaultCiAutofixEnabled != "true" {
+		t.Fatalf("DefaultCiAutofixEnabled = %q, want \"true\"", DefaultCiAutofixEnabled)
+	}
+
+	// present-true / present-false honored; any OTHER value → default ON.
+	for _, tc := range []struct {
+		stored string
+		want   bool
+	}{
+		{"true", true},
+		{"false", false},
+		{"", true},       // empty → default ON
+		{"banana", true}, // junk → default ON
+		{"TRUE", true},   // non-canonical → default, not a lenient parse
+		{"0", true},
+	} {
+		c := New(&fakeStore{rows: []store.AppSetting{row(KeyCiAutofixEnabled, tc.stored)}}, time.Minute)
+		if got, _ := c.CiAutofixEnabled(ctx); got != tc.want {
+			t.Errorf("CiAutofixEnabled(stored=%q) = %v, want %v", tc.stored, got, tc.want)
+		}
+	}
+}
+
+// TestCiAutofixEnabledFailClosed pins the PRD #914 fail-closed reconciliation: a
+// genuine store READ ERROR must be PROPAGATED, not collapsed into the value. An
+// absent row reads ON (default), but the caller (the detector) must be able to tell
+// an error apart from absent so it maps error → OFF. This exercises a REAL
+// cold-cache read error, not merely an absent row.
+func TestCiAutofixEnabledFailClosed(t *testing.T) {
+	ctx := context.Background()
+
+	// Cold cache + store error: the reader RETURNS the error so the caller fails
+	// closed. Contrast with the absent-row case above, which returns (true, nil).
+	c := New(&fakeStore{err: errors.New("db down")}, time.Minute)
+	if _, err := c.CiAutofixEnabled(ctx); err == nil {
+		t.Fatal("CiAutofixEnabled on a cold store error must propagate the error (caller maps it to OFF)")
+	}
+}
+
+// TestCiAutofixValidation pins the PRD #914 write-time gate: the key routes to the
+// strict bool parse. It MUST have an explicit Validate case — the default branch
+// (ValidateLabel) would accept junk that then reads as the default (ON).
+func TestCiAutofixValidation(t *testing.T) {
+	for _, ok := range []string{"true", "false"} {
+		if err := Validate(KeyCiAutofixEnabled, ok); err != nil {
+			t.Errorf("Validate(ci_autofix_enabled, %q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "yes", "1", "TRUE", "on"} {
+		if err := Validate(KeyCiAutofixEnabled, bad); err == nil {
+			t.Errorf("Validate(ci_autofix_enabled, %q) = nil, want a non-bool rejection", bad)
+		}
+	}
+	if !Known(KeyCiAutofixEnabled) {
+		t.Errorf("%s should be Known (admin-writable)", KeyCiAutofixEnabled)
+	}
+}
+
 // TestJudgeSpendGuardAccessors pins the PRD #69 M5 Decision 9 per-user spend-guard
 // accessors: the cooldown defaults ON (60s), the daily budget OFF (0), and a stored
 // value is returned verbatim while an unparseable row falls back to the default

--- a/api/internal/store/ci_autofix.sql.go
+++ b/api/internal/store/ci_autofix.sql.go
@@ -140,7 +140,7 @@ JOIN pipeline_statuses ps
 JOIN repos rp ON rp.id = $1::uuid
 JOIN users u ON u.id = per_branch.user_id
 WHERE per_branch.branch <> rp.default_branch
-  AND u.ci_autofix_enabled
+  AND u.ci_autofix_enabled IS NOT FALSE
   AND EXISTS (
       SELECT 1 FROM user_secrets s
       WHERE s.user_id = per_branch.user_id AND s.kind = 'anthropic_token'
@@ -185,8 +185,11 @@ type ListCIAutofixCandidateRefsRow struct {
 //     branches always carry an mr_iid and are never protected by construction, so
 //     default-branch exclusion + mr_iid IS NOT NULL is a sound stand-in for a
 //     protected-branch check.
-//  3. THE OWNER OPT-IN + TOKEN GATE. The run's owner must have opted into ci
-//     autofix (u.ci_autofix_enabled) AND have an Anthropic token on file. The token
+//  3. THE OWNER OPT-IN + TOKEN GATE. The run's owner must not have opted OUT of ci
+//     autofix AND have an Anthropic token on file. ci_autofix_enabled is a tri-state
+//     (PRD #914): NULL (inherit the admin global default, which is ON) and explicit
+//     true both pass; only an explicit false is excluded — hence `IS NOT FALSE`. The
+//     token
 //     check mirrors GetAutopilotConnectionContext's has_anthropic_token: an EXISTS
 //     over user_secrets (kind = 'anthropic_token'), NOT a column on users — there is
 //     no anthropic_token_ciphertext column.

--- a/api/internal/store/ci_autofix_integration_test.go
+++ b/api/internal/store/ci_autofix_integration_test.go
@@ -46,9 +46,10 @@ func TestCIAutofixLiveDB(t *testing.T) {
 	defer pool.Close()
 	q := store.New(pool)
 
-	// Three owners: u1 opted in WITH a token (eligible), u2 opted OUT (with a token),
-	// u3 opted in but with NO token. Only u1's branches can be candidates.
-	u1, u2, u3 := uuid.New(), uuid.New(), uuid.New()
+	// Four owners: u1 opted in WITH a token (eligible), u2 opted OUT (with a token),
+	// u3 opted in but with NO token, u4 whose ci_autofix_enabled is NULL (inherit)
+	// WITH a token. u1's and u4's branches can be candidates.
+	u1, u2, u3, u4 := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	connID, repoID := uuid.New(), uuid.New()
 	for _, u := range []struct {
 		id      uuid.UUID
@@ -57,9 +58,16 @@ func TestCIAutofixLiveDB(t *testing.T) {
 		mustExec(ctx, t, pool, `INSERT INTO users (id, email, password_hash, ci_autofix_enabled) VALUES ($1, $2, 'x', $3)`,
 			u.id, fmt.Sprintf("autofix-%s@e2e", u.id), u.enabled)
 	}
-	// u1 and u2 have an anthropic token; u3 does not.
+	// PRD #914: u4 OMITS ci_autofix_enabled entirely, so post-00190 (DROP DEFAULT,
+	// nullable) it is NULL = inherit the admin global default (ON). u4 proves the
+	// candidate gate is `IS NOT FALSE`: a NULL owner is INCLUDED, unlike u2's explicit
+	// false. Do NOT add u4 to the enabled-bool loop above.
+	mustExec(ctx, t, pool, `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`,
+		u4, fmt.Sprintf("autofix-%s@e2e", u4))
+	// u1, u2, and u4 have an anthropic token; u3 does not.
 	mustExec(ctx, t, pool, `INSERT INTO user_secrets (user_id, kind, ciphertext, label) VALUES ($1, 'anthropic_token', $2, 'default')`, u1, []byte{0x1})
 	mustExec(ctx, t, pool, `INSERT INTO user_secrets (user_id, kind, ciphertext, label) VALUES ($1, 'anthropic_token', $2, 'default')`, u2, []byte{0x1})
+	mustExec(ctx, t, pool, `INSERT INTO user_secrets (user_id, kind, ciphertext, label) VALUES ($1, 'anthropic_token', $2, 'default')`, u4, []byte{0x1})
 
 	mustExec(ctx, t, pool,
 		`INSERT INTO forge_connections (id, user_id, forge_type, base_url, bot_username, bot_forge_user_id, token_ciphertext)
@@ -149,11 +157,18 @@ func TestCIAutofixLiveDB(t *testing.T) {
 	insertRun(u3, "self_improve", u3SelfImproveBranch, 7, iid(107), "1 hour")
 	insertPipeline(u3SelfImproveBranch, 9007, "failed")
 
+	// PRD #914: u4 (ci_autofix_enabled NULL = inherit → ON) proves the candidate gate is
+	// `IS NOT FALSE`: an inherit-default owner is INCLUDED, exactly as u2's explicit false
+	// is EXCLUDED. An eligible issue run on an agent-MR branch with a FAILED pipeline.
+	insertRun(u4, "issue", "agent/issue-9", 9, iid(109), "1 hour")
+	insertPipeline("agent/issue-9", 9009, "failed")
+
 	// ── ListCIAutofixCandidateRefs: the exact eligible SET ──
-	// Eligible now = agent/issue-1 (issue lane) + u1's two scheduled-lane branches. Every
-	// other seed is excluded by a specific gate (default-branch, mr_iid, green pipeline,
-	// owner opt-out, missing token). Assert the exact set by branch name — precise, not a
-	// bare count — so a stray candidate or a missing one both fail.
+	// Eligible now = agent/issue-1 (issue lane) + u1's two scheduled-lane branches +
+	// agent/issue-9 (u4, ci_autofix_enabled NULL = inherit → ON under the IS NOT FALSE
+	// gate). Every other seed is excluded by a specific gate (default-branch, mr_iid,
+	// green pipeline, owner opt-out, missing token). Assert the exact set by branch name —
+	// precise, not a bare count — so a stray candidate or a missing one both fail.
 	cands, err := q.ListCIAutofixCandidateRefs(ctx, repoID)
 	if err != nil {
 		t.Fatalf("ListCIAutofixCandidateRefs: %v", err)
@@ -162,7 +177,9 @@ func TestCIAutofixLiveDB(t *testing.T) {
 	for _, cand := range cands {
 		gotRefs[cand.Ref.String] = true
 	}
-	wantRefs := []string{"agent/issue-1", selfImproveBranch, promptBranch}
+	// agent/issue-9 (u4, NULL) proves inherit→included under IS NOT FALSE; u2's
+	// explicit-false branch proves false→excluded.
+	wantRefs := []string{"agent/issue-1", selfImproveBranch, promptBranch, "agent/issue-9"}
 	if len(cands) != len(wantRefs) {
 		t.Fatalf("want exactly %d candidates %v, got %d: %+v", len(wantRefs), wantRefs, len(cands), cands)
 	}

--- a/api/internal/store/ci_autofix_tristate_migrate_livedb_test.go
+++ b/api/internal/store/ci_autofix_tristate_migrate_livedb_test.go
@@ -1,0 +1,215 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/vtmocanu/uzi/api/internal/store"
+)
+
+// TestCIAutofixTristateMigrateLiveDB is the regression gate for the one-time data
+// fold in 00190_user_ci_autofix_tristate.sql (PRD #914): making
+// users.ci_autofix_enabled a nullable tri-state (NULL = inherit the admin global
+// default, which is ON), folding every existing `false` row to NULL and dropping
+// the column DEFAULT so new rows are NULL too.
+//
+// # THE BLIND SPOT THIS TEST EXISTS FOR
+//
+// A once-over-existing-rows fold runs exactly once, over whatever rows exist when
+// the migration is applied. Every OTHER live-DB test in this package reaches the
+// schema through store.Migrate (migrations to HEAD), so by the time they insert
+// anything 00190 has already run over an EMPTY users table and the fold matched
+// nothing. A miswrite of the fold (wrong direction, wrong predicate) is therefore
+// STRUCTURALLY INVISIBLE to them: it can only be wrong about pre-existing rows, and
+// an always-at-head fixture never has any.
+//
+// This test uses the store.MigrateTo seam to stand a throwaway database at version
+// 189 (the version BEFORE 00190), seed two users carrying the OLD schema
+// (ci_autofix_enabled NOT NULL: one false = "opted out / never chose", one true =
+// explicit opt-in), prove those values pre-migration, then apply 00190 and assert
+// the fold happened: false -> NULL (Assertion A), true stays true (Assertion B).
+// Assertion A/B MUST run at exactly v190 — a once-over-existing-rows fold is only
+// observable against rows that predate it.
+//
+// It then migrates the rest of the way to HEAD and asserts the DROP DEFAULT
+// (Assertion C): a user created via the generated CreateUser query (which does not
+// stamp the column) reads NULL, proving a fresh row inherits (on), NOT false. This
+// generated-query assertion runs at HEAD, not at v190: CreateUser's RETURNING *
+// reflects the HEAD schema, so calling it against a v190 DB would fail with
+// SQLSTATE 42703 on any column added after 00190.
+//
+// Skipped unless UZI_TEST_DATABASE_URL points at a throwaway Postgres; the
+// store-IT runner provides one. `go test ./...` without it SKIPs.
+func TestCIAutofixTristateMigrateLiveDB(t *testing.T) {
+	dsn := os.Getenv("UZI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("UZI_TEST_DATABASE_URL not set; run via the store-IT runner for live-DB coverage")
+	}
+	ctx := context.Background()
+
+	// --- Stand an isolated database on the same server. CREATE DATABASE cannot
+	// run inside a transaction; a bare pool Exec is autocommit. The name is
+	// all-lowercase hex + underscore, a safe identifier; still Sanitize it.
+	name := "ci_af_tri_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+
+	adminPool, err := store.OpenPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open admin pool: %v", err)
+	}
+	if _, err := adminPool.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{name}.Sanitize()); err != nil {
+		adminPool.Close()
+		t.Fatalf("create database %s: %v", name, err)
+	}
+	adminPool.Close()
+
+	// Register teardown the instant the database exists. The work pool is opened
+	// below; the cleanup owns closing it (single owner, no double Close). Cleanup
+	// opens a FRESH admin pool on the ORIGINAL dsn to DROP ... WITH (FORCE) (pg17)
+	// so the drop cannot hang on a leftover connection. A cleanup failure is
+	// logged, never fatal — it must not mask the real result of the test.
+	var pool *pgxpool.Pool
+	t.Cleanup(func() {
+		if pool != nil {
+			pool.Close()
+		}
+		cleanupAdmin, err := store.OpenPool(ctx, dsn)
+		if err != nil {
+			t.Logf("cleanup: open admin pool to drop %s: %v", name, err)
+			return
+		}
+		defer cleanupAdmin.Close()
+		if _, err := cleanupAdmin.Exec(ctx,
+			"DROP DATABASE IF EXISTS "+pgx.Identifier{name}.Sanitize()+" WITH (FORCE)"); err != nil {
+			t.Logf("cleanup: drop database %s: %v", name, err)
+		}
+	})
+
+	// Build the DSN for the new database by swapping only the path, leaving the
+	// query (sslmode etc.) intact.
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	u.Path = "/" + name
+	newDSN := u.String()
+
+	// --- Migrate the isolated database to 189 — the version BEFORE 00190.
+	if err := store.MigrateTo(ctx, newDSN, 189); err != nil {
+		t.Fatalf("MigrateTo(189): %v", err)
+	}
+
+	pool, err = store.OpenPool(ctx, newDSN)
+	if err != nil {
+		t.Fatalf("open work pool: %v", err)
+	}
+	// NOTE: no `defer pool.Close()` — the cleanup above owns closing pool.
+
+	// --- Prove we are genuinely pre-migration: at v189 the column must still be
+	// NOT NULL with DEFAULT false (its 00115 shape). If the seam over-migrated
+	// past 00190 the column would already be nullable with no default and the fold
+	// assertions would be vacuous.
+	var isNullable, colDefault string
+	if err := pool.QueryRow(ctx,
+		`SELECT is_nullable, COALESCE(column_default, '') FROM information_schema.columns
+		 WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'ci_autofix_enabled'`).
+		Scan(&isNullable, &colDefault); err != nil {
+		t.Fatalf("probe users.ci_autofix_enabled at v189: %v", err)
+	}
+	if isNullable != "NO" {
+		t.Fatalf("users.ci_autofix_enabled is_nullable at v189 = %q, want \"NO\" — MigrateTo(189) did not stop before 00190; test would be vacuous", isNullable)
+	}
+	if !strings.Contains(colDefault, "false") {
+		t.Fatalf("users.ci_autofix_enabled default at v189 = %q, want it to contain \"false\" — MigrateTo(189) did not stop before 00190; test would be vacuous", colDefault)
+	}
+
+	// --- Seed two users carrying the OLD schema, with RAW SQL (the generated
+	// CreateUser reflects the HEAD schema; we are deliberately at v189):
+	//   optedOut: ci_autofix_enabled = false — the pre-00190 default, indistinguishable
+	//             between "explicitly opted out" and "never chose".
+	//   optedIn:  ci_autofix_enabled = true  — an explicit opt-in that must survive.
+	optedOutID, optedInID := uuid.New(), uuid.New()
+	mustExec(ctx, t, pool,
+		`INSERT INTO users (id, email, password_hash, ci_autofix_enabled) VALUES ($1, $2, 'x', false)`,
+		optedOutID, fmt.Sprintf("ci-af-out-%s@e2e", optedOutID))
+	mustExec(ctx, t, pool,
+		`INSERT INTO users (id, email, password_hash, ci_autofix_enabled) VALUES ($1, $2, 'x', true)`,
+		optedInID, fmt.Sprintf("ci-af-in-%s@e2e", optedInID))
+
+	// --- Non-vacuity control: confirm the pre-migration values are genuinely
+	// false and true, so a later green proves a real fold, not a no-op. At v189 the
+	// column is NOT NULL, so a plain bool scan is safe.
+	var outBefore, inBefore bool
+	if err := pool.QueryRow(ctx, `SELECT ci_autofix_enabled FROM users WHERE id = $1`, optedOutID).Scan(&outBefore); err != nil {
+		t.Fatalf("read opted-out user ci_autofix_enabled at v189: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT ci_autofix_enabled FROM users WHERE id = $1`, optedInID).Scan(&inBefore); err != nil {
+		t.Fatalf("read opted-in user ci_autofix_enabled at v189: %v", err)
+	}
+	if outBefore {
+		t.Fatalf("pre-migration: opted-out user ci_autofix_enabled = true, want false (fixture did not land the old default)")
+	}
+	if !inBefore {
+		t.Fatalf("pre-migration: opted-in user ci_autofix_enabled = false, want true (fixture did not land the explicit opt-in)")
+	}
+
+	// --- Apply the migration under test.
+	if err := store.MigrateTo(ctx, newDSN, 190); err != nil {
+		t.Fatalf("MigrateTo(190): %v", err)
+	}
+
+	// --- Assertion A (the fold): the previously-false row is now NULL (inherit =
+	// on). Scan into a pgtype.Bool so a NULL is observable rather than an error.
+	var outAfter pgtype.Bool
+	if err := pool.QueryRow(ctx, `SELECT ci_autofix_enabled FROM users WHERE id = $1`, optedOutID).Scan(&outAfter); err != nil {
+		t.Fatalf("read opted-out user ci_autofix_enabled after 00190: %v", err)
+	}
+	if outAfter.Valid {
+		t.Errorf("fold: opted-out user ci_autofix_enabled = %v after 00190, want NULL (00190 UPDATE did not fold false -> NULL)", outAfter.Bool)
+	}
+
+	// --- Assertion B: the previously-true row is still true (explicit opt-in preserved).
+	var inAfter pgtype.Bool
+	if err := pool.QueryRow(ctx, `SELECT ci_autofix_enabled FROM users WHERE id = $1`, optedInID).Scan(&inAfter); err != nil {
+		t.Fatalf("read opted-in user ci_autofix_enabled after 00190: %v", err)
+	}
+	if !inAfter.Valid || !inAfter.Bool {
+		t.Errorf("fold: opted-in user ci_autofix_enabled = %+v after 00190, want true (the fold clobbered an explicit opt-in)", inAfter)
+	}
+
+	// --- Migrate the rest of the way to HEAD before the generated-query assertion.
+	// Assertions A/B above had to run at EXACTLY v190 (the fold is once-over-existing-
+	// rows; see the header). Assertion C uses the HEAD-generated CreateUser whose
+	// RETURNING * reflects the HEAD schema, so calling it against a v190 DB would fail
+	// with SQLSTATE 42703 on any column added after 00190. The dropped default set at
+	// 00190 PERSISTS to HEAD, so Assertion C still validates exactly what it intends.
+	if err := store.Migrate(ctx, newDSN); err != nil {
+		t.Fatalf("Migrate to HEAD before generated-query assertion: %v", err)
+	}
+
+	// --- Assertion C (dropped default → new rows NULL = inherit = on): a NEW user
+	// created via the generated CreateUser query (which does not stamp the column)
+	// reads NULL, proving DROP DEFAULT means a fresh row inherits (on), not false.
+	q := store.New(pool)
+	newUserID := uuid.New()
+	newUser, err := q.CreateUser(ctx, store.CreateUserParams{
+		Email:        fmt.Sprintf("ci-af-new-%s@e2e", newUserID),
+		PasswordHash: pgtype.Text{String: "x", Valid: true},
+		DisplayName:  pgtype.Text{String: "New User", Valid: true},
+		IsAdmin:      false,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser after 00190: %v", err)
+	}
+	if newUser.CiAutofixEnabled.Valid {
+		t.Errorf("dropped default: CreateUser produced ci_autofix_enabled = %v after 00190, want NULL (users column default not dropped; a fresh row must inherit = on, not read false)", newUser.CiAutofixEnabled.Bool)
+	}
+}

--- a/api/internal/store/migrations/00190_user_ci_autofix_tristate.sql
+++ b/api/internal/store/migrations/00190_user_ci_autofix_tristate.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+-- PRD #914: make users.ci_autofix_enabled a nullable tri-state (NULL = inherit the
+-- admin global default, which is ON). Mirrors mr_rework (00165). The column was added
+-- NOT NULL DEFAULT false (00115), so history cannot distinguish "opted out" from
+-- "never chose" — both are false. We deliberately TURN EVERYONE ON: fold existing
+-- false -> NULL (inherit = on), preserve existing true. New rows get NULL (the insert
+-- paths never set the column and the default is dropped) = inherit = on. This
+-- RE-ENABLES prior explicit opt-outs — an accepted one-time trade (best practice is
+-- preserved by the tri-state going forward). The gate becomes `IS NOT FALSE`.
+ALTER TABLE users ALTER COLUMN ci_autofix_enabled DROP NOT NULL, ALTER COLUMN ci_autofix_enabled DROP DEFAULT;
+UPDATE users SET ci_autofix_enabled = NULL WHERE ci_autofix_enabled = false;
+
+-- +goose Down
+
+-- LOSSY: rollback collapses every inherit-on (NULL) row to off; it CANNOT restore the
+-- pre-Up values (the fold above is irreversible). This only restores the column shape.
+UPDATE users SET ci_autofix_enabled = false WHERE ci_autofix_enabled IS NULL;
+ALTER TABLE users ALTER COLUMN ci_autofix_enabled SET DEFAULT false;
+ALTER TABLE users ALTER COLUMN ci_autofix_enabled SET NOT NULL;

--- a/api/internal/store/models.go
+++ b/api/internal/store/models.go
@@ -637,7 +637,7 @@ type User struct {
 	JudgeEnabled            bool               `json:"judge_enabled"`
 	JudgeAnthropicSecretID  pgtype.UUID        `json:"judge_anthropic_secret_id"`
 	WaitOnLimit             bool               `json:"wait_on_limit"`
-	CiAutofixEnabled        bool               `json:"ci_autofix_enabled"`
+	CiAutofixEnabled        pgtype.Bool        `json:"ci_autofix_enabled"`
 	SidebarTokenIds         []uuid.UUID        `json:"sidebar_token_ids"`
 	JudgeModel              pgtype.Text        `json:"judge_model"`
 	SummaryModel            pgtype.Text        `json:"summary_model"`

--- a/api/internal/store/queries/ci_autofix.sql
+++ b/api/internal/store/queries/ci_autofix.sql
@@ -29,8 +29,11 @@
 --      branches always carry an mr_iid and are never protected by construction, so
 --      default-branch exclusion + mr_iid IS NOT NULL is a sound stand-in for a
 --      protected-branch check.
---   3. THE OWNER OPT-IN + TOKEN GATE. The run's owner must have opted into ci
---      autofix (u.ci_autofix_enabled) AND have an Anthropic token on file. The token
+--   3. THE OWNER OPT-IN + TOKEN GATE. The run's owner must not have opted OUT of ci
+--      autofix AND have an Anthropic token on file. ci_autofix_enabled is a tri-state
+--      (PRD #914): NULL (inherit the admin global default, which is ON) and explicit
+--      true both pass; only an explicit false is excluded — hence `IS NOT FALSE`. The
+--      token
 --      check mirrors GetAutopilotConnectionContext's has_anthropic_token: an EXISTS
 --      over user_secrets (kind = 'anthropic_token'), NOT a column on users — there is
 --      no anthropic_token_ciphertext column.
@@ -76,7 +79,7 @@ JOIN pipeline_statuses ps
 JOIN repos rp ON rp.id = @repo_id::uuid
 JOIN users u ON u.id = per_branch.user_id
 WHERE per_branch.branch <> rp.default_branch
-  AND u.ci_autofix_enabled
+  AND u.ci_autofix_enabled IS NOT FALSE
   AND EXISTS (
       SELECT 1 FROM user_secrets s
       WHERE s.user_id = per_branch.user_id AND s.kind = 'anthropic_token'

--- a/api/internal/store/users.sql.go
+++ b/api/internal/store/users.sql.go
@@ -783,8 +783,8 @@ RETURNING id, email, password_hash, display_name, is_admin, is_active, token_ver
 `
 
 type SetUserCIAutofixEnabledParams struct {
-	ID               uuid.UUID `json:"id"`
-	CiAutofixEnabled bool      `json:"ci_autofix_enabled"`
+	ID               uuid.UUID   `json:"id"`
+	CiAutofixEnabled pgtype.Bool `json:"ci_autofix_enabled"`
 }
 
 // Flip a user's automatic CI-fix opt-in (PRD #71). Per-user consent to spend the

--- a/api/internal/uzidocs/embed/ai-attribution.md
+++ b/api/internal/uzidocs/embed/ai-attribution.md
@@ -17,7 +17,7 @@ Open **Settings → Run defaults**, find the **AI attribution in commits**
 card, and uncheck **Include the Co-Authored-By: Claude trailer in my worker
 commits**. It's an account default, and it's owner-only — you can only
 change it for yourself, and there's no admin force-toggle for it (unlike
-[Automatic CI fixes](./ci-autofix.md#1-opt-in) and the [run judge](./judge.md),
+[Automatic CI fixes](./ci-autofix.md#1-opt-out) and the [run judge](./judge.md),
 which admins can enable or disable for any individual user).
 
 ## When it takes effect

--- a/api/internal/uzidocs/embed/ci-autofix.md
+++ b/api/internal/uzidocs/embed/ci-autofix.md
@@ -11,16 +11,44 @@ own agent merge-request branches by itself: no clicking **Fix CI**. Like the
 manual button, it spends your own Anthropic token, not the instance's. It's
 the unattended sibling of the manual **Fix CI** button described in
 [Configuration](./configuration.md#ci-status-integration-prd-6) — same
-`ci_fix` run type, same verification, just started for you. Off by default,
-and opt-in per user.
+`ci_fix` run type, same verification, just started for you. **On by
+default** for every user, capped by `CI_AUTOFIX_MAX_ATTEMPTS` and bounded to
+your own branches — see [Opting out](#1-opt-in) below, and [Upgrading from
+an older uzi](#upgrading-from-an-older-uzi) if this instance predates the
+change.
 
 ## 1. Opt in
 
-Open **Settings → Automatic CI fixes** and check **Automatically fix my
-failed CI pipelines**. Off by default; it only ever spends your own
-Anthropic token, and only on branches that trace back to your own agent
-runs. Admins can also force-enable or force-disable it for any individual
-user from **Admin → Users**, the same pattern as the [run judge](./judge.md).
+Automatic CI fixes ship **on** for every user — there is nothing to turn on.
+Your per-user setting is really a tri-state opt-**out**: leaving it alone
+stores nothing (`NULL`, meaning "inherit the instance default", which is
+ON); unchecking it stores an explicit off. To opt out, open **Settings →
+Automatic CI fixes** and uncheck **Automatically fix my failed CI
+pipelines**. Either way — inherited on or explicitly on — it only ever
+spends your own Anthropic token, never the instance's, and only on branches
+that trace back to your own agent runs. Admins can also force-enable or
+force-disable it for any individual user from **Admin → Users**, the same
+pattern as the [run judge](./judge.md).
+
+On top of the per-user setting, an admin can flip a separate,
+instance-wide kill-switch (`ci_autofix_enabled`, default **on**) that turns
+automatic CI fixes off for every user at once regardless of their own
+setting — the same pattern as [MR review rework](./mr-review-watcher.md#enablement)'s
+kill-switch, and set the same way: through the settings API rather than a
+dedicated Admin Settings control today. A settings-read hiccup is treated as
+off (fail closed), never as silently on.
+
+### Upgrading from an older uzi
+
+Automatic CI fixes used to be off by default and opt-in per user. A
+one-time migration turns the feature **on for everyone**, including anyone
+who had previously opted out on purpose — folding their old "off" into the
+same "never chose" state, since the pre-migration column couldn't tell the
+two apart. That is an accepted, intentional trade so that going forward the
+tri-state can distinguish them. If you'd previously turned this off
+deliberately, check **Settings → Automatic CI fixes** after upgrading and
+opt out again if you still want it off: until you do, it resumes spending
+your Anthropic token on failed pipelines.
 
 ## What triggers it
 
@@ -29,15 +57,19 @@ every watched **agent-owned MR branch** — the branch one of your agent runs
 pushed to: an issue run's `agent/issue-N`, or a [scheduled
 run](./scheduling.md)'s `uzi/prompt-<id>` (an ad-hoc prompt job) or
 `uzi/self-improve/<id>` (self-improvement). When that branch's latest pipeline
-is failed and you have the toggle on and an Anthropic token configured, uzi
+is failed and you haven't opted out and an Anthropic token is configured, uzi
 queues the same `ci_fix` run the **Fix CI** button would — auto-approved, so it
 skips the plan-approval step and starts working right away. A scheduled run
-inherits your account-wide opt-in; there is no separate per-schedule switch.
+inherits your account-wide setting; there is no separate per-schedule switch.
 
 `main`, the repo's default branch, and any non-MR ref are never auto-touched
-— only a branch that is itself the product of one of your agent runs. And
-none of this fires at all unless the pipeline watch itself is on
-(`CI_WATCH_MAX_REFS` > 0 — see [Configuration](./configuration.md#ci-status-integration-prd-6)); with the watch off, there are no CI badges and no automatic fixes.
+— only a branch that is itself the product of one of your agent runs. None of
+this fires at all unless the pipeline watch itself is on (`CI_WATCH_MAX_REFS`
+> 0 — see [Configuration](./configuration.md#ci-status-integration-prd-6));
+with the watch off, there are no CI badges and no automatic fixes. It also
+doesn't fire while the [instance-wide kill-switch](#1-opt-in) is off,
+regardless of anyone's own setting — and, fail-closed, a settings-read
+hiccup on that admin gate is treated the same as off.
 
 ## The loop guard
 

--- a/api/internal/uzidocs/embed/ci-autofix.md
+++ b/api/internal/uzidocs/embed/ci-autofix.md
@@ -13,11 +13,11 @@ the unattended sibling of the manual **Fix CI** button described in
 [Configuration](./configuration.md#ci-status-integration-prd-6) — same
 `ci_fix` run type, same verification, just started for you. **On by
 default** for every user, capped by `CI_AUTOFIX_MAX_ATTEMPTS` and bounded to
-your own branches — see [Opting out](#1-opt-in) below, and [Upgrading from
+your own branches — see [Opting out](#1-opt-out) below, and [Upgrading from
 an older uzi](#upgrading-from-an-older-uzi) if this instance predates the
 change.
 
-## 1. Opt in
+## 1. Opt out
 
 Automatic CI fixes ship **on** for every user — there is nothing to turn on.
 Your per-user setting is really a tri-state opt-**out**: leaving it alone
@@ -67,7 +67,7 @@ inherits your account-wide setting; there is no separate per-schedule switch.
 this fires at all unless the pipeline watch itself is on (`CI_WATCH_MAX_REFS`
 > 0 — see [Configuration](./configuration.md#ci-status-integration-prd-6));
 with the watch off, there are no CI badges and no automatic fixes. It also
-doesn't fire while the [instance-wide kill-switch](#1-opt-in) is off,
+doesn't fire while the [instance-wide kill-switch](#1-opt-out) is off,
 regardless of anyone's own setting — and, fail-closed, a settings-read
 hiccup on that admin gate is treated the same as off.
 

--- a/api/internal/uzidocs/embed/configuration.md
+++ b/api/internal/uzidocs/embed/configuration.md
@@ -150,12 +150,15 @@ one operator-only piece is the SSRF allowlist for the clone target, a
 
 uzi caches the latest pipeline per **watched ref** (a repo's default branch, plus the branches of that repo's recent agent runs) on the same poll tick as the issue sync — no second loop or interval — and renders it as a status badge on the repos list, the board header, and each card. A failed pipeline offers a **Fix CI** button that queues a plan-gated `ci_fix` agent run; when that run's fix branch pipeline concludes, the sync stamps the run `verified` or `fix_failed` ("uzi verifies its work"). See [ARCHITECTURE.md](../ARCHITECTURE.md) for the full pipeline-sync + verification design.
 
-On top of the manual button, a per-user opt-in can queue that same `ci_fix`
+On top of the manual button, a per-user setting queues that same `ci_fix`
 run **automatically** when one of a user's own agent MR branches goes red —
 see [Automatic CI fixes](./ci-autofix.md) for the feature and its loop
-guard. It's off for every user until they opt in in Settings (or an admin
-force-enables them from Admin → Users), so the two `CI_AUTOFIX_*` vars
-below have no effect on an instance where nobody has opted in yet.
+guard. It ships **on for every user** by default (a tri-state opt-out: unset
+inherits the instance default, which is on); an admin can force it on or
+off for an individual user from Admin → Users, or flip a separate
+instance-wide kill-switch (`ci_autofix_enabled`, default on) that overrides
+everyone's own setting at once. The two `CI_AUTOFIX_*` vars below apply
+whenever the feature is enabled for a given user.
 
 | Var | Default | Notes |
 |---|---|---|

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -420,10 +420,12 @@ issue runs open:
   schedule's runs. See [that page's Enablement
   section](./mr-review-watcher.md#enablement) for the full resolution order.
 - **[Automatic CI fixes](./ci-autofix.md)** react to a failed head pipeline on a
-  scheduled-run MR branch. This lane stays **opt-in, off by default**, on the
-  same account-wide **Settings → Automatic CI fixes** toggle your issue runs use
-  — a scheduled run inherits the owner's opt-in; there is no separate
-  per-schedule switch for it.
+  scheduled-run MR branch. This lane is **on by default**, on the same
+  account-wide **Settings → Automatic CI fixes** toggle your issue runs use —
+  a scheduled run inherits the owner's setting; there is no separate
+  per-schedule switch for it. An instance-wide admin kill-switch can turn it
+  off for everyone regardless of any owner's own setting; see [Automatic CI
+  fixes](./ci-autofix.md#1-opt-in) for both.
 
 Both lanes act only on a **still-open** MR and spend the schedule owner's own
 Anthropic token, the same as any other run. A prompt schedule's MR has no

--- a/api/internal/uzidocs/embed/scheduling.md
+++ b/api/internal/uzidocs/embed/scheduling.md
@@ -425,7 +425,7 @@ issue runs open:
   a scheduled run inherits the owner's setting; there is no separate
   per-schedule switch for it. An instance-wide admin kill-switch can turn it
   off for everyone regardless of any owner's own setting; see [Automatic CI
-  fixes](./ci-autofix.md#1-opt-in) for both.
+  fixes](./ci-autofix.md#1-opt-out) for both.
 
 Both lanes act only on a **still-open** MR and spend the schedule owner's own
 Anthropic token, the same as any other run. A prompt schedule's MR has no

--- a/docs/ai-attribution.md
+++ b/docs/ai-attribution.md
@@ -17,7 +17,7 @@ Open **Settings → Run defaults**, find the **AI attribution in commits**
 card, and uncheck **Include the Co-Authored-By: Claude trailer in my worker
 commits**. It's an account default, and it's owner-only — you can only
 change it for yourself, and there's no admin force-toggle for it (unlike
-[Automatic CI fixes](./ci-autofix.md#1-opt-in) and the [run judge](./judge.md),
+[Automatic CI fixes](./ci-autofix.md#1-opt-out) and the [run judge](./judge.md),
 which admins can enable or disable for any individual user).
 
 ## When it takes effect

--- a/docs/ci-autofix.md
+++ b/docs/ci-autofix.md
@@ -11,16 +11,44 @@ own agent merge-request branches by itself: no clicking **Fix CI**. Like the
 manual button, it spends your own Anthropic token, not the instance's. It's
 the unattended sibling of the manual **Fix CI** button described in
 [Configuration](./configuration.md#ci-status-integration-prd-6) — same
-`ci_fix` run type, same verification, just started for you. Off by default,
-and opt-in per user.
+`ci_fix` run type, same verification, just started for you. **On by
+default** for every user, capped by `CI_AUTOFIX_MAX_ATTEMPTS` and bounded to
+your own branches — see [Opting out](#1-opt-in) below, and [Upgrading from
+an older uzi](#upgrading-from-an-older-uzi) if this instance predates the
+change.
 
 ## 1. Opt in
 
-Open **Settings → Automatic CI fixes** and check **Automatically fix my
-failed CI pipelines**. Off by default; it only ever spends your own
-Anthropic token, and only on branches that trace back to your own agent
-runs. Admins can also force-enable or force-disable it for any individual
-user from **Admin → Users**, the same pattern as the [run judge](./judge.md).
+Automatic CI fixes ship **on** for every user — there is nothing to turn on.
+Your per-user setting is really a tri-state opt-**out**: leaving it alone
+stores nothing (`NULL`, meaning "inherit the instance default", which is
+ON); unchecking it stores an explicit off. To opt out, open **Settings →
+Automatic CI fixes** and uncheck **Automatically fix my failed CI
+pipelines**. Either way — inherited on or explicitly on — it only ever
+spends your own Anthropic token, never the instance's, and only on branches
+that trace back to your own agent runs. Admins can also force-enable or
+force-disable it for any individual user from **Admin → Users**, the same
+pattern as the [run judge](./judge.md).
+
+On top of the per-user setting, an admin can flip a separate,
+instance-wide kill-switch (`ci_autofix_enabled`, default **on**) that turns
+automatic CI fixes off for every user at once regardless of their own
+setting — the same pattern as [MR review rework](./mr-review-watcher.md#enablement)'s
+kill-switch, and set the same way: through the settings API rather than a
+dedicated Admin Settings control today. A settings-read hiccup is treated as
+off (fail closed), never as silently on.
+
+### Upgrading from an older uzi
+
+Automatic CI fixes used to be off by default and opt-in per user. A
+one-time migration turns the feature **on for everyone**, including anyone
+who had previously opted out on purpose — folding their old "off" into the
+same "never chose" state, since the pre-migration column couldn't tell the
+two apart. That is an accepted, intentional trade so that going forward the
+tri-state can distinguish them. If you'd previously turned this off
+deliberately, check **Settings → Automatic CI fixes** after upgrading and
+opt out again if you still want it off: until you do, it resumes spending
+your Anthropic token on failed pipelines.
 
 ## What triggers it
 
@@ -29,15 +57,19 @@ every watched **agent-owned MR branch** — the branch one of your agent runs
 pushed to: an issue run's `agent/issue-N`, or a [scheduled
 run](./scheduling.md)'s `uzi/prompt-<id>` (an ad-hoc prompt job) or
 `uzi/self-improve/<id>` (self-improvement). When that branch's latest pipeline
-is failed and you have the toggle on and an Anthropic token configured, uzi
+is failed and you haven't opted out and an Anthropic token is configured, uzi
 queues the same `ci_fix` run the **Fix CI** button would — auto-approved, so it
 skips the plan-approval step and starts working right away. A scheduled run
-inherits your account-wide opt-in; there is no separate per-schedule switch.
+inherits your account-wide setting; there is no separate per-schedule switch.
 
 `main`, the repo's default branch, and any non-MR ref are never auto-touched
-— only a branch that is itself the product of one of your agent runs. And
-none of this fires at all unless the pipeline watch itself is on
-(`CI_WATCH_MAX_REFS` > 0 — see [Configuration](./configuration.md#ci-status-integration-prd-6)); with the watch off, there are no CI badges and no automatic fixes.
+— only a branch that is itself the product of one of your agent runs. None of
+this fires at all unless the pipeline watch itself is on (`CI_WATCH_MAX_REFS`
+> 0 — see [Configuration](./configuration.md#ci-status-integration-prd-6));
+with the watch off, there are no CI badges and no automatic fixes. It also
+doesn't fire while the [instance-wide kill-switch](#1-opt-in) is off,
+regardless of anyone's own setting — and, fail-closed, a settings-read
+hiccup on that admin gate is treated the same as off.
 
 ## The loop guard
 

--- a/docs/ci-autofix.md
+++ b/docs/ci-autofix.md
@@ -13,11 +13,11 @@ the unattended sibling of the manual **Fix CI** button described in
 [Configuration](./configuration.md#ci-status-integration-prd-6) — same
 `ci_fix` run type, same verification, just started for you. **On by
 default** for every user, capped by `CI_AUTOFIX_MAX_ATTEMPTS` and bounded to
-your own branches — see [Opting out](#1-opt-in) below, and [Upgrading from
+your own branches — see [Opting out](#1-opt-out) below, and [Upgrading from
 an older uzi](#upgrading-from-an-older-uzi) if this instance predates the
 change.
 
-## 1. Opt in
+## 1. Opt out
 
 Automatic CI fixes ship **on** for every user — there is nothing to turn on.
 Your per-user setting is really a tri-state opt-**out**: leaving it alone
@@ -67,7 +67,7 @@ inherits your account-wide setting; there is no separate per-schedule switch.
 this fires at all unless the pipeline watch itself is on (`CI_WATCH_MAX_REFS`
 > 0 — see [Configuration](./configuration.md#ci-status-integration-prd-6));
 with the watch off, there are no CI badges and no automatic fixes. It also
-doesn't fire while the [instance-wide kill-switch](#1-opt-in) is off,
+doesn't fire while the [instance-wide kill-switch](#1-opt-out) is off,
 regardless of anyone's own setting — and, fail-closed, a settings-read
 hiccup on that admin gate is treated the same as off.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,12 +150,15 @@ one operator-only piece is the SSRF allowlist for the clone target, a
 
 uzi caches the latest pipeline per **watched ref** (a repo's default branch, plus the branches of that repo's recent agent runs) on the same poll tick as the issue sync — no second loop or interval — and renders it as a status badge on the repos list, the board header, and each card. A failed pipeline offers a **Fix CI** button that queues a plan-gated `ci_fix` agent run; when that run's fix branch pipeline concludes, the sync stamps the run `verified` or `fix_failed` ("uzi verifies its work"). See [ARCHITECTURE.md](../ARCHITECTURE.md) for the full pipeline-sync + verification design.
 
-On top of the manual button, a per-user opt-in can queue that same `ci_fix`
+On top of the manual button, a per-user setting queues that same `ci_fix`
 run **automatically** when one of a user's own agent MR branches goes red —
 see [Automatic CI fixes](./ci-autofix.md) for the feature and its loop
-guard. It's off for every user until they opt in in Settings (or an admin
-force-enables them from Admin → Users), so the two `CI_AUTOFIX_*` vars
-below have no effect on an instance where nobody has opted in yet.
+guard. It ships **on for every user** by default (a tri-state opt-out: unset
+inherits the instance default, which is on); an admin can force it on or
+off for an individual user from Admin → Users, or flip a separate
+instance-wide kill-switch (`ci_autofix_enabled`, default on) that overrides
+everyone's own setting at once. The two `CI_AUTOFIX_*` vars below apply
+whenever the feature is enabled for a given user.
 
 | Var | Default | Notes |
 |---|---|---|

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -420,10 +420,12 @@ issue runs open:
   schedule's runs. See [that page's Enablement
   section](./mr-review-watcher.md#enablement) for the full resolution order.
 - **[Automatic CI fixes](./ci-autofix.md)** react to a failed head pipeline on a
-  scheduled-run MR branch. This lane stays **opt-in, off by default**, on the
-  same account-wide **Settings → Automatic CI fixes** toggle your issue runs use
-  — a scheduled run inherits the owner's opt-in; there is no separate
-  per-schedule switch for it.
+  scheduled-run MR branch. This lane is **on by default**, on the same
+  account-wide **Settings → Automatic CI fixes** toggle your issue runs use —
+  a scheduled run inherits the owner's setting; there is no separate
+  per-schedule switch for it. An instance-wide admin kill-switch can turn it
+  off for everyone regardless of any owner's own setting; see [Automatic CI
+  fixes](./ci-autofix.md#1-opt-in) for both.
 
 Both lanes act only on a **still-open** MR and spend the schedule owner's own
 Anthropic token, the same as any other run. A prompt schedule's MR has no

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -425,7 +425,7 @@ issue runs open:
   a scheduled run inherits the owner's setting; there is no separate
   per-schedule switch for it. An instance-wide admin kill-switch can turn it
   off for everyone regardless of any owner's own setting; see [Automatic CI
-  fixes](./ci-autofix.md#1-opt-in) for both.
+  fixes](./ci-autofix.md#1-opt-out) for both.
 
 Both lanes act only on a **still-open** MR and spend the schedule owner's own
 Anthropic token, the same as any other run. A prompt schedule's MR has no

--- a/fixtures/api-contract/user.zero.json
+++ b/fixtures/api-contract/user.zero.json
@@ -8,7 +8,7 @@
   "wait_on_limit": false,
   "notify_early_limit_reset": false,
   "judge_enabled": false,
-  "ci_autofix_enabled": false,
+  "ci_autofix_enabled": null,
   "attribution_enabled": false,
   "ephemeral_workers_enabled": false,
   "judge_anthropic_secret_id": null,

--- a/prds/done/914-ci-autofix-default-on.md
+++ b/prds/done/914-ci-autofix-default-on.md
@@ -1,10 +1,12 @@
 # PRD #914: CI autofix on by default (mirror mr_rework — admin global + per-user tri-state)
 
 > Anchors re-verified against main at fcfd8aa on 2026-09-03, after the epic #915 file splits.
-> **Precondition status 2026-09-03: #908 is NOT on main** (`forgesvc/scheduled_mr_watch.go` absent; `ListCIAutofixCandidateRefs` still filters `r.kind IN ('issue','ci_fix')`). This PRD was pulled from the nightly sweep (`uzi` label removed) until #908 merges.
+> **Precondition status 2026-09-05: #908 is on main** (`forgesvc/scheduled_mr_watch.go` present; `ListCIAutofixCandidateRefs` filters `r.kind IN ('issue','ci_fix','prompt','self_improve')`). The precondition gate passed and this PRD was implemented.
+>
+> **As-built deltas (2026-09-05):** the migration landed as **00190** (the live head was 00189, not the drafted 00185/00186). The DTO/type became a nullable `*bool` / `boolean|null` **end-to-end** (M2's `toDTO` maps `pgtype.Bool`→`*bool` null-preserving via the existing `boolPtrValue`, and M3 carried the write-path pointer for clear-to-inherit) rather than the drafted interim "resolve inherit→true, DTO stays bool" — the tri-state renders on the web via `checked={x !== false}`, mirroring mr_rework. The admin global read reuses `Cache.CiAutofixEnabled` mirroring `MrReworkEnabled` (fail-closed in the detector).
 
 **Issue**: #914
-**Status**: Draft — ready for implementation
+**Status**: Done — implemented 2026-09-05 (all milestones landed; gate:api + gate:web green; 5-package `*LiveDB` sweep green)
 **Priority**: Medium
 **Split from**: #908 (this was #908's former Part B; #908 keeps Part A — autofix for scheduled runs).
 **Scope**: `api/` (one migration) + `web/`. No `agent/` change. No `.github/workflows/**` changes.
@@ -115,7 +117,7 @@ mr_rework is the template, but ci_autofix differs in ways that make this more th
 **Offline** = unit-testable with fakes. **LiveDB** = needs `./e2e/run-store-it.sh`. **web** = touches
 `web/`.
 
-- [ ] **M1 — Admin global `ci_autofix_enabled` setting + detector fail-closed read.** *(Offline)*
+- [x] **M1 — Admin global `ci_autofix_enabled` setting + detector fail-closed read.** *(Offline)*
   In `api/internal/settings/keys.go` add (all NEW): `KeyCiAutofixEnabled = "ci_autofix_enabled"`,
   `DefaultCiAutofixEnabled = "true"`, and the `Defaults` map entry (mirroring `KeyMrReworkEnabled`
   `:224`, `DefaultMrReworkEnabled` `:339`, `Defaults` entry `:449`). In a new
@@ -128,7 +130,7 @@ mr_rework is the template, but ci_autofix differs in ways that make this more th
   **Also fix the now-stale comment at `cmd/server/main.go:538-539`** ("per-user ci_autofix_enabled
   (default-OFF)" and "kill-switch is simply NOT wiring it") — both become false once the global exists.
 
-- [ ] **M2 — User column → nullable tri-state + candidate gate + Go-type ripple.** *(Offline + LiveDB)*
+- [x] **M2 — User column → nullable tri-state + candidate gate + Go-type ripple.** *(Offline + LiveDB)*
   New migration (number at merge time; live head 00185, so this lands at 00186):
   - Up: `ALTER TABLE users ALTER COLUMN ci_autofix_enabled DROP NOT NULL, DROP DEFAULT;` then
     `UPDATE users SET ci_autofix_enabled = NULL WHERE ci_autofix_enabled = false;` (existing `true`
@@ -144,7 +146,7 @@ mr_rework is the template, but ci_autofix differs in ways that make this more th
   Regenerate sqlc; `store.User.CiAutofixEnabled` flips `bool` → `pgtype.Bool` — fix `handler/handler.go:477`
   (`toDTO`, resolve inherit→true) and the `SetUserCIAutofixEnabled` param.
 
-- [ ] **M3 — Tri-state over the API + web toggles.** *(Offline; web)*
+- [x] **M3 — Tri-state over the API + web toggles.** *(Offline; web)*
   Retrofit the dedicated endpoints to carry inherit/clear: `handler/ci_autofix_toggle.go`
   (`setCIAutofixRequest`, both handler methods → the single `SetUserCIAutofixEnabled` param as
   `pgtype.Bool`), the DTO `apitypes/user.go:36` + web `apiTypes.ts:23` `User.ci_autofix_enabled` →
@@ -160,7 +162,7 @@ mr_rework is the template, but ci_autofix differs in ways that make this more th
   (`web/src/mocks/data/users.ts` ×6, lines 16/37/59/77/97/115, + ~10 web test files) — update the
   ones M4's positive-control tests assert on so they don't assert "off" for a default-on user.
 
-- [ ] **M4 — Tests + docs.** *(Offline + LiveDB)*
+- [x] **M4 — Tests + docs.** *(Offline + LiveDB)*
   Migration test: an existing `false` row becomes NULL, a `true` row is preserved, a fresh row is NULL.
   Candidate query (**extend `api/internal/store/ci_autofix_integration_test.go:55-59`, which seeds only
   `{true,false,true}` — add a NULL case**): a NULL-user run is a candidate (default-on), an explicit

--- a/prds/done/914-ci-autofix-default-on.md
+++ b/prds/done/914-ci-autofix-default-on.md
@@ -131,7 +131,7 @@ mr_rework is the template, but ci_autofix differs in ways that make this more th
   (default-OFF)" and "kill-switch is simply NOT wiring it") — both become false once the global exists.
 
 - [x] **M2 — User column → nullable tri-state + candidate gate + Go-type ripple.** *(Offline + LiveDB)*
-  New migration (number at merge time; live head 00185, so this lands at 00186):
+  New migration (number at merge time; live head 00185, so this lands at 00186): (Superseded — see As-built deltas above: landed as 00190.)
   - Up: `ALTER TABLE users ALTER COLUMN ci_autofix_enabled DROP NOT NULL, DROP DEFAULT;` then
     `UPDATE users SET ci_autofix_enabled = NULL WHERE ci_autofix_enabled = false;` (existing `true`
     preserved).
@@ -144,7 +144,7 @@ mr_rework is the template, but ci_autofix differs in ways that make this more th
 
   Change `ci_autofix.sql:76` `AND u.ci_autofix_enabled` → `AND u.ci_autofix_enabled IS NOT FALSE`.
   Regenerate sqlc; `store.User.CiAutofixEnabled` flips `bool` → `pgtype.Bool` — fix `handler/handler.go:477`
-  (`toDTO`, resolve inherit→true) and the `SetUserCIAutofixEnabled` param.
+  (`toDTO`, resolve inherit→true) and the `SetUserCIAutofixEnabled` param. (Superseded — see As-built deltas above: the DTO is nullable `*bool` / `boolean|null` end-to-end, preserving the null clear-to-inherit path.)
 
 - [x] **M3 — Tri-state over the API + web toggles.** *(Offline; web)*
   Retrofit the dedicated endpoints to carry inherit/clear: `handler/ci_autofix_toggle.go`

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -20237,12 +20237,17 @@ also reach — those must never spawn runs).
 - **Sibling of the PRD #19 autopilot detector** (`api/internal/poller/ci_autofix.go`): runs
   each tick **after** the pipeline-status sync, on the freshly-refreshed `pipeline_statuses`
   cache — the same "detect only in the poller" placement as §98. Nil-optional-wired via
-  `engine.SetCIAutoFix(...)` in `api/cmd/server/main.go`; **not wiring it is the instance
-  kill-switch** (the autopilot nil pattern), and it can only run where the pipeline watch is
-  on (`CI_WATCH_MAX_REFS>0`), since it reads that cache.
-- **Global `app_settings.ci_autofix_enabled` (full judge parity) deliberately deferred** —
-  the optional-wiring is the instance switch, per-user opt-in is the consent gate; a global
-  KV kill-switch is a documented follow-up (Decision Log Q4), not shipped.
+  `engine.SetCIAutoFix(...)` in `api/cmd/server/main.go`; leaving it un-wired disables the
+  detector (the autopilot nil pattern), and it can only run where the pipeline watch is
+  on (`CI_WATCH_MAX_REFS>0`), since it reads that cache. The runtime kill-switch is the
+  admin global below, not the wiring.
+- **Global `settings.ci_autofix_enabled` admin kill-switch shipped in PRD #914** (was
+  deferred under PRD #71) — a text `"true"`/`"false"` KV, compiled default `"true"`, so the
+  feature ships ON. The accessor `settings.CiAutofixEnabled` (`settings/settings_ci_autofix.go`,
+  key `settings/keys.go#KeyCiAutofixEnabled`) is DELIBERATELY three-state and
+  error-propagating, mirroring `MrReworkEnabled`: absent/malformed → default ON, but a store
+  READ ERROR must not be misread as absent; the accessor propagates the error and the detector
+  (`poller/ci_autofix.go`) is the caller that maps a non-nil error to OFF (**fail closed**).
 
 ## 513. PRD #71 — durable `ci_autofix_attempts` ledger: the `autopilot_triggers` analogue, keyed `(repo_id, ref)`
 
@@ -20380,12 +20385,19 @@ Serves human: "on giving up, uzi comments + notifies"; the notification story PR
 
 ## 519. PRD #71 — scope, opt-in, and cross-forge posture
 
-Serves human: "opt-in per-user default OFF, admin can force-toggle; agent-owned MR branches
-only; never main/protected."
+Serves human: "on by default per user (tri-state opt-out, NULL=inherit=on), admin can
+force-toggle; agent-owned MR branches only; never main/protected." (Updated PRD #914; PRD
+#71 originally shipped this per-user default OFF.)
 
-- **Per-user `ci_autofix_enabled`, default OFF** (migration `00115_user_ci_autofix_enabled`,
-  mirrors the judge/autopilot boolean): self-service PUT + an **admin force-toggle** (judge
-  parity). Surfaced on the user DTO and web `Settings.tsx` / `AdminUsers.tsx`.
+- **Per-user `ci_autofix_enabled` is a NULLABLE tri-state, default ON** (PRD #914, migration
+  `00190_user_ci_autofix_tristate`): NULL = inherit = on, `true` = explicit opt-in, `false` =
+  explicit opt-out. The candidate gate is `AND u.ci_autofix_enabled IS NOT FALSE`
+  (`store/ci_autofix.sql.go`), so only an explicit `false` suppresses. PRD #71's original
+  `00115_user_ci_autofix_enabled` column was `NOT NULL DEFAULT false`; 00190 does a one-time
+  `false → NULL` fold (down-migration re-folds `NULL → false` and restores NOT NULL/default)
+  so the pre-914 default-off rows become inherit-on rather than staying silently opted out.
+  Self-service PUT + an **admin force-toggle** (judge parity). Surfaced on the user DTO and
+  web `Settings.tsx` / `AdminUsers.tsx`.
 - **MR-branch pipelines only** (`refs/merge-requests/*` of `agent/issue-N` branches); `main`,
   default, and protected branches are **never** auto-touched — a fix lands on the MR branch
   and a human still merges (the primary directive). The four `main`-untouched guardrail layers

--- a/specs/human.md
+++ b/specs/human.md
@@ -473,7 +473,7 @@ Tracked as GitLab issue vtmocanu/uzi#64; PRD at `prds/done/64-uzi-cli.md`.
 
 Tracked as GitLab issue vtmocanu/uzi#71; PRD at `prds/done/71-ci-autofix.md`.
 
-- Automatic CI-fix is ON by default for every user (per-user tri-state opt-out, NULL=inherit=on), behind an admin instance-wide kill-switch (default on); admin can force-toggle any user. [user 2026-07-17] (AI-synced 2026-09-05, PRD #914)
+- Automatic CI-fix is ON by default for every user (per-user tri-state opt-out, NULL=inherit=on), behind an admin instance-wide kill-switch (default on); admin can force-toggle any user. [user, PRD #914 — supersedes the earlier default-off from #71]
 - Fires only on agent-owned MR-branch pipelines (`agent/issue-N`); `main`/protected branches are never auto-touched — a fix still lands on the MR branch and a human still merges (primary directive). [user 2026-07-17]
 - Loop-guarded: max 2 automatic attempts per branch + an early stop when the failure hasn't changed; on giving up, uzi comments + notifies and stops (the manual Fix CI button remains). [user 2026-07-17]
 - "Usually we fix the code, not CI itself, but if CI is really at fault we can add a CI fix in the MR" — code fixes push automatically; a fix that edits the CI config passes the approval gate (human-approved before it pushes). [user 2026-07-17]

--- a/specs/human.md
+++ b/specs/human.md
@@ -473,7 +473,7 @@ Tracked as GitLab issue vtmocanu/uzi#64; PRD at `prds/done/64-uzi-cli.md`.
 
 Tracked as GitLab issue vtmocanu/uzi#71; PRD at `prds/done/71-ci-autofix.md`.
 
-- Opt-in per-user automatic CI-fix, default OFF (mirrors judge/autopilot); admin can force-toggle. [user 2026-07-17]
+- Automatic CI-fix is ON by default for every user (per-user tri-state opt-out, NULL=inherit=on), behind an admin instance-wide kill-switch (default on); admin can force-toggle any user. [user 2026-07-17] (AI-synced 2026-09-05, PRD #914)
 - Fires only on agent-owned MR-branch pipelines (`agent/issue-N`); `main`/protected branches are never auto-touched — a fix still lands on the MR branch and a human still merges (primary directive). [user 2026-07-17]
 - Loop-guarded: max 2 automatic attempts per branch + an early stop when the failure hasn't changed; on giving up, uzi comments + notifies and stops (the manual Fix CI button remains). [user 2026-07-17]
 - "Usually we fix the code, not CI itself, but if CI is really at fault we can add a CI fix in the MR" — code fixes push automatically; a fix that edits the CI config passes the approval gate (human-approved before it pushes). [user 2026-07-17]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -367,7 +367,7 @@ const realApi = {
     request<{ user: User }>("PUT", `/admin/users/${id}/judge`, { enabled }),
   // Admin per-user CI-autofix toggle (PRD #71): force any user's opt-in. Actor is
   // admin (route-gated); target is the path id, never the body. Returns the user.
-  setUserCIAutofixEnabled: (id: string, enabled: boolean) =>
+  setUserCIAutofixEnabled: (id: string, enabled: boolean | null) =>
     request<{ user: User }>("PUT", `/admin/users/${id}/ci-autofix`, { enabled }),
   getSettings: () => request<SettingsResponse>("GET", "/admin/settings"),
   updateSettings: (settings: UpdateSettingsPayload) =>
@@ -425,7 +425,7 @@ const realApi = {
     request<{ user: User }>("PUT", "/me/autopilot", { enabled }),
   // Flip the current user's CI-autofix opt-in (PRD #71). Session identity only —
   // the body carries no user id. Returns the updated user.
-  setCIAutofixEnabled: (enabled: boolean) =>
+  setCIAutofixEnabled: (enabled: boolean | null) =>
     request<{ user: User }>("PUT", "/me/ci-autofix", { enabled }),
   // Flip the current user's AI-attribution opt-out (issue #916). Session identity only —
   // the body carries no user id. Returns the updated user.

--- a/web/src/lib/apiTypes.ts
+++ b/web/src/lib/apiTypes.ts
@@ -17,10 +17,11 @@ export interface User {
   // judge_enabled is the per-user opt-in to run retrospectives (PRD #46). Default
   // false; the user toggles their own from Settings, an admin can force any user's.
   judge_enabled: boolean;
-  // ci_autofix_enabled is the per-user opt-in to automatic CI fixes (PRD #71).
-  // Default false; the user toggles their own from Settings, an admin can force any
-  // user's.
-  ci_autofix_enabled: boolean;
+  // ci_autofix_enabled is the per-user opt-in to automatic CI fixes (PRD #71, made
+  // a tri-state in #914 M3): true = explicit on, false = explicit off, null =
+  // inherit the admin global default (on). The user toggles their own from
+  // Settings, an admin can force any user's.
+  ci_autofix_enabled: boolean | null;
   // attribution_enabled is the per-user opt-out for AI attribution in worker commits
   // (issue #916). Default TRUE (today's behavior): when true the worker's commits keep
   // the Co-Authored-By: Claude trailer; when false it is suppressed on the user's next

--- a/web/src/lib/apiTypes.ts
+++ b/web/src/lib/apiTypes.ts
@@ -717,6 +717,10 @@ export interface AppSettings {
   judge_enforce_all: string;
   judge_cooldown_seconds: string;
   judge_daily_budget: string;
+  // Instance-wide CI-autofix kill-switch (PRD #914). The text "true"/"false" (default
+  // "true"). When OFF, no user's failed pipeline is auto-fixed regardless of their
+  // per-user opt-in — the admin per-user CI-autofix toggle is inert while it is off.
+  ci_autofix_enabled: string;
   // Ephemeral worker auto-provisioning instance kill-switch (PRD #529 / #649 M1).
   // The text "true"/"false" (default "false"). When OFF, no run ever auto-provisions
   // a throwaway hosted worker regardless of a user's per-account opt-in; when ON,

--- a/web/src/mocks/mockApi/settings.ts
+++ b/web/src/mocks/mockApi/settings.ts
@@ -676,13 +676,13 @@ export const settingsApi = {
 
   // ── CI-autofix opt-in (PRD #71) ──────────────────────────────────────────────
   // Own-user (session identity, never a body id, mirroring the server).
-  setCIAutofixEnabled: async (enabled: boolean) => {
+  setCIAutofixEnabled: async (enabled: boolean | null) => {
     const u = requireSession();
     u.ci_autofix_enabled = enabled;
     return delay({ user: { ...u } }, 200);
   },
   // Admin per-user toggle: target from the id argument (the path on the server).
-  setUserCIAutofixEnabled: async (id: string, enabled: boolean) => {
+  setUserCIAutofixEnabled: async (id: string, enabled: boolean | null) => {
     const u = users.find((x) => x.id === id);
     if (!u) throw new ApiError(404, "user not found");
     u.ci_autofix_enabled = enabled;

--- a/web/src/mocks/mockApi/settings.ts
+++ b/web/src/mocks/mockApi/settings.ts
@@ -55,6 +55,8 @@ const SEED_APP_SETTINGS: AppSettings = {
   judge_enforce_all: "false",
   judge_cooldown_seconds: "60",
   judge_daily_budget: "0",
+  // PRD #914: instance-wide CI-autofix kill-switch, default ON.
+  ci_autofix_enabled: "true",
   // PRD #529 / #649 M1: ephemeral worker auto-provisioning instance kill-switch, default OFF.
   ephemeral_workers_enabled: "false",
   // PRD #836: upstream release-check toggles, both default ON (the master air-gap

--- a/web/src/pages/AdminBranding.test.tsx
+++ b/web/src/pages/AdminBranding.test.tsx
@@ -37,6 +37,7 @@ const settings = (over: Partial<AppSettings> = {}): AppSettings => ({
   judge_cooldown_seconds: "60",
   judge_daily_budget: "0",
   ephemeral_workers_enabled: "false",
+  ci_autofix_enabled: "true",
   release_check_enabled: "true",
   release_check_banner_enabled: "true",
   summary_model: "haiku",

--- a/web/src/pages/AdminSettings.test.tsx
+++ b/web/src/pages/AdminSettings.test.tsx
@@ -44,6 +44,7 @@ const settings = (over: Partial<import("../lib/api").AppSettings> = {}) => ({
   judge_cooldown_seconds: "60",
   judge_daily_budget: "0",
   ephemeral_workers_enabled: "false",
+  ci_autofix_enabled: "true",
   release_check_enabled: "true",
   release_check_banner_enabled: "true",
   summary_model: "haiku",

--- a/web/src/pages/AdminSettingsUpdates.test.tsx
+++ b/web/src/pages/AdminSettingsUpdates.test.tsx
@@ -47,6 +47,7 @@ const settings = (over: Partial<Settings> = {}): Settings => ({
   judge_cooldown_seconds: "60",
   judge_daily_budget: "0",
   ephemeral_workers_enabled: "false",
+  ci_autofix_enabled: "true",
   release_check_enabled: "true",
   release_check_banner_enabled: "true",
   summary_model: "haiku",

--- a/web/src/pages/AdminUsers.test.tsx
+++ b/web/src/pages/AdminUsers.test.tsx
@@ -129,6 +129,35 @@ describe("AdminUsers judge enforced mode (PRD #69 M4)", () => {
   });
 });
 
+// PRD #914 M2/M3: the admin CI-autofix column is now tri-state (boolean | null). A null
+// (inherit) user collapses to On/Disable, exactly as an explicit true does; only an
+// explicit false shows Off/Enable. Every existing fixture pins false, so this null→On
+// flip was untested — a plain-bool / `?? false` read would render null as Off/Enable and
+// still pass the old suite, so this test is what pins the inherit-renders-on semantics.
+describe("AdminUsers CI autofix tri-state display (PRD #914 M3)", () => {
+  it("shows a null (inherit) user's CI-autofix badge as On and the action as Disable", async () => {
+    mockApi.listUsers.mockResolvedValue({ users: [aUser({ ci_autofix_enabled: null })] });
+
+    render(
+      <MemoryRouter>
+        <AdminUsers />
+      </MemoryRouter>,
+    );
+
+    const row = (await screen.findByText("mira@uzi.local")).closest("tr")!;
+    // CI autofix is cell index 5 (0 Email, 1 Name, 2 Role, 3 Status, 4 Judge, 5 CI
+    // autofix, 6 Last login, 7 Action). Scope to it so the Judge column's own On/Off
+    // badge and Enable/Disable button don't collide.
+    const ciCell = () => within(within(row).getAllByRole("cell")[5]);
+    // Inherit (null) collapses to On/Disable, NOT Off/Enable — a `?? false` or
+    // plain-bool read would show Off/Enable here.
+    expect(ciCell().getByText("On")).toBeTruthy();
+    expect(ciCell().getByText("Disable")).toBeTruthy();
+    expect(ciCell().queryByText("Off")).toBeNull();
+    expect(ciCell().queryByText("Enable")).toBeNull();
+  });
+});
+
 describe("AdminUsers name fallback (PRD #54)", () => {
   it("renders an em-dash for an empty-string display_name (?? missed it)", async () => {
     mockApi.listUsers.mockResolvedValue({ users: [aUser({ display_name: "" })] });

--- a/web/src/pages/AdminUsers.test.tsx
+++ b/web/src/pages/AdminUsers.test.tsx
@@ -25,10 +25,17 @@ vi.mock("../auth/AuthContext", () => ({ useAuth: vi.fn() }));
 
 const mockApi = vi.mocked(api);
 
-// settingsResp is the minimal admin settings the AdminUsers load path reads: only
-// judge_enforce_all is consumed, so the rest is a thin cast.
-function settingsResp(enforceAll: boolean): SettingsResponse {
-  return { settings: { judge_enforce_all: enforceAll ? "true" : "false" } } as unknown as SettingsResponse;
+// settingsResp is the minimal admin settings the AdminUsers load path reads:
+// judge_enforce_all and (PRD #914) the instance-wide ci_autofix_enabled kill-switch are
+// consumed, so the rest is a thin cast. ciAutofixEnabled defaults to on, matching the
+// server default, so existing tests keep the per-user CI-autofix control live.
+function settingsResp(enforceAll: boolean, ciAutofixEnabled = true): SettingsResponse {
+  return {
+    settings: {
+      judge_enforce_all: enforceAll ? "true" : "false",
+      ci_autofix_enabled: ciAutofixEnabled ? "true" : "false",
+    },
+  } as unknown as SettingsResponse;
 }
 
 function aUser(over: Partial<User> = {}): User {
@@ -155,6 +162,55 @@ describe("AdminUsers CI autofix tri-state display (PRD #914 M3)", () => {
     expect(ciCell().getByText("Disable")).toBeTruthy();
     expect(ciCell().queryByText("Off")).toBeNull();
     expect(ciCell().queryByText("Enable")).toBeNull();
+  });
+});
+
+// PRD #914 M1: the instance-wide ci_autofix_enabled kill-switch dominates the per-user
+// column. When it is "false" every user's CI-autofix is inert regardless of their own
+// flag, so the badge must read Off and the toggle must be disabled — otherwise clicking
+// "Disable" on an inherit (null) user would persist an explicit false that survives the
+// global being re-enabled (the sticky-false trap this fix removes).
+describe("AdminUsers CI autofix instance kill-switch (PRD #914 M1)", () => {
+  it("shows Off and disables the toggle for a null user when the instance switch is off", async () => {
+    mockApi.listUsers.mockResolvedValue({ users: [aUser({ ci_autofix_enabled: null })] });
+    mockApi.getSettings.mockResolvedValue(settingsResp(false, false));
+
+    render(
+      <MemoryRouter>
+        <AdminUsers />
+      </MemoryRouter>,
+    );
+
+    const row = (await screen.findByText("mira@uzi.local")).closest("tr")!;
+    // CI autofix is cell index 5 (0 Email, 1 Name, 2 Role, 3 Status, 4 Judge, 5 CI
+    // autofix, 6 Last login, 7 Action). Scope to it so the Judge column's own inert
+    // note and On/Off badge don't collide.
+    const ciCell = () => within(within(row).getAllByRole("cell")[5]);
+    // Wait for the best-effort settings read to land, then assert the inert state.
+    await waitFor(() => expect(ciCell().getByText(/Inert/).textContent).toContain("kill-switch"));
+    expect(ciCell().getByText("Off")).toBeTruthy();
+    expect(ciCell().queryByText("On")).toBeNull();
+    const btn = ciCell().getByText("Enable") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("keeps the null user On with an enabled toggle when the instance switch is on", async () => {
+    mockApi.listUsers.mockResolvedValue({ users: [aUser({ ci_autofix_enabled: null })] });
+    mockApi.getSettings.mockResolvedValue(settingsResp(false, true));
+
+    render(
+      <MemoryRouter>
+        <AdminUsers />
+      </MemoryRouter>,
+    );
+
+    const row = (await screen.findByText("mira@uzi.local")).closest("tr")!;
+    const ciCell = () => within(within(row).getAllByRole("cell")[5]);
+    // Inherit (null) collapses to On/Disable; the switch being on leaves it live.
+    await waitFor(() => expect(ciCell().getByText("On")).toBeTruthy());
+    const btn = ciCell().getByText("Disable") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(ciCell().queryByText(/Inert/)).toBeNull();
   });
 });
 

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -27,6 +27,13 @@ export function AdminUsers() {
   // best-effort from the admin settings alongside the user list; a failed read leaves
   // it false so the toggle stays live rather than falsely claiming to be inert.
   const [judgeEnforceAll, setJudgeEnforceAll] = useState(false);
+  // Whether the instance-wide CI-autofix kill-switch is OFF (PRD #914 M1). When the
+  // global ci_autofix_enabled is "false" no user's pipeline is auto-fixed regardless
+  // of their per-user flag, so the per-user toggle in this table is INERT — greyed and
+  // annotated, not removed, exactly like judgeEnforceAll above. Read best-effort from
+  // the admin settings; a failed read leaves it false so the toggle stays live rather
+  // than falsely claiming to be inert.
+  const [ciAutofixInstanceOff, setCiAutofixInstanceOff] = useState(false);
 
   const { loading, error: loadError } = useAsyncData(
     async ({ isCurrent }) => {
@@ -40,9 +47,15 @@ export function AdminUsers() {
       setUsers(users);
       try {
         const { settings } = await api.getSettings();
-        if (isCurrent()) setJudgeEnforceAll(settings.judge_enforce_all === "true");
+        if (isCurrent()) {
+          setJudgeEnforceAll(settings.judge_enforce_all === "true");
+          setCiAutofixInstanceOff(settings.ci_autofix_enabled === "false");
+        }
       } catch {
-        if (isCurrent()) setJudgeEnforceAll(false);
+        if (isCurrent()) {
+          setJudgeEnforceAll(false);
+          setCiAutofixInstanceOff(false);
+        }
       }
     },
     [],
@@ -159,19 +172,27 @@ export function AdminUsers() {
                       )}
                     </td>
                     <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Badge tone={u.ci_autofix_enabled !== false ? "ok" : "neutral"} dot>
-                          {u.ci_autofix_enabled !== false ? "On" : "Off"}
+                      <div className={`flex items-center gap-2 ${ciAutofixInstanceOff ? "opacity-50" : ""}`}>
+                        <Badge
+                          tone={!ciAutofixInstanceOff && u.ci_autofix_enabled !== false ? "ok" : "neutral"}
+                          dot
+                        >
+                          {!ciAutofixInstanceOff && u.ci_autofix_enabled !== false ? "On" : "Off"}
                         </Badge>
                         <Button
                           variant="ghost"
                           size="sm"
-                          disabled={ciAutofixBusyId === u.id}
+                          disabled={ciAutofixBusyId === u.id || ciAutofixInstanceOff}
                           onClick={() => toggleCIAutofix(u)}
                         >
-                          {u.ci_autofix_enabled !== false ? "Disable" : "Enable"}
+                          {!ciAutofixInstanceOff && u.ci_autofix_enabled !== false ? "Disable" : "Enable"}
                         </Button>
                       </div>
+                      {ciAutofixInstanceOff && (
+                        <p className="mt-1 text-xs text-faint">
+                          Inert: the instance kill-switch is off; autofix is disabled for every user.
+                        </p>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-muted">
                       {u.last_login ? new Date(u.last_login).toLocaleString() : "—"}

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -85,7 +85,11 @@ export function AdminUsers() {
     setError("");
     setCiAutofixBusyId(u.id);
     try {
-      const { user } = await api.setUserCIAutofixEnabled(u.id, !u.ci_autofix_enabled);
+      // NULL (inherit) and true both read as currently-on (PRD #914 M3); the admin
+      // control is an explicit force-toggle, so it always sends the opposite bool
+      // (never clears to inherit — that is a self-service capability only).
+      const currentlyOn = u.ci_autofix_enabled !== false;
+      const { user } = await api.setUserCIAutofixEnabled(u.id, !currentlyOn);
       setUsers((prev) => prev.map((x) => (x.id === user.id ? user : x)));
     } catch (err) {
       setError(errorMessage(err, "Update failed"));
@@ -156,8 +160,8 @@ export function AdminUsers() {
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">
-                        <Badge tone={u.ci_autofix_enabled ? "ok" : "neutral"} dot>
-                          {u.ci_autofix_enabled ? "On" : "Off"}
+                        <Badge tone={u.ci_autofix_enabled !== false ? "ok" : "neutral"} dot>
+                          {u.ci_autofix_enabled !== false ? "On" : "Off"}
                         </Badge>
                         <Button
                           variant="ghost"
@@ -165,7 +169,7 @@ export function AdminUsers() {
                           disabled={ciAutofixBusyId === u.id}
                           onClick={() => toggleCIAutofix(u)}
                         >
-                          {u.ci_autofix_enabled ? "Disable" : "Enable"}
+                          {u.ci_autofix_enabled !== false ? "Disable" : "Enable"}
                         </Button>
                       </div>
                     </td>

--- a/web/src/pages/RunDefaults.test.tsx
+++ b/web/src/pages/RunDefaults.test.tsx
@@ -624,9 +624,10 @@ describe("Run defaults — early-limit-reset alert (PRD #1020 M5)", () => {
   });
 });
 
-// Issue #916 M4: the per-user AI-attribution opt-out. DEFAULT ON (opt-out), the
-// OPPOSITE of ci_autofix — so a field-absent user renders CHECKED, and the copy must
-// describe the commit trailer, never the MR description.
+// Issue #916 M4: the per-user AI-attribution opt-out. DEFAULT ON (opt-out) — so a
+// field-absent user renders CHECKED, and the copy must describe the commit trailer,
+// never the MR description. (Post-PRD-#914-M3 ci_autofix is likewise default-on when
+// its value is absent/null, so this is no longer the opposite of ci_autofix.)
 describe("Run defaults — AI attribution opt-out (issue #916 M4)", () => {
   const attributionToggle = () =>
     screen.getByLabelText(
@@ -725,5 +726,50 @@ describe("Run defaults — AI attribution opt-out (issue #916 M4)", () => {
 
     expect(await screen.findByText("internal error")).toBeTruthy();
     expect(attributionToggle().disabled).toBe(false);
+  });
+});
+
+// PRD #914 M2/M3: the per-user CI-autofix opt-in is now TRI-STATE (boolean | null).
+// The DISPLAY collapses inherit (null) and explicit true to CHECKED, and only an
+// explicit false to UNCHECKED — checked={user?.ci_autofix_enabled !== false}. The null
+// (inherit) branch was previously untested (every fixture pinned false), so a `?? false`
+// or plain-bool display would render null as UNCHECKED and still pass the old suite; the
+// null→CHECKED assertion below is what pins the tri-state semantics.
+describe("Run defaults — CI autofix tri-state display (PRD #914 M3)", () => {
+  const ciAutofixToggle = () =>
+    screen.getByLabelText(
+      "Automatically fix my failed CI pipelines",
+    ) as HTMLInputElement;
+
+  it("renders CHECKED when ci_autofix_enabled is null (inherit → on)", () => {
+    mockAuth({ ...baseUser, ci_autofix_enabled: null });
+    render(
+      <MemoryRouter>
+        <RunDefaults />
+      </MemoryRouter>,
+    );
+    // Under the old `?? false` display this would be UNCHECKED; the tri-state
+    // `!== false` renders inherit as on.
+    expect(ciAutofixToggle().checked).toBe(true);
+  });
+
+  it("renders CHECKED when ci_autofix_enabled is true", () => {
+    mockAuth({ ...baseUser, ci_autofix_enabled: true });
+    render(
+      <MemoryRouter>
+        <RunDefaults />
+      </MemoryRouter>,
+    );
+    expect(ciAutofixToggle().checked).toBe(true);
+  });
+
+  it("renders UNCHECKED when ci_autofix_enabled is explicitly false", () => {
+    mockAuth({ ...baseUser, ci_autofix_enabled: false });
+    render(
+      <MemoryRouter>
+        <RunDefaults />
+      </MemoryRouter>,
+    );
+    expect(ciAutofixToggle().checked).toBe(false);
   });
 });

--- a/web/src/pages/RunDefaults.tsx
+++ b/web/src/pages/RunDefaults.tsx
@@ -572,9 +572,11 @@ export function RunDefaults() {
         <div>
           <SectionTitle>Automatic CI fixes</SectionTitle>
           <p className="mt-2 text-sm text-muted">
-            With this on, when a pipeline fails on one of your agent merge-request branches, uzi spends
-            your <strong className="text-fg">own Anthropic tokens</strong> to attempt a fix automatically.
-            Off by default.
+            When a pipeline fails on one of your agent merge-request branches, uzi spends your{" "}
+            <strong className="text-fg">own Anthropic tokens</strong> to attempt a fix automatically.
+            On by default. Opting out stops autofix on{" "}
+            <strong className="text-fg">your</strong> MRs — the admin kill-switch that turns the
+            feature off for the whole instance is separate.
           </p>
         </div>
 
@@ -584,7 +586,7 @@ export function RunDefaults() {
           <input
             type="checkbox"
             className="h-4 w-4 accent-brand"
-            checked={user?.ci_autofix_enabled ?? false}
+            checked={user?.ci_autofix_enabled !== false}
             disabled={ciAutofixBusy}
             onChange={(e) => toggleCIAutofix(e.target.checked)}
           />


### PR DESCRIPTION
Implements issue #914.

Closes #914

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-914`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic CI fixes are now enabled by default.
  * Users can inherit the default, explicitly enable fixes, or opt out.
  * Administrators can control CI autofix globally or for individual users.
  * Scheduled-run merge requests inherit the owner’s autofix setting.
* **Bug Fixes**
  * CI autofix now stops safely when the global setting cannot be read.
* **Documentation**
  * Updated configuration, scheduling, and CI autofix guidance to reflect default-on behavior and inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->