### PR TITLE
model-pass: HOME cleanup can race the aborted SDK CLI on the timeout path

### DIFF
--- a/agent/src/model-pass.ts
+++ b/agent/src/model-pass.ts
@@ -76,6 +76,12 @@ export interface ReadOnlyModelPassOpts {
   /** "judge" | "review" | "summary" — used in the timeout + generic-error messages. */
   label: string;
   timeoutMs: number;
+  /** Bounded grace, after the wall-clock abort, to wait for the SDK query to settle
+   *  before the ephemeral HOME is removed — so cleanup does not race the aborted CLI
+   *  while it is still exiting and may still touch $HOME. Defaults to
+   *  DEFAULT_ABORT_GRACE_MS; the three runners omit it. Tests inject a value to drive
+   *  the timeout path deterministically. */
+  graceMs?: number;
   queryFn: SdkQueryFn;
   /** The deny-hook reason string (verbatim per runner). */
   denyReason: string;
@@ -87,6 +93,35 @@ export interface ReadOnlyModelPassOpts {
    *  `${label} model call returned an error result` on an error frame, return the
    *  accumulated text on success. */
   onResult?(msg: unknown, ctx: { isError: boolean; latest: RateLimitObservation | undefined }): void;
+}
+
+/** Default bounded grace (ms) for the aborted SDK CLI to finish exiting before its
+ *  ephemeral HOME is removed. Generous versus the near-immediate ProcessTransport.close()
+ *  termination scheduling, and it is a best-effort cleanup guard, not a correctness
+ *  guarantee — the grace only ever elapses on the timeout path when the query does not
+ *  settle promptly after abort (the normal success path settles the query before cleanup,
+ *  so no grace is waited). */
+const DEFAULT_ABORT_GRACE_MS = 500;
+
+/** Wait for the (possibly aborted) SDK query to settle before its HOME is removed, so the
+ *  ephemeral HOME is not rm'd while the aborted CLI is still exiting and may still touch
+ *  $HOME (the SDK's abort handler terminates the CLI asynchronously). Bounded by graceMs
+ *  so a query that never settles after abort can never wedge cleanup. NEVER rejects: the
+ *  query's own rejection was already surfaced to the caller by the race in
+ *  runReadOnlyModelPass, so it is swallowed here (attaching a rejection handler also keeps
+ *  a post-abort rejection from surfacing as an unhandled rejection) — cleanup must never
+ *  fail a run. */
+async function awaitQuerySettled(query: Promise<unknown>, graceMs: number): Promise<void> {
+  let graceTimer: NodeJS.Timeout | undefined;
+  const grace = new Promise<void>((resolve) => {
+    graceTimer = setTimeout(resolve, graceMs);
+    graceTimer.unref?.();
+  });
+  try {
+    await Promise.race([query.then(() => {}, () => {}), grace]);
+  } finally {
+    if (graceTimer) clearTimeout(graceTimer);
+  }
 }
 
 /**
@@ -117,10 +152,17 @@ export async function runReadOnlyModelPass(opts: ReadOnlyModelPassOpts): Promise
       reject(new Error(`${opts.label} model call exceeded ${opts.timeoutMs}ms`));
     }, opts.timeoutMs);
   });
+  const consumePromise = consume(opts, homeDir, abort);
   try {
-    return await Promise.race([consume(opts, homeDir, abort), timeout]);
+    return await Promise.race([consumePromise, timeout]);
   } finally {
     if (timer) clearTimeout(timer);
+    // Defer HOME cleanup until the query settles (bounded by a grace after abort): on the
+    // timeout path the race rejects as soon as `abort.abort()` fires, but the SDK
+    // terminates the CLI asynchronously, so removing HOME here immediately could race the
+    // aborted CLI while it is still exiting and may still touch $HOME. On the success path
+    // the query has already settled, so this returns without waiting.
+    await awaitQuerySettled(consumePromise, opts.graceMs ?? DEFAULT_ABORT_GRACE_MS);
     // Best-effort HOME cleanup. The M6 reclaim sweep will NEVER collect this directory:
     // it is named `uzi-<label>-*`, not a run UUID, so the sweep's RUN_ID_RE filter skips
     // it BY DESIGN — this warn is the only thing anywhere that will say a dir stranded.

--- a/agent/test/model-pass.test.ts
+++ b/agent/test/model-pass.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import { promises as fs } from "node:fs";
+import { existsSync } from "node:fs";
 
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
 
@@ -140,5 +141,150 @@ describe("runReadOnlyModelPass — HOME lifecycle", () => {
     const after = await fs.readdir(os.tmpdir());
     const stranded = after.find((d) => d.startsWith("uzi-modelpass-cleanup-"));
     assert.equal(stranded, undefined, "the ephemeral HOME dir is cleaned up");
+  });
+});
+
+// ── issue #933: HOME cleanup must not race the aborted SDK CLI on the timeout path ──
+//
+// runReadOnlyModelPass races the query against a wall-clock timeout that calls
+// `abort.abort()`; the SDK terminates the CLI asynchronously, so cleanup must wait for the
+// query to settle (bounded by a grace) before removing the ephemeral HOME — otherwise it
+// can rm $HOME while the aborted CLI is still exiting and may still touch it. These
+// fixtures drive an aborting/gated query and read the ephemeral HOME from
+// `options.env.HOME` (buildSdkEnv pins HOME = homeDir). Assertions are timing-free (no
+// Date.now()/sleep comparisons); node's --test-timeout is the only backstop for a hang.
+
+interface FixtureOptions {
+  env?: Record<string, string | undefined>;
+  abortController?: AbortController;
+}
+
+/** Resolve once the query's abort signal has fired (or is already aborted). */
+function whenAborted(signal: AbortSignal | undefined): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!signal || signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+describe("runReadOnlyModelPass — HOME cleanup vs the aborted CLI (issue #933)", () => {
+  it("timeout path: aborts the query, rejects, and removes HOME only after the query settles", async () => {
+    let capturedHome: string | undefined;
+    let homeExistedAtSettle: boolean | undefined;
+
+    // Never yields a terminal result, so the wall-clock timeout wins the race. On abort
+    // (the exiting CLI) it records whether HOME still exists, then ends the iteration so
+    // the consume() promise settles.
+    const queryFn: SdkQueryFn = (params) => {
+      const fixtureOpts = (params as { options: FixtureOptions }).options;
+      capturedHome = fixtureOpts.env?.HOME;
+      const signal = fixtureOpts.abortController?.signal;
+      // A hung/aborting query is the fixture: it never yields a terminal result (mirrors
+      // judge-runner.test's hung fixture), so the wall-clock timeout fires.
+      // eslint-disable-next-line require-yield
+      return (async function* () {
+        await whenAborted(signal);
+        homeExistedAtSettle = capturedHome ? existsSync(capturedHome) : undefined;
+      })() as never;
+    };
+
+    await assert.rejects(
+      runReadOnlyModelPass(baseOpts({ queryFn, timeoutMs: 5, graceMs: 1000 })),
+      /review model call exceeded 5ms/,
+    );
+    assert.equal(homeExistedAtSettle, true, "HOME must still exist when the aborted query settles");
+    assert.ok(capturedHome, "the query must have received an ephemeral HOME");
+    assert.equal(existsSync(capturedHome!), false, "HOME must be removed after the query settles");
+  });
+
+  it("timeout path: the pass does not settle (HOME is not cleaned) until the query settles", async () => {
+    let openGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+    let sawAbort!: () => void;
+    const abortSeen = new Promise<void>((resolve) => {
+      sawAbort = resolve;
+    });
+
+    // After abort the query does NOT settle on its own — it blocks on a test-controlled
+    // gate, modelling the aborted CLI still exiting. With the fix, cleanup (and thus the
+    // returned promise) is deferred until the query settles; without it, the finally
+    // removes HOME and the promise rejects at the timeout, gate still closed.
+    const queryFn: SdkQueryFn = (params) => {
+      const signal = (params as { options: FixtureOptions }).options.abortController?.signal;
+      // eslint-disable-next-line require-yield
+      return (async function* () {
+        await whenAborted(signal);
+        sawAbort();
+        await gate;
+      })() as never;
+    };
+
+    // graceMs is an hour: the grace must not be what unblocks cleanup here — only the
+    // query settling (via the gate) may.
+    const pass = runReadOnlyModelPass(baseOpts({ queryFn, timeoutMs: 5, graceMs: 3_600_000 }));
+    let settled = false;
+    pass.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await abortSeen;
+    // Drain the event loop so that if cleanup were NOT deferred, the finally would have
+    // removed HOME and settled the promise by now (no wall-clock wait — just event-loop
+    // yields). With the fix the query is still gated, so the pass stays pending here no
+    // matter how many turns elapse.
+    for (let i = 0; i < 20; i++) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(settled, false, "the pass must not settle until the query settles");
+
+    openGate();
+    await assert.rejects(pass, /review model call exceeded 5ms/);
+  });
+
+  it("timeout path: a query that rejects after abort is swallowed — the run still cleans HOME", async () => {
+    let capturedHome: string | undefined;
+    let homeExistedAtSettle: boolean | undefined;
+
+    // On abort the query records, then rejects. The timeout error (not the query error)
+    // must propagate, cleanup must still run, and the rejection must not surface as an
+    // unhandled rejection (which node's test runner would fail on).
+    const queryFn: SdkQueryFn = (params) => {
+      const fixtureOpts = (params as { options: FixtureOptions }).options;
+      capturedHome = fixtureOpts.env?.HOME;
+      const signal = fixtureOpts.abortController?.signal;
+      // eslint-disable-next-line require-yield
+      return (async function* () {
+        await whenAborted(signal);
+        homeExistedAtSettle = capturedHome ? existsSync(capturedHome) : undefined;
+        throw new Error("aborted query boom");
+      })() as never;
+    };
+
+    await assert.rejects(
+      runReadOnlyModelPass(baseOpts({ queryFn, timeoutMs: 5, graceMs: 1000 })),
+      /review model call exceeded 5ms/,
+    );
+    assert.equal(homeExistedAtSettle, true, "HOME must still exist when the aborted query settles");
+    assert.ok(capturedHome);
+    assert.equal(existsSync(capturedHome!), false, "HOME must be removed after the query settles");
+  });
+
+  it("success path: does not wait for the grace once the query has settled", async () => {
+    // Settles immediately with text. graceMs is set to an hour: if cleanup wrongly waited
+    // on the grace instead of the settled query, the test would hang past --test-timeout.
+    const { queryFn, seen } = capturingQueryFn([assistantText("hello"), successResult()]);
+    const out = await runReadOnlyModelPass(baseOpts({ queryFn, timeoutMs: 60_000, graceMs: 3_600_000 }));
+    assert.equal(out, "hello");
+    const home = (seen.options as FixtureOptions | undefined)?.env?.HOME;
+    assert.ok(home, "the query must have received an ephemeral HOME");
+    assert.equal(existsSync(home!), false, "HOME must be cleaned without waiting for the grace");
   });
 });

--- a/agent/test/model-pass.test.ts
+++ b/agent/test/model-pass.test.ts
@@ -249,6 +249,38 @@ describe("runReadOnlyModelPass — HOME cleanup vs the aborted CLI (issue #933)"
     await assert.rejects(pass, /review model call exceeded 5ms/);
   });
 
