### PR TITLE
mock-fidelity: three mockApi divergences from the real backend (schedules addScheduleRepo ordering, secrets deleteAnthropicToken cascade, settings key allow-list)

### DIFF
--- a/web/src/mocks/mockApi.mockFidelity.test.ts
+++ b/web/src/mocks/mockApi.mockFidelity.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import type { AppSettings, UpdateSettingsPayload } from "../lib/apiTypes";
+
+// Mock-fidelity regressions: three places where the VITE_UZI_MOCK demo backend
+// diverged from the real Go API. Each test fails on the pre-fix mock and passes
+// after, mirroring the server behaviour it is pinned to:
+//   F1 (schedules) — addScheduleRepo validates the sibling-uniqueness conflict
+//                     BEFORE stamping the source's group id, so a rejected add
+//                     leaves the source un-stamped (server does it in one tx).
+//   F2 (secrets)   — the kind-path deleteAnthropicToken runs the same worker+judge
+//                     unbind cascade the by-id path does (schema ON DELETE SET NULL).
+//   F3 (settings)  — updateSettings accepts the nine AppSettings keys the server's
+//                     Validate accepts (health bools/seconds, capability/project-sync
+//                     flags, docker_repo_allowlist) instead of 400 "unknown setting".
+//
+// Each test reloads the module against a fresh (empty) localStorage so the
+// in-memory store re-seeds. Because vi.resetModules() gives the freshly imported
+// module its OWN ApiError class, rejections are asserted on the `.status` field
+// (toMatchObject), never instanceof.
+
+const KEY = "uzi.mock.v3";
+
+function installStorage(initial: Record<string, string> = {}): void {
+  const m = new Map<string, string>(Object.entries(initial));
+  const storage = {
+    getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+    setItem: (k: string, v: string) => void m.set(k, String(v)),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+}
+
+async function reload() {
+  vi.resetModules();
+  return (await import("./mockApi")).mockApi;
+}
+
+beforeEach(() => installStorage({ [KEY]: "" }));
+afterEach(() => vi.resetModules());
+
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+
+describe("mockApi — F1 addScheduleRepo validates before stamping the group id", () => {
+  it("rejects adding the source's OWN repo with 409 and leaves the source un-stamped", async () => {
+    const api = await reload();
+    const { repos } = await api.listRepos();
+    const repoId = repos[0].id;
+
+    const created = await api.createSchedule(repoId, { target: "issue", timing: "recurring" });
+    expect(created.sibling_group_id).toBeNull();
+
+    // Adding the schedule's own repo is a partial-unique-index conflict.
+    await expect(api.addScheduleRepo(created.id, repoId)).rejects.toMatchObject({ status: 409 });
+
+    // The rejected add must NOT have stamped a fresh group id onto the source (this is
+    // the half that fails on the pre-fix mock, which stamped before checking).
+    const all = await api.listSchedules();
+    const src = all.find((s) => s.id === created.id);
+    expect(src?.sibling_group_id ?? null).toBeNull();
+  });
+
+  it("adds a genuinely new repo to the group and both rows share one sibling_group_id", async () => {
+    const api = await reload();
+    const { repos } = await api.listRepos();
+    expect(repos.length).toBeGreaterThan(1);
+    const repoA = repos[0].id;
+    const repoB = repos[1].id;
+
+    const created = await api.createSchedule(repoA, { target: "issue", timing: "recurring" });
+    const sibling = await api.addScheduleRepo(created.id, repoB);
+
+    const all = await api.listSchedules();
+    const src = all.find((s) => s.id === created.id);
+    expect(src?.sibling_group_id).toBeTruthy();
+    expect(sibling.sibling_group_id).toBe(src?.sibling_group_id);
+    expect(sibling.repo_id).toBe(repoB);
+  });
+});
+
+describe("mockApi — F2 kind-path deleteAnthropicToken cascades the unbind", () => {
+  it("clears the bound worker and judge bindings when the sole token is deleted", async () => {
+    const api = await reload();
+
+    // Trim the seed down to exactly one anthropic token (the sole default), deleting the
+    // non-defaults by id first (D6: the default cannot go while siblings exist).
+    let toks = (await api.listSecrets()).secrets.filter((s) => s.kind === "anthropic_token");
+    for (const s of toks.filter((t) => !t.is_default)) await api.deleteAnthropicTokenById(s.id);
+    toks = (await api.listSecrets()).secrets.filter((s) => s.kind === "anthropic_token");
+    expect(toks).toHaveLength(1);
+    const token = toks[0];
+
+    // Bind a worker to the token (pinned) and bind the judge to it.
+    const { workers } = await api.listWorkers();
+    const workerId = workers[0].id;
+    await api.setWorkerBindMode(workerId, "pinned", token.label);
+    await api.setJudgeEnabled(true, token.label);
+
+    // Sanity: bindings are actually set before the delete.
+    const boundWorker = (await api.listWorkers()).workers.find((w) => w.id === workerId);
+    expect(boundWorker?.anthropic_secret_id).toBe(token.id);
+    const boundMe = await api.me();
+    expect(boundMe.user.judge_anthropic_secret_id).toBe(token.id);
+
+    // The KIND-path delete must cascade the unbind (fails on the pre-fix mock).
+    await api.deleteAnthropicToken();
+
+    const worker = (await api.listWorkers()).workers.find((w) => w.id === workerId);
+    expect(worker?.anthropic_secret_id ?? null).toBeNull();
+    expect(worker?.anthropic_secret_label ?? null).toBeNull();
+
+    const me = await api.me();
+    expect(me.user.judge_anthropic_secret_id ?? null).toBeNull();
+    expect(me.user.judge_anthropic_secret_label ?? null).toBeNull();
+  });
+});
+
+describe("mockApi — F3 updateSettings accepts the nine missing AppSettings keys", () => {
+  it("accepts valid values for the health/flag/list keys and echoes them", async () => {
+    const api = await reload();
+
+    const check = async (key: keyof AppSettings, payload: UpdateSettingsPayload, value: string) => {
+      const res = await api.updateSettings(payload);
+      expect((res.settings as unknown as Record<string, string>)[key]).toBe(value);
+    };
+
+    await check("health_enabled", { health_enabled: "true" }, "true");
+    await check("health_stall_seconds", { health_stall_seconds: "120" }, "120");
+    await check("health_stall_seconds", { health_stall_seconds: "0" }, "0");
+    await check("capability_aware_scheduling", { capability_aware_scheduling: "false" }, "false");
+    await check("github_project_sync_enabled", { github_project_sync_enabled: "true" }, "true");
+    await check("docker_repo_allowlist", { docker_repo_allowlist: VALID_UUID }, VALID_UUID);
+    await check("docker_repo_allowlist", { docker_repo_allowlist: "" }, "");
+  });
+
+  it("still 400s on invalid values for those keys", async () => {
+    const api = await reload();
+
+    await expect(api.updateSettings({ health_enabled: "yes" })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(api.updateSettings({ health_stall_seconds: "30" })).rejects.toMatchObject({
+      status: 400,
+    });
+    await expect(api.updateSettings({ docker_repo_allowlist: "not-a-uuid" })).rejects.toMatchObject(
+      { status: 400 },
+    );
+  });
+});

--- a/web/src/mocks/mockApi/schedules.ts
+++ b/web/src/mocks/mockApi/schedules.ts
@@ -814,13 +814,20 @@ export const schedulesApi = {
     // Coalesce a group id onto the source (the server does this under a row lock so two
     // racing calls settle on one id; a single-writer mock just assigns it once).
     const groupId = src.sibling_group_id ?? crypto.randomUUID();
+    // The partial unique index (sibling_group_id, repo_id) rejects a second sibling on a
+    // repo already in the group — an idempotent-safe 409, no duplicate row created. The
+    // server does the group-coalesce and sibling insert in ONE transaction
+    // (handler/schedules_clone.go AddScheduleRepo: CoalesceScheduleSiblingGroup then
+    // CreateRunSchedule under tx.Begin/defer tx.Rollback), so a partial-unique-index
+    // conflict rolls the group stamp back. Mirror that by running the duplicate check
+    // BEFORE stamping the source: treat the source as a (post-coalesce) group member, so a
+    // collision exists when the source itself already carries that repo_id (adding its own
+    // repo) OR an existing row already in the group does.
+    if (schedules.some((x) => (x.id === src.id || x.sibling_group_id === groupId) && x.repo_id === repoId)) {
+      throw new ApiError(409, "that schedule is already on that repo");
+    }
     if (!src.sibling_group_id) {
       schedules = schedules.map((x) => (x.id === src.id ? { ...x, sibling_group_id: groupId } : x));
-    }
-    // The partial unique index (sibling_group_id, repo_id) rejects a second sibling on a
-    // repo already in the group — an idempotent-safe 409, no duplicate row created.
-    if (schedules.some((x) => x.sibling_group_id === groupId && x.repo_id === repoId)) {
-      throw new ApiError(409, "that schedule is already on that repo");
     }
     const now = new Date().toISOString();
     // Copy the source's current config onto the new repo as an independent sibling. The

--- a/web/src/mocks/mockApi/secrets.ts
+++ b/web/src/mocks/mockApi/secrets.ts
@@ -49,6 +49,30 @@ const pooledFixtureStatus: Record<string, AutoStatus> = {
   "sec-low": "below_threshold",
 };
 
+// unbindAnthropicSecret mirrors the schema cascade (migrations 00078/00079 hang composite
+// FKs off user_secrets (user_id, id) with ON DELETE SET NULL): deleting a bound anthropic
+// token unbinds its workers and the judge rather than orphaning them. Every delete path
+// (both the by-id path and the D14 kind-path alias) must run this or the mock leaves a
+// worker reading a token that no longer exists. Kept module-local (not exported) so knip
+// does not flag it as an unused export.
+function unbindAnthropicSecret(id: string): void {
+  workers.forEach((w) => {
+    if (w.anthropic_secret_id === id) {
+      w.anthropic_secret_id = null;
+      w.anthropic_secret_label = null;
+    }
+  });
+  // `state.session` is a COPY, not a reference into `users`, so both have to be
+  // swept or the cascade would be invisible to /me — which is the read every
+  // judge surface actually uses.
+  [...users, state.session].forEach((u) => {
+    if (u && u.judge_anthropic_secret_id === id) {
+      u.judge_anthropic_secret_id = null;
+      u.judge_anthropic_secret_label = null;
+    }
+  });
+}
+
 export const secretsApi = {
   // ── Secrets ─────────────────────────────────────────────────────────────────
   listSecrets: async () =>
@@ -188,29 +212,14 @@ export const secretsApi = {
       );
     }
     secrets = secrets.filter((s) => s.id !== id);
-    // The real schema CASCADES: migrations 00078/00079 hang composite FKs off
-    // user_secrets (user_id, id) with ON DELETE SET NULL, so deleting a bound token
-    // unbinds its workers and the judge rather than orphaning them. Without this the
-    // mock left workers reading "spends console-key" forever — and with one token
-    // left the picker is hidden, so there was no way to correct it. Two reasons that
-    // matters beyond tidiness: the shipped Dockerfile.mock demo was showing D5's own
-    // promise being broken, and D5's cascade otherwise has schema-level evidence
-    // only. Mirrored here so a browser can prove the behaviour end to end.
-    workers.forEach((w) => {
-      if (w.anthropic_secret_id === id) {
-        w.anthropic_secret_id = null;
-        w.anthropic_secret_label = null;
-      }
-    });
-    // `state.session` is a COPY, not a reference into `users`, so both have to be
-    // swept or the cascade would be invisible to /me — which is the read every
-    // judge surface actually uses.
-    [...users, state.session].forEach((u) => {
-      if (u && u.judge_anthropic_secret_id === id) {
-        u.judge_anthropic_secret_id = null;
-        u.judge_anthropic_secret_label = null;
-      }
-    });
+    // The real schema CASCADES: deleting a bound token unbinds its workers and the judge
+    // rather than orphaning them. Without this the mock left workers reading "spends
+    // console-key" forever — and with one token left the picker is hidden, so there was
+    // no way to correct it. Two reasons that matters beyond tidiness: the shipped
+    // Dockerfile.mock demo was showing D5's own promise being broken, and D5's cascade
+    // otherwise has schema-level evidence only. Mirrored here so a browser can prove the
+    // behaviour end to end.
+    unbindAnthropicSecret(id);
     return delay(null);
   },
 
@@ -243,7 +252,12 @@ export const secretsApi = {
         "you have multiple tokens; delete a specific one by id (DELETE /api/me/secrets/anthropic_token/{id})",
       );
     }
+    // Capture the sole token's id BEFORE filtering it out (at most one survives the 409
+    // guard above), then run the same unbind cascade the by-id path does. No token row is
+    // a no-op.
+    const tokenId = anthropic[0]?.id;
     secrets = secrets.filter((s) => s.kind !== "anthropic_token");
+    if (tokenId) unbindAnthropicSecret(tokenId);
     return delay(null);
   },
 };

