### PR TITLE
worker finalize: preserve push_secret_blocked fail_origin if reportState throws + add runner-level regression test

### DIFF
--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -68,6 +68,21 @@ import { REASON_NO_TOKEN } from "./sdk-executor.js";
  *  (forge.ts) so a runaway SDK error can't bloat the run row or the stream. */
 const MAX_FAILURE_REASON_LEN = 512;
 
+/** PRD #974 follow-up (#1077): a terminal push_secret_blocked report whose reportState
+ *  exhausted its bounded retries and threw. Carrying the typed origin + safe reason through
+ *  execute()'s generic catch preserves fail_origin=push_secret_blocked (instead of defaulting
+ *  to agent_failure) WITHOUT ever attaching preserved_patch. */
+class TerminalReportError extends Error {
+  constructor(
+    readonly reason: string,
+    readonly failOrigin: string,
+    cause?: unknown,
+  ) {
+    super("terminal state report failed", { cause });
+    this.name = "TerminalReportError";
+  }
+}
+
 /** Map a known failure-reason CONSTANT to the server's fail_origin enum (PRD #69
  *  M7a). Authored WORKER-SIDE from the reason constant the throw site used — it never
  *  parses free text: it matches only the fixed prefixes the two fatal pre-start
@@ -743,13 +758,22 @@ export class RunRunner {
         // carries the user's verbatim reason; scrubbing it too is harmless for plain
         // text and a safety net if the user pasted a secret.
         const rawReason =
-          err instanceof PlanRejectedError ? err.reason : errMessage(err);
+          err instanceof PlanRejectedError
+            ? err.reason
+            : err instanceof TerminalReportError
+              ? err.reason
+              : errMessage(err);
         const reason = redactText(rawReason);
         // PRD #69 M7a: derive the TRUSTED failure class from the RAW reason (before
         // redaction) so a fatal pre-start failure (provisioning / no token) carries a
         // structured origin the judge can key on; an ordinary agent failure maps to
-        // undefined and the server defaults it to 'agent_failure'.
-        const failOrigin = failOriginForReason(rawReason);
+        // undefined and the server defaults it to 'agent_failure'. PRD #1077: a
+        // TerminalReportError carries its own typed origin (push_secret_blocked) whose
+        // terminal report threw after exhausting retries — honor it verbatim.
+        const failOrigin =
+          err instanceof TerminalReportError
+            ? err.failOrigin
+            : failOriginForReason(rawReason);
         runLog.error("run failed", { error: reason });
         batcher.emit({
           kind: "error",
@@ -1352,6 +1376,24 @@ export class RunRunner {
       }
     }
 
+    // PRD #974 M2 / #1077: the single terminal reporter for a push_secret_blocked failure.
+    // If reportState exhausts its bounded retries and throws, rethrow a typed sentinel so
+    // execute()'s generic catch preserves the push_secret_blocked origin instead of defaulting
+    // to agent_failure — and NEVER attach preserved_patch (the diff carries the detected secret).
+    const reportPushSecretBlocked = async (reason: string): Promise<void> => {
+      const capped = reason.slice(0, MAX_FAILURE_REASON_LEN);
+      try {
+        await reportState({
+          status: "failed",
+          failure_reason: capped,
+          fail_origin: "push_secret_blocked",
+          preserved_patch: undefined,
+        });
+      } catch (e) {
+        throw new TerminalReportError(capped, "push_secret_blocked", e);
+      }
+    };
+
     // PRD #974 M2 (load-bearing security): a GitHub run's committed range is scanned for secrets
     // with the pinned gitleaks (default ruleset, all three silencers GitHub Push Protection
     // ignores DISABLED — see git.secretScanRange) BEFORE the doomed push, mirroring the #377
@@ -1391,12 +1433,7 @@ export class RunRunner {
           },
         );
         await batcher.close();
-        await reportState({
-          status: "failed",
-          failure_reason: reason.slice(0, MAX_FAILURE_REASON_LEN),
-          fail_origin: "push_secret_blocked",
-          preserved_patch: undefined,
-        });
+        await reportPushSecretBlocked(reason);
         return;
       }
       if (!scan.trusted) {
@@ -1455,12 +1492,7 @@ export class RunRunner {
         run_id: runId,
       });
       await batcher.close();
-      await reportState({
-        status: "failed",
-        failure_reason: reason.slice(0, MAX_FAILURE_REASON_LEN),
-        fail_origin: "push_secret_blocked",
-        preserved_patch: undefined,
-      });
+      await reportPushSecretBlocked(reason);
     };
 
     // PRD #456 M1: a GitHub run can be merely BEHIND the default branch on

--- a/agent/test/runner-secret-block.test.ts
+++ b/agent/test/runner-secret-block.test.ts
@@ -1,0 +1,157 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { nullLogger } from "./helpers.js";
+import { StubExecutor } from "../src/executor.js";
+import { RunRunner } from "../src/runner.js";
+import {
+  api,
+  client,
+  fakeGitHub,
+  fx,
+  git,
+  gitlabClaim,
+  installHarness,
+} from "./runner-harness.js";
+
+installHarness();
+
+// PRD #974 M2 / #1077: the two terminal push_secret_blocked sites (the trusted pre-push
+// gitleaks block and the GH013 remote backstop) must persist fail_origin=push_secret_blocked
+// and NEVER a preserved_patch — even when the terminal reportState exhausts its bounded
+// retries and throws, in which case execute()'s generic catch honors a typed sentinel
+// (TerminalReportError) instead of defaulting the origin to agent_failure.
+describe("RunRunner — push_secret_blocked typed terminal (PRD #974 M2 / #1077)", () => {
+  // A github claim: forge_type=github routes the pre-push gitleaks scan + GH013 backstop,
+  // clone_url is the local fixture (git is forge-agnostic).
+  const githubClaim = (iid: number) =>
+    gitlabClaim(iid, {
+      repo: {
+        id: "r1",
+        url: "https://github.com/org/repo",
+        clone_url: fx.originPath,
+        forge_type: "github",
+      },
+    });
+
+  // The github-wired runner (mirrors runner-push-mr.test.ts): a fakeGitHub forge client so
+  // no network, StubExecutor so a real branch is committed and finalize proceeds.
+  const githubRunner = () => {
+    const { github } = fakeGitHub();
+    return new RunRunner(
+      client,
+      git,
+      () => ({ executor: new StubExecutor(nullLogger()) }),
+      nullLogger(),
+      20,
+      undefined,
+      {
+        pollMs: 5,
+        planApprovalTimeoutMs: 0,
+        github,
+      },
+    );
+  };
+
+  const failedBody = (runId: string) =>
+    api.states.find((s) => s.runId === runId && s.body.status === "failed")!.body;
+
+  it("trusted scan finding fails typed as push_secret_blocked, omits preserved_patch, and never pushes", async () => {
+    git.secretScanRange = (async () => ({
+      trusted: true,
+      findings: [
+        {
+          file: "src/leak.ts",
+          startLine: 1,
+          commit: "deadbeefcafe",
+          ruleId: "generic-api-key",
+        },
+      ],
+    })) as typeof git.secretScanRange;
+    let pushed = 0;
+    git.pushBranch = (async () => {
+      pushed++;
+    }) as typeof git.pushBranch;
+
+    const claim = githubClaim(1001);
+    await githubRunner().execute(claim);
+
+    const failed = failedBody(claim.run_id);
+    assert.strictEqual(failed.fail_origin, "push_secret_blocked");
+    assert.strictEqual(failed.preserved_patch, undefined);
+    // The trusted-scan block returns BEFORE pushToOrigin — the doomed push never happens.
+    assert.strictEqual(pushed, 0, "a trusted secret finding must block the push entirely");
+  });
+
+  it("GH013 backstop fails typed as push_secret_blocked and omits preserved_patch", async () => {
+    // Fail-open scan (untrustworthy/empty): the pre-push block does not fire, so the run
+    // reaches the finalize push and relies on GitHub's GH013 rejection backstop.
+    git.secretScanRange = (async () => ({
+      trusted: false,
+      findings: [],
+    })) as typeof git.secretScanRange;
+    git.pushBranch = (async () => {
+      throw new Error(
+        "remote: error: GH013: Repository rule violations found — push cannot contain secrets (push protection)",
+      );
+    }) as typeof git.pushBranch;
+
+    const claim = githubClaim(1002);
+    await githubRunner().execute(claim);
+
+    const failed = failedBody(claim.run_id);
+    assert.strictEqual(failed.fail_origin, "push_secret_blocked");
+    assert.strictEqual(failed.preserved_patch, undefined);
+  });
+
+  it("preserves push_secret_blocked origin when the terminal report throws (trusted-scan path)", async () => {
+    // Arm the /state failure at the MOMENT of the terminal report (inside secretScanRange,
+    // just before returning the finding) so the earlier non-terminal running reports do not
+    // consume the injected budget. With terminalRetrySchedule:[1,1] the terminal report makes
+    // three attempts, all 503 → it throws → generic catch → TerminalReportError → the fallback
+    // reportState (4th /state call) succeeds and persists the typed origin.
+    git.secretScanRange = (async () => {
+      api.failStateNext(3, 503);
+      return {
+        trusted: true,
+        findings: [
+          {
+            file: "src/leak.ts",
+            startLine: 1,
+            commit: "deadbeefcafe",
+            ruleId: "generic-api-key",
+          },
+        ],
+      };
+    }) as typeof git.secretScanRange;
+
+    const claim = githubClaim(1003);
+    await githubRunner().execute(claim);
+
+    const failed = failedBody(claim.run_id);
+    // The compound fix: WITHOUT it, the sentinel's typed origin is lost and the server
+    // defaults to agent_failure.
+    assert.strictEqual(failed.fail_origin, "push_secret_blocked");
+    assert.strictEqual(failed.preserved_patch, undefined);
+  });
+
+  it("preserves push_secret_blocked origin when the terminal report throws (GH013 backstop)", async () => {
+    git.secretScanRange = (async () => ({
+      trusted: false,
+      findings: [],
+    })) as typeof git.secretScanRange;
+    git.pushBranch = (async () => {
+      // Arm the failure so the terminal backstop report exhausts its retries and throws.
+      api.failStateNext(3, 503);
+      throw new Error(
+        "remote: error: GH013: push cannot contain secrets (push protection)",
+      );
+    }) as typeof git.pushBranch;
+
+    const claim = githubClaim(1004);
+    await githubRunner().execute(claim);
+
+    const failed = failedBody(claim.run_id);
+    assert.strictEqual(failed.fail_origin, "push_secret_blocked");
+    assert.strictEqual(failed.preserved_patch, undefined);
+  });
+});


### PR DESCRIPTION
Implements issue #1077.

Closes #1077

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1077`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of secret-blocked push failures in GitHub runs.
  * Preserved the failure origin when push attempts are blocked locally or rejected remotely.
  * Ensured failed terminal report retries retain the correct failure status without preserving the associated patch.

* **Tests**
  * Added coverage for trusted pre-push secret findings, remote GH013 rejections, and exhausted terminal report retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->