### PR TITLE
clampWireReportMd truncates before secretscrub.Scrub — a near-cap credential can leak into a filed report_md

### DIFF
--- a/api/internal/workersvc/report_only.go
+++ b/api/internal/workersvc/report_only.go
@@ -6,9 +6,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/vtmocanu/uzi/api/internal/runkind"
-	"github.com/vtmocanu/uzi/api/internal/secretscrub"
 	"github.com/vtmocanu/uzi/api/internal/store"
-	"github.com/vtmocanu/uzi/api/internal/termsafe"
 )
 
 // clampWireReportOnly gates the worker's report_only declaration to issue runs
@@ -47,10 +45,12 @@ func clampWireReportMd(run store.Run, p *string, reportOnly bool) pgtype.Text {
 		slog.Warn("dropping report_md: report_only not set", "run_id", run.ID, "kind", run.Kind)
 		return pgtype.Text{}
 	}
-	// Order matters: sanitize (strip + cap) THEN scrub — mirroring judge_worker.go:
-	// ScrubSecrets(termsafe.SanitizeBounded(...)), so the scrubber sees whole runes and the
-	// cap is applied to structural text before redaction rewrites it.
-	s := secretscrub.Scrub(termsafe.SanitizeBounded(*p, ReviewSummaryMaxBytes))
+	// Order matters: sanitize the WHOLE field, secret-scrub it, and ONLY THEN apply the
+	// byte cap (see scrubThenBound). secretscrub.Scrub matches a credential only when it
+	// sees the whole token, so capping first can leave a sub-match-length prefix that Scrub
+	// misses — a near-cap credential would leak into the filed report_md. This is the
+	// report-only sibling of clampWireProposal's F4 fix (#1122).
+	s := scrubThenBound(*p, ReviewSummaryMaxBytes)
 	if s == "" {
 		return pgtype.Text{}
 	}

--- a/api/internal/workersvc/report_only_test.go
+++ b/api/internal/workersvc/report_only_test.go
@@ -116,6 +116,35 @@ func TestClampWireReportMdBoundsToCap(t *testing.T) {
 	}
 }
 
+// TestClampWireReportMdScrubsSecretStraddlingCap pins the scrub-BEFORE-cap ordering: a
+// credential positioned so it straddles ReviewSummaryMaxBytes must be scrubbed WHOLE,
+// never truncated first into a sub-match-length prefix that Scrub misses and that then
+// leaks into the stored report_md. This is the report-only sibling of
+// TestClampWireProposalScrubsSecretStraddlingCap (F4 from PR #1122). It FAILS on a
+// truncate-then-scrub order (the tail is cut, "glpat-<few>" survives) and PASSES on
+// scrub-then-cap.
+func TestClampWireReportMdScrubsSecretStraddlingCap(t *testing.T) {
+	// Assembled from parts (.claude/rules/prds.md): a contiguous glpat-<20> literal in
+	// tracked source is rejected by GitHub Push Protection. glpat- + 20 chars = 26 bytes.
+	secret := "glpat-" + "straddlethecap000000"
+	// Place the secret so it STARTS before the cap and ENDS past it: 10 bytes of the token
+	// sit beyond ReviewSummaryMaxBytes, so a truncate-first order would cut it mid-token.
+	pad := strings.Repeat("A", ReviewSummaryMaxBytes-(len(secret)-10))
+	got := clampWireReportMd(issueRun(), strp(pad+secret), true)
+	if !got.Valid {
+		t.Fatal("expected stored text, got NULL")
+	}
+	if strings.Contains(got.String, "glpat-") {
+		t.Errorf("a credential prefix leaked past the cap (truncate-before-scrub): report_md=%q", got.String)
+	}
+	if strings.Contains(got.String, secret) {
+		t.Errorf("full secret survived: report_md=%q", got.String)
+	}
+	if len(got.String) > ReviewSummaryMaxBytes {
+		t.Errorf("stored %d bytes, want <= %d", len(got.String), ReviewSummaryMaxBytes)
+	}
+}
+
 // A completed report from a run that produced a normal MR carries neither field: the
 // worker sends no key rather than "" or false, so both decode nil and clamp to the
 // no-report-only shape (report_only=false, report_md NULL), byte-identical to before.


### PR DESCRIPTION
Implements issue #1124.

Closes #1124

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1124`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved report-only processing to scrub sensitive information before applying content length limits.
  - Prevented partial credentials or secrets from being retained when they span the report size boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->