+  // Grace-expiry branch, the complement of the preceding "does not settle until the query
+  // settles" case: here the query stays pending forever after abort, so the bounded grace
+  // (not the query settling) is what unblocks cleanup — HOME is removed once the small
+  // graceMs elapses, and the authoritative timeout error still propagates.
+  it("timeout path: the grace expiry (not the query settling) unblocks HOME cleanup when the query never settles", async () => {
+    let capturedHome: string | undefined;
+
+    // Never settles after abort: models an aborted CLI that hangs. The finally's
+    // awaitQuerySettled must fall back to the grace timer to proceed with cleanup.
+    const queryFn: SdkQueryFn = (params) => {
+      const fixtureOpts = (params as { options: FixtureOptions }).options;
+      capturedHome = fixtureOpts.env?.HOME;
+      const signal = fixtureOpts.abortController?.signal;
+      // eslint-disable-next-line require-yield
+      return (async function* () {
+        await whenAborted(signal);
+        await new Promise<void>(() => {});
+      })() as never;
+    };
+
+    await assert.rejects(
+      runReadOnlyModelPass(baseOpts({ queryFn, timeoutMs: 5, graceMs: 20 })),
+      /review model call exceeded 5ms/,
+    );
+    assert.ok(capturedHome, "the query must have received an ephemeral HOME");
+    assert.equal(
+      existsSync(capturedHome!),
+      false,
+      "HOME must be removed after the grace expires even though the query never settled",
+    );
+  });
+
   it("timeout path: a query that rejects after abort is swallowed — the run still cleans HOME", async () => {
     let capturedHome: string | undefined;
     let homeExistedAtSettle: boolean | undefined;


### PR DESCRIPTION
Implements issue #933.

Closes #933

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-933`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of timed-out read-only model operations by allowing briefly delayed requests to finish before temporary environment cleanup.
  - Preserved the original timeout error when an aborted operation later reports an error.
  - Successful operations continue without an additional waiting period.
  - Added configurable control over the post-timeout settlement grace period, with a default of 500 milliseconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->