--- a/web/src/mocks/mockApi/settings.ts
+++ b/web/src/mocks/mockApi/settings.ts
@@ -503,7 +503,10 @@ export const settingsApi = {
         key === "judge_enforce_all" ||
         key === "ephemeral_workers_enabled" ||
         key === "release_check_enabled" ||
-        key === "release_check_banner_enabled"
+        key === "release_check_banner_enabled" ||
+        key === "health_enabled" ||
+        key === "capability_aware_scheduling" ||
+        key === "github_project_sync_enabled"
       ) {
         if (value !== "true" && value !== "false") {
           throw new ApiError(400, `${key}: must be "true" or "false"`);
@@ -595,6 +598,46 @@ export const settingsApi = {
           throw new ApiError(400, "brand_company: must be at most 64 characters");
         }
         nonSecret.brand_company = value;
+        continue;
+      }
+      // Run-health detector thresholds (PRD #47), mirroring the server's
+      // validateHealthSeconds: a whole number of seconds, accept 0 (off), otherwise the
+      // inclusive range [60, 86400].
+      if (
+        key === "health_stall_seconds" ||
+        key === "health_slow_seconds" ||
+        key === "health_queued_seconds" ||
+        key === "health_approval_seconds" ||
+        key === "health_nudge_cooldown_seconds"
+      ) {
+        if (!/^\d+$/.test(value)) {
+          throw new ApiError(400, `${key}: must be a whole number of seconds`);
+        }
+        const n = Number(value);
+        if (n !== 0 && (n < 60 || n > 86400)) {
+          throw new ApiError(400, `${key}: must be 0 (off) or between 60 and 86400`);
+        }
+        (nonSecret as Record<string, string>)[key] = String(n);
+        continue;
+      }
+      // docker_repo_allowlist (PRD #957): a comma-separated list of repo ids, mirroring the
+      // server's validateRepoAllowlist. Empty is allowed (fail-closed empty); every
+      // non-empty token must be a valid UUID. The raw (untrimmed) value is stored.
+      if (key === "docker_repo_allowlist") {
+        const ok = value
+          .split(",")
+          .map((t) => t.trim())
+          .filter((t) => t !== "")
+          .every((t) =>
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(t),
+          );
+        if (!ok) {
+          throw new ApiError(
+            400,
+            "docker_repo_allowlist: must be a comma-separated list of repo ids (UUIDs)",
+          );
+        }
+        nonSecret.docker_repo_allowlist = value;
         continue;
       }
       if (key !== "autopilot_label" && key !== "uzi_label") {


### PR DESCRIPTION
Implements issue #1013.

Closes #1013

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1013`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate repository additions from partially assigning group membership.
  * Ensured deleted Anthropic tokens are fully unlinked from associated worker and judge configurations.
  * Improved settings validation for health thresholds, project synchronization, capability-aware scheduling, notification banners, and Docker repository allowlists.

* **Tests**
  * Added regression coverage for repository conflicts, token cleanup, and supported settings validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->