### PR TITLE
fix(forge): Forgejo issue state/description use a field-only PATCH (no title round-trip) (#1058)

### DIFF
--- a/api/internal/forge/forgejo.go
+++ b/api/internal/forge/forgejo.go
@@ -1,7 +1,9 @@
 package forge
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -243,4 +245,51 @@ func (f *forgejo) rawGetLimited(ctx context.Context, path string, limit int64) (
 		return body, f.wrapErr(fmt.Sprintf("GET %s", path), fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body))))
 	}
 	return body, nil
+}
+
+// forgejoPatchErrBodyLimit caps how much of a non-2xx PATCH response patchIssue
+// reads: the body is only ever folded into a redacted error message, never
+// parsed, so a modest ceiling is enough and keeps a hostile forge's error body
+// byte-bounded (same reasoning as rawGetLimited's LimitReader).
+const forgejoPatchErrBodyLimit = 1 << 20
+
+// patchIssue PATCHes a single issue with a caller-supplied struct, marshalling
+// ONLY the fields that struct carries. It exists to sidestep the gitea SDK's
+// gitea.EditIssueOption, whose Title field is a plain `string` tagged
+// `json:"title"` with NO `omitempty`: marshalling that struct ALWAYS emits a
+// "title" key, so any edit that goes through it round-trips (and can clobber) the
+// title, and an empty Title wipes it outright. A field-only PATCH omits "title"
+// entirely, so a field the caller does not send — including a title edited
+// concurrently by someone else — survives untouched (no read, no TOCTOU).
+//
+// Auth and redaction mirror rawGetLimited: the shared timeout client, the
+// "token " Authorization header, an io.LimitReader-bounded body read, and a
+// non-2xx error routed through f.wrapErr so a PAT echoed in the error body is
+// still redacted.
+func (f *forgejo) patchIssue(ctx context.Context, slug repoSlug, issueIID int64, op string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return f.wrapErr(op, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch,
+		f.baseURL+"/api/v1"+fmt.Sprintf("/repos/%s/%s/issues/%d", slug.owner, slug.repo, issueIID),
+		bytes.NewReader(body))
+	if err != nil {
+		return f.wrapErr(op, err)
+	}
+	req.Header.Set("Authorization", "token "+f.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return f.wrapErr(op, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, forgejoPatchErrBodyLimit))
+	if err != nil {
+		return f.wrapErr(op, err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return f.wrapErr(op, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody))))
+	}
+	return nil
 }

