### PR TITLE
syncOneMRState: locked->closed does not cancel an in-flight mr_rework (issue lane)

### DIFF
--- a/api/internal/forgesvc/mr_watch.go
+++ b/api/internal/forgesvc/mr_watch.go
@@ -125,17 +125,25 @@ func (s *Service) syncOneMRState(ctx context.Context, repoID uuid.UUID, forgePro
 		}
 		s.recordMRState(ctx, c.ID, observed)
 	default:
-		// A KNOWN non-edge transition (merged / locked): record, never move.
-		// Unknown states never reach here — they are ignored before the bootstrap
-		// check above. A merge closes the issue via `Closes #N`, which the existing
-		// issue-close sync owns; locked is transient during merge processing.
+		// A KNOWN non-edge transition: record, never move (this arm makes no board
+		// move). Unknown states never reach here — they are ignored before the
+		// bootstrap check above. A merge closes the issue via `Closes #N`, which the
+		// existing issue-close sync owns.
 		//
-		// A merge additionally means the branch is gone and any in-flight rework can
-		// never land — abort it (#853). Locked is transient during merge processing
-		// and must NOT trigger a cancel.
-		if observed == forge.MRStateMerged {
+		// A confirmed TERMINAL state (merged OR closed) means the branch is gone / the
+		// MR can never land, so any in-flight rework must be aborted (#853). This must
+		// fire for `locked`->`closed` (and `locked`->`merged`) too: `locked` is the
+		// transient mid-merge state, so an `opened`->`locked`->`closed` sequence reaches
+		// this arm on the `locked`->`closed` tick — the `opened`->`closed` close arm
+		// above never sees it, so without cancelling here the run self-evicts at the
+		// terminal `closed` state with the rework still spending (issue #1072, the
+		// issue-lane analogue of the scheduled-lane fix in recordScheduledMRState). The
+		// cancel is keyed on the MR, not the card; no board move happens here because
+		// `locked` was mid-merge. A `locked`->`opened` settle is a non-terminal
+		// transition and must NOT cancel — the rework gate stays open.
+		if observed == forge.MRStateMerged || observed == forge.MRStateClosed {
 			if err := s.cancelReworkOnClosedMR(ctx, repoID, c.MrIid.Int64); err != nil {
-				slog.Warn("forgesvc: cancel rework on MR merge failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "error", err)
+				slog.Warn("forgesvc: cancel rework on MR terminal state failed, will retry", "repo", repoID, "issue", c.IssueIid.Int64, "mr", c.MrIid.Int64, "state", observed, "error", err)
 				return // leave mr_state unadvanced so the next tick retries
 			}
 		}

--- a/api/internal/forgesvc/mr_watch_test.go
+++ b/api/internal/forgesvc/mr_watch_test.go
@@ -315,6 +315,38 @@ func TestMRLockedIsRecordedNeverMoves(t *testing.T) {
 	assertRecorded(t, st, runID, "locked")
 }
 
+// TestMRLockedClosedCancelsRework pins the issue #1072 fix: a MR that passes
+// through the transient `locked` state before closing (opened->locked->closed)
+// reaches syncOneMRState on the `locked`->`closed` tick with stored=="locked", so
+// it falls to the `default` arm — not the `opened`->`closed` close arm. Before the
+// fix that arm cancelled only on `merged`, so the in-flight rework leaked; the run
+// then self-evicted at the terminal `closed` state with the rework still spending.
+// It must now cancel exactly once (keyed on the MR), while still making NO board
+// move (`locked` was mid-merge) and recording the terminal `closed`. The `run`
+// helper wires no canceller, so this builds the service directly.
+func TestMRLockedClosedCancelsRework(t *testing.T) {
+	runID, repoID := uuid.New(), uuid.New()
+	st := &fakeStore{
+		candidates: []store.ListMRWatchCandidatesRow{candidate(runID, 9, 13, mrTxt("locked"))},
+		issue:      mrIssue(repoID, 9, "opened", "PRD", board.ColumnHumanReview),
+		columns:    mrCols(),
+	}
+	f := &fakeForge{mr: forgeMR(13, "closed")}
+	canceller := &fakeReworkCanceller{}
+	svc := newTestService(st)
+	svc.SetReworkCanceller(canceller)
+
+	if err := svc.SyncMRStates(context.Background(), repoID, testProjectID, f); err != nil {
+		t.Fatalf("SyncMRStates: %v", err)
+	}
+
+	if len(canceller.calls) != 1 || canceller.calls[0] != 13 {
+		t.Fatalf("expected exactly one cancel of mr 13, got %v", canceller.calls)
+	}
+	assertNoMove(t, f) // locked is mid-merge → no board move, only the cancel was missing
+	assertRecorded(t, st, runID, "closed")
+}
+
 func TestMRUnknownStateInTransitionIsIgnored(t *testing.T) {
 	// Reviewer hardening (post-audit): an unrecognized state is ignored ENTIRELY —
 	// no move AND no write — so the prior baseline ("opened") is preserved and a

--- a/api/internal/forgesvc/scheduled_mr_watch_test.go
+++ b/api/internal/forgesvc/scheduled_mr_watch_test.go
@@ -27,9 +27,9 @@ import (
 //   - opened->locked            → locked is transient: record, NO cancel.
 //   - locked->opened            → the transient state settles back to opened: record, NO cancel.
 //   - locked->merged            → merge from the transient state still cancels exactly once.
-//   - locked->closed            → records 'closed' but does NOT cancel — the close edge only
-//     cancels from 'opened' (default arm cancels only on merged), exact parity with the
-//     issue-lane syncOneMRState. Pinned so the parity gap is intentional, not an accident.
+//   - locked->closed            → a TERMINAL edge: cancels exactly once then records 'closed',
+//     matching the issue-lane syncOneMRState — both lanes cancel on any transition into
+//     closed/merged from a non-terminal stored state (issue #1072 closed the former parity gap).
 //   - unknown-state             → an unrecognized forge state writes nothing and cancels
 //     nothing (the baseline is preserved so a later real state still fires).
 //   - no-transition             → observed==stored: no write, no cancel.
@@ -102,8 +102,8 @@ func TestSyncScheduledMRStatesDifferential(t *testing.T) {
 			// the rework whenever the MR passed through 'locked' before closing — the run
 			// then self-evicted at mr_state='closed' with the rework still spending. Fixed by
 			// cancelling on any transition INTO closed/merged from a valid non-terminal state.
-			// (The issue-lane syncOneMRState still has the analogous latent leak; tracked
-			// separately as a follow-up.)
+			// (The issue-lane syncOneMRState carried the analogous latent leak; fixed in
+			// issue #1072 so both lanes now cancel on a locked->closed edge.)
 			name:       "locked->closed",
 			stored:     strptr(forge.MRStateLocked),
 			observed:   forge.MRStateClosed,


### PR DESCRIPTION
Implements issue #1072.

Closes #1072

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1072`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rework is now cancelled when merge requests transition from `locked` to `closed` or `merged`.
  - Terminal merge-request states are recorded correctly after successful cancellation.
  - Failed cancellations remain retryable without changing the recorded state.
- **Tests**
  - Added coverage for the `locked` → `closed` transition, confirming cancellation occurs once and no board movement takes place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->