--- a/api/internal/forge/forgejo_issues.go
+++ b/api/internal/forge/forgejo_issues.go
@@ -96,18 +96,16 @@ func (f *forgejo) GetIssue(ctx context.Context, projectID, issueIID int64) (Issu
 
 // UpdateIssueDescription replaces an issue's body (PRD #72 M5).
 //
-// THE INTERNAL READ IS NOT OPTIONAL, and this is the hazard the whole method
-// exists to work around. In code.gitea.io/sdk/gitea, EditIssueOption.Title is a
-// plain `string` with the json tag "title" and NO `omitempty`, so a naive call
-// PATCHes `"title": ""` and can wipe the issue's title. Whether Forgejo happens to
-// ignore an empty title is not verifiable from this tree, and "probably ignores
-// it" is not a basis for a write against a user's issue. So: read the issue first
-// and send its current title back unchanged.
+// This sends a BODY-ONLY PATCH and does NOT read the issue first. The gitea SDK's
+// gitea.EditIssueOption cannot express that: its Title field is a plain `string`
+// tagged `json:"title"` with NO `omitempty`, so marshalling it always emits a
+// "title" key, and any driver built on it must round-trip the current title to
+// avoid PATCHing `"title": ""` (which wipes it). That read-then-write is a TOCTOU:
+// a title edited concurrently between the read and the write is silently clobbered
+// by the stale value. Bypassing the SDK struct via patchIssue lets us omit "title"
+// entirely, so a concurrent title edit survives and no read is needed.
 //
-// A driver absorbing its own forge's quirk is the established shape here —
-// UpdateIssueLabels above does a read-then-full-PUT for the same kind of reason
-// (Forgejo has no add/remove delta). The interface stays neutral, which is the
-// point; the GitLab driver sends the description alone.
+// The interface stays neutral; the GitLab driver sends the description alone.
 func (f *forgejo) UpdateIssueDescription(ctx context.Context, projectID, issueIID int64, description string) error {
 	c, err := f.newClient(ctx)
 	if err != nil {
@@ -117,32 +115,26 @@ func (f *forgejo) UpdateIssueDescription(ctx context.Context, projectID, issueII
 	if err != nil {
 		return err
 	}
-	cur, _, err := c.GetIssue(slug.owner, slug.repo, issueIID)
-	if err != nil {
-		// Redaction is per-method and not automatic, so the INTERNAL read's error
-		// needs wrapping too — it carries the same client and the same PAT.
-		return f.wrapErr("update issue description: read current issue", err)
-	}
-	if _, _, err := c.EditIssue(slug.owner, slug.repo, issueIID, gitea.EditIssueOption{
-		Title: cur.Title,
-		Body:  &description,
-	}); err != nil {
-		return f.wrapErr("update issue description", err)
-	}
-	return nil
+	return f.patchIssue(ctx, slug, issueIID, "update issue description",
+		struct {
+			Body string `json:"body"`
+		}{Body: description})
 }
 
 // SetIssueState closes or reopens an issue.
 //
-// THE INTERNAL READ IS NOT OPTIONAL, for the same reason UpdateIssueDescription
-// above reads first: EditIssueOption.Title is a plain `string` with no
-// `omitempty`, so a naive edit PATCHes `"title": ""` and can wipe the issue's
-// title. So read the issue first and send its current title back unchanged
-// alongside the state. EditIssueOption.State is a *gitea.StateType, mapped from
-// the neutral state by forgejoIssueStateMutation (the MUTATE mapper, NOT the
+// This sends a STATE-ONLY PATCH and does NOT read the issue first, for the same
+// reason UpdateIssueDescription above does not: the gitea SDK's
+// gitea.EditIssueOption.Title is a plain `string` with no `omitempty`, so a driver
+// built on it must round-trip the current title to avoid wiping it — a
+// read-then-write that clobbers a concurrent title edit (TOCTOU). patchIssue omits
+// "title" entirely, so there is no title round-trip and therefore no read.
+//
+// The state is mapped by forgejoIssueStateMutation (the MUTATE mapper, NOT the
 // list-filter forgejoIssueStateParam whose default is StateAll): StateClosed
-// closes, anything else reopens — reopening being the safe direction for a
-// caller bug, matching the GitLab and GitHub drivers.
+// closes, anything else reopens — reopening being the safe direction for a caller
+// bug, matching the GitLab and GitHub drivers. gitea.StateType JSON-marshals to
+// "closed"/"open".
 func (f *forgejo) SetIssueState(ctx context.Context, projectID, issueIID int64, state IssueState) error {
 	c, err := f.newClient(ctx)
 	if err != nil {
@@ -152,20 +144,11 @@ func (f *forgejo) SetIssueState(ctx context.Context, projectID, issueIID int64, 
 	if err != nil {
 		return err
 	}
-	cur, _, err := c.GetIssue(slug.owner, slug.repo, issueIID)
-	if err != nil {
-		// Redaction is per-method and not automatic, so the INTERNAL read's error
-		// needs wrapping too — it carries the same client and the same PAT.
-		return f.wrapErr("set issue state: read current issue", err)
-	}
 	st := forgejoIssueStateMutation(state)
-	if _, _, err := c.EditIssue(slug.owner, slug.repo, issueIID, gitea.EditIssueOption{
-		Title: cur.Title,
-		State: &st,
-	}); err != nil {
-		return f.wrapErr("set issue state", err)
-	}
-	return nil
+	return f.patchIssue(ctx, slug, issueIID, "set issue state",
+		struct {
+			State gitea.StateType `json:"state"`
+		}{State: st})
 }
 
 func (f *forgejo) CreateIssue(ctx context.Context, projectID int64, title, description string, labels []string) (Issue, error) {

--- a/api/internal/forge/set_issue_state_test.go
+++ b/api/internal/forge/set_issue_state_test.go
@@ -138,6 +138,9 @@ func TestForgejoSetIssueStateSendsState(t *testing.T) {
 			if got := patched["state"]; got != tc.want {
 				t.Errorf("state = %v, want %q", got, tc.want)
 			}
+			if len(patched) != 1 {
+				t.Errorf("SetIssueState must PATCH ONLY state — a stray field clobbers an unrelated attribute: %v", patched)
+			}
 			// Parity with the GitLab and GitHub tests: a state-only PATCH must not
 			// carry a title, so a concurrent title edit cannot be clobbered.
 			if _, sent := patched["title"]; sent {

--- a/api/internal/forge/set_issue_state_test.go
+++ b/api/internal/forge/set_issue_state_test.go
@@ -116,15 +116,13 @@ func TestForgejoSetIssueStateSendsState(t *testing.T) {
 			m := newMockForgejo(t, map[string]http.HandlerFunc{
 				"/repos/acme/widgets/issues/5": func(w http.ResponseWriter, r *http.Request) {
 					switch r.Method {
-					case http.MethodGet:
-						_ = json.NewEncoder(w).Encode(map[string]any{
-							"number": 5, "title": "Fix the login flow", "body": "b", "state": "open",
-						})
 					case http.MethodPatch:
 						raw, _ := io.ReadAll(r.Body)
 						_ = json.Unmarshal(raw, &patched)
 						_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "title": "Fix the login flow"})
 					default:
+						// Only a PATCH is expected: the state-only PATCH does not read the
+						// issue first, so a GET here would be the reintroduced round-trip.
 						t.Errorf("unexpected method %s", r.Method)
 					}
 				},
@@ -140,34 +138,46 @@ func TestForgejoSetIssueStateSendsState(t *testing.T) {
 			if got := patched["state"]; got != tc.want {
 				t.Errorf("state = %v, want %q", got, tc.want)
 			}
+			// Parity with the GitLab and GitHub tests: a state-only PATCH must not
+			// carry a title, so a concurrent title edit cannot be clobbered.
+			if _, sent := patched["title"]; sent {
+				t.Errorf("SetIssueState must not send a title: %v", patched)
+			}
 		})
 	}
 }
 
-// TestForgejoSetIssueStatePreservesTheTitle pins the same no-omitempty hazard the
-// Forgejo UpdateIssueDescription driver works around: EditIssueOption.Title is a
-// plain `string` with no `omitempty`, so a naive edit PATCHes `"title": ""` and
-// can wipe the issue's title. SetIssueState reads the issue first and sends the
-// current title back — this asserts the PATCH body carries that title, not "".
+// TestForgejoSetIssueStatePreservesAConcurrentTitleEdit pins the lost-update bug
+// the state-only PATCH exists to prevent. The gitea SDK's EditIssueOption.Title is
+// a plain `string` with no `omitempty`, so a driver built on it must read the
+// issue and round-trip the current title — and that read-then-write silently
+// clobbers a title edited concurrently by someone else (TOCTOU).
 //
-// If someone later "simplifies" the driver by dropping the internal read, this is
-// the test that reddens, and the empty string in the failure message is the bug.
-func TestForgejoSetIssueStatePreservesTheTitle(t *testing.T) {
-	const existingTitle = "Fix the login flow"
+// The concurrent edit is modelled deterministically, no timing: the issue already
+// holds a "renamed concurrently" title, tracked in a mutable var the PATCH handler
+// rewrites ONLY when the body carries a "title" key (Forgejo field-only PATCH
+// semantics). A correct state-only PATCH omits "title", so the tracked title
+// survives; a driver that reads-then-writes the stale title reddens here.
+//
+// If someone later reintroduces the internal read, the non-PATCH arm's t.Errorf
+// fires too — the driver must not GET the issue first.
+func TestForgejoSetIssueStatePreservesAConcurrentTitleEdit(t *testing.T) {
+	const concurrentTitle = "Renamed concurrently by someone else"
+	title := concurrentTitle // mutable: only a PATCH that sends "title" changes it
 	var patched map[string]any
 	m := newMockForgejo(t, map[string]http.HandlerFunc{
 		"/repos/acme/widgets/issues/5": func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
-			case http.MethodGet:
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"number": 5, "title": existingTitle, "body": "old body", "state": "open",
-				})
 			case http.MethodPatch:
 				raw, _ := io.ReadAll(r.Body)
 				_ = json.Unmarshal(raw, &patched)
-				_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "title": existingTitle, "state": "closed"})
+				// Forgejo field-only semantics: a title only changes if "title" is sent.
+				if t2, sent := patched["title"].(string); sent {
+					title = t2
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "title": title, "state": "closed"})
 			default:
-				t.Errorf("unexpected method %s", r.Method)
+				t.Errorf("state-only PATCH must not read the issue first; unexpected method %s", r.Method)
 			}
 		},
 	})
@@ -179,23 +189,27 @@ func TestForgejoSetIssueStatePreservesTheTitle(t *testing.T) {
 	if patched == nil {
 		t.Fatal("no PATCH was sent")
 	}
-	title, _ := patched["title"].(string)
-	if title == "" {
-		t.Fatalf("the PATCH carried an EMPTY title, which can wipe the issue's title — "+
-			"EditIssueOption.Title has no omitempty, so the driver must read the current title first; body = %v", patched)
+	if _, sent := patched["title"]; sent {
+		t.Errorf("the PATCH carried a title, which clobbers a concurrent rename (lost update) — "+
+			"a state-only PATCH must omit \"title\"; body = %v", patched)
 	}
-	if title != existingTitle {
-		t.Errorf("title = %q, want the issue's existing %q", title, existingTitle)
+	if got := patched["state"]; got != "closed" {
+		t.Errorf("state = %v, want %q", got, "closed")
+	}
+	if title != concurrentTitle {
+		t.Errorf("the concurrent rename was lost: title = %q, want %q", title, concurrentTitle)
 	}
 }
 
-// SetIssueState's error returns redact the PAT, including the Forgejo driver's
-// INTERNAL read — same per-method redaction contract as UpdateIssueDescription.
-func TestForgejoSetIssueStateRedactsTokenOnInternalRead(t *testing.T) {
+// SetIssueState's error returns redact the PAT. The state-only PATCH is the only
+// request the driver makes, so a forge that 403s the PATCH and echoes the token in
+// the error body must not leak it — same per-method redaction contract as the
+// GitLab and GitHub drivers.
+func TestForgejoSetIssueStateRedactsTokenOnPatchError(t *testing.T) {
 	const token = "forgejo-set-state-redaction-probe-0123456789" //nolint:gosec // G101: fake PAT fixture, the value this test asserts is redacted out of the error, never a real secret; gitleaks:allow
 	m := newMockForgejo(t, map[string]http.HandlerFunc{
 		"/repos/acme/widgets/issues/5": func(w http.ResponseWriter, _ *http.Request) {
-			// Fail the GET, which is the driver's own read.
+			// Fail the PATCH and echo the PAT back in the error body.
 			w.WriteHeader(http.StatusForbidden)
 			_, _ = w.Write([]byte(`{"message":"denied for token ` + token + `"}`))
 		},
@@ -207,8 +221,5 @@ func TestForgejoSetIssueStateRedactsTokenOnInternalRead(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), token) {
 		t.Errorf("the PAT leaked into the error: %v", err)
-	}
-	if !strings.Contains(err.Error(), "read current issue") {
-		t.Errorf("the internal read's error should say which call failed; got %v", err)
 	}
 }

--- a/api/internal/forge/update_issue_description_test.go
+++ b/api/internal/forge/update_issue_description_test.go
@@ -45,33 +45,37 @@ func TestGitLabUpdateIssueDescriptionSendsOnlyTheDescription(t *testing.T) {
 	}
 }
 
-// TestForgejoUpdateIssueDescriptionPreservesTheTitle pins the hazard the whole
-// Forgejo implementation exists to work around.
+// TestForgejoUpdateIssueDescriptionPreservesTheTitle pins the lost-update bug the
+// body-only PATCH exists to prevent.
 //
 // In code.gitea.io/sdk/gitea, EditIssueOption.Title is a plain `string` with the
-// json tag "title" and NO `omitempty`. A naive EditIssue therefore PATCHes
-// `"title": ""`, which can wipe the issue's title. The driver reads the issue first
-// and sends the current title back — this asserts the PATCH body carries that
-// title, not "".
+// json tag "title" and NO `omitempty`. A driver built on it must read the issue
+// and round-trip the current title to avoid PATCHing `"title": ""` (which wipes
+// it) — and that read-then-write silently clobbers a title edited concurrently by
+// someone else (TOCTOU). A body-only PATCH omits "title" entirely, so the
+// concurrent rename survives and no read is needed.
 //
-// If someone later "simplifies" the driver by dropping the internal read, this is
-// the test that reddens, and the empty string in the failure message is the bug.
+// The concurrent edit is modelled deterministically, no timing: the issue already
+// holds a "renamed concurrently" title, tracked in a mutable var the PATCH handler
+// rewrites ONLY when the body carries a "title" key. The non-PATCH arm t.Errorf's
+// so a reintroduced internal read reddens.
 func TestForgejoUpdateIssueDescriptionPreservesTheTitle(t *testing.T) {
-	const existingTitle = "Fix the login flow"
+	const concurrentTitle = "Renamed concurrently by someone else"
+	title := concurrentTitle // mutable: only a PATCH that sends "title" changes it
 	var patched map[string]any
 	m := newMockForgejo(t, map[string]http.HandlerFunc{
 		"/repos/acme/widgets/issues/5": func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
-			case http.MethodGet:
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"number": 5, "title": existingTitle, "body": "old body", "state": "open",
-				})
 			case http.MethodPatch:
 				raw, _ := io.ReadAll(r.Body)
 				_ = json.Unmarshal(raw, &patched)
-				_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "title": existingTitle})
+				// Forgejo field-only semantics: a title only changes if "title" is sent.
+				if t2, sent := patched["title"].(string); sent {
+					title = t2
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "title": title})
 			default:
-				t.Errorf("unexpected method %s", r.Method)
+				t.Errorf("body-only PATCH must not read the issue first; unexpected method %s", r.Method)
 			}
 		},
 	})
@@ -86,22 +90,25 @@ func TestForgejoUpdateIssueDescriptionPreservesTheTitle(t *testing.T) {
 	if got := patched["body"]; got != "the new body" {
 		t.Errorf("body = %v, want %q", got, "the new body")
 	}
-	title, _ := patched["title"].(string)
-	if title == "" {
-		t.Fatalf("the PATCH carried an EMPTY title, which can wipe the issue's title — "+
-			"EditIssueOption.Title has no omitempty, so the driver must read the current title first; body = %v", patched)
+	if _, sent := patched["title"]; sent {
+		t.Errorf("the PATCH carried a title, which clobbers a concurrent rename (lost update) — "+
+			"a body-only PATCH must omit \"title\"; body = %v", patched)
 	}
-	if title != existingTitle {
-		t.Errorf("title = %q, want the issue's existing %q", title, existingTitle)
+	if title != concurrentTitle {
+		t.Errorf("the concurrent rename was lost: title = %q, want %q", title, concurrentTitle)
 	}
 }
 
 // Redaction is per-method and not automatic: every error return in both drivers
-// wraps through the embedded redactor. That includes the Forgejo driver's INTERNAL
-// read, which carries the same client and the same PAT.
+// wraps through the embedded redactor. For Forgejo the body-only PATCH is the only
+// request the driver makes, so a forge that 403s it and echoes the PAT in the
+// error body must not leak it.
 func TestUpdateIssueDescriptionRedactsTheToken(t *testing.T) {
 	t.Run("gitlab", func(t *testing.T) {
-		const token = "glpat-update-desc-redaction-probe-0123456789" //gitleaks:allow // fake PAT fixture: the value this test asserts is redacted out of the error, never a real secret
+		// Assembled from parts so no glpat- token SHAPE lives in source: GitHub Push
+		// Protection scans literals across the whole push and honours no in-file allow
+		// directive (.claude/rules/prds.md); runtime assembly satisfies it and gitleaks.
+		const token = "glpat-" + "update-desc-redaction-probe" + "-0123456789" // fake PAT fixture, asserted to be redacted from the error, never a real secret
 		m := newMockGitLab(t, map[string]http.HandlerFunc{
 			"/api/v4/projects/7/issues/5": func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusForbidden)
@@ -119,11 +126,11 @@ func TestUpdateIssueDescriptionRedactsTheToken(t *testing.T) {
 		}
 	})
 
-	t.Run("forgejo, and the error is from the INTERNAL read", func(t *testing.T) {
-		const token = "forgejo-update-desc-redaction-probe-0123456789"
+	t.Run("forgejo, and the error is from the PATCH", func(t *testing.T) {
+		const token = "forgejo-update-desc-redaction-probe-0123456789" //nolint:gosec // G101: fake PAT fixture, the value this test asserts is redacted out of the error, never a real secret; gitleaks:allow
 		m := newMockForgejo(t, map[string]http.HandlerFunc{
-			"/repos/acme/widgets/issues/5": func(w http.ResponseWriter, r *http.Request) {
-				// Fail the GET, which is the driver's own read, not the caller's.
+			"/repos/acme/widgets/issues/5": func(w http.ResponseWriter, _ *http.Request) {
+				// Fail the PATCH and echo the PAT back in the error body.
 				w.WriteHeader(http.StatusForbidden)
 				_, _ = w.Write([]byte(`{"message":"denied for token ` + token + `"}`))
 			},
@@ -135,9 +142,6 @@ func TestUpdateIssueDescriptionRedactsTheToken(t *testing.T) {
 		}
 		if strings.Contains(err.Error(), token) {
 			t.Errorf("the PAT leaked into the error: %v", err)
-		}
-		if !strings.Contains(err.Error(), "read current issue") {
-			t.Errorf("the internal read's error should say which call failed; got %v", err)
 		}
 	})
 }

--- a/api/internal/forge/update_issue_description_test.go
+++ b/api/internal/forge/update_issue_description_test.go
@@ -90,6 +90,9 @@ func TestForgejoUpdateIssueDescriptionPreservesTheTitle(t *testing.T) {
 	if got := patched["body"]; got != "the new body" {
 		t.Errorf("body = %v, want %q", got, "the new body")
 	}
+	if len(patched) != 1 {
+		t.Errorf("the PATCH must carry ONLY body — a stray field overwrites an unrelated issue attribute: %v", patched)
+	}
 	if _, sent := patched["title"]; sent {
 		t.Errorf("the PATCH carried a title, which clobbers a concurrent rename (lost update) — "+
 			"a body-only PATCH must omit \"title\"; body = %v", patched)


### PR DESCRIPTION
Recovers uzi run #1058 (issue #1058) off the worker PVC after it failed `push_secret_blocked` at finalize.

## What this fixes (issue #1058)
Forgejo `SetIssueState` did a read-then-write that could overwrite a concurrent title edit (lost-update TOCTOU). This sends a **field-only PATCH** (no title round-trip), so a concurrent title edit is preserved. Includes an interleaving regression test.

## Recovery notes
- Branch recovered from the worker PVC tracking ref; rebased onto current `main`.
- The finalize push was blocked by GitHub Push Protection (GH013) on a `glpat-`-shaped **test fixture** at `update_issue_description_test.go:108`. Per `.claude/rules/prds.md`, the fixture is now **assembled from parts at runtime** (`"glpat-" + ... + ...`) so no token shape lives in source — satisfies both gitleaks and GitHub PP. Folded into the introducing commit; range verified clean (gitleaks 0 findings, no contiguous `glpat-{20,}`).
- No `.github/workflows` in the diff. `task gate:api` green.

Systemic pattern filed as #1120.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Issue descriptions and states can now be updated without overwriting concurrent title changes.
  * Forgejo update failures no longer expose authentication tokens in error responses.
  * Issue updates avoid unnecessary internal reads, reducing the risk of stale data during concurrent edits.
  * Forgejo issue updates now use focused changes, helping preserve unrelated edits made at the same time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->