### PR TITLE
web: Findings surface uses a bug icon instead of the warning triangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ through `[0.52.0]`.)
 - **Slack DM when a usage-limit-paused run resumes ([#1116](https://github.com/vtmocanu/uzi/issues/1116)).**
   A run parked on an Anthropic usage limit already posts a ⏸️ Paused reply into its Slack DM thread; now the first time it is back to running it posts a single ▶️ Resumed reply into the same thread, carrying how long it waited and (from the second pause) the pause count (a resume straight into the plan gate, a question, or a terminal state is carried by that reply instead), deduped through the per-run Slack anchor so a redelivered running report never re-posts.
 
+### Changed
+
+- **The Findings surface in the web UI now uses a bug glyph instead of the warning triangle ([#1139](https://github.com/vtmocanu/uzi/issues/1139)).**
+  The sidebar nav item, page header, empty state, and run-view finding card for Findings ("off-task bugs your workers flagged mid-run") switch from the AlertIcon warning triangle to a new BugIcon, keeping the sky/info tint; AlertIcon stays the genuine-warning glyph everywhere else (e.g. the missing-sweep-labels notice).
+
 ## [0.78.0] - 2026-09-03
 
 ### Added

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -26,11 +26,11 @@ import { BuildInfoPopover } from "./BuildInfoPopover";
 import { ChangelogDrawer } from "./ChangelogDrawer";
 import {
   ActivityIcon,
-  AlertIcon,
   BellIcon,
   BoardIcon,
   BookIcon,
   BotIcon,
+  BugIcon,
   ChatIcon,
   ClockIcon,
   ChevronRightIcon,
@@ -771,7 +771,7 @@ function SidebarContent({
               meta; brand "count" tone, the noun is "open". */}
           <NavItem
             to="/findings"
-            icon={<AlertIcon />}
+            icon={<BugIcon />}
             label="Findings"
             badge={findingsOpen}
             badgeTone="count"

--- a/web/src/components/FindingCard.tsx
+++ b/web/src/components/FindingCard.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { api, ApiError, isHttpsUrl, type IncidentalFindingFiledIssue } from "../lib/api";
 import { errorMessage } from "../lib/apiError";
 import { Badge, Button } from "./ui";
-import { AlertIcon, ExternalLinkIcon } from "./icons";
+import { BugIcon, ExternalLinkIcon } from "./icons";
 import { stripUnsafeChars } from "../lib/safeText";
 
 // FindingCard renders an incidental-finding card in the run stream (PRD #333 M7, D10).
@@ -123,7 +123,7 @@ export function FindingCard({
       <div className="flex items-center justify-between gap-2 border-b border-info/20 bg-info/10 px-3 py-2">
         <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-info">
           <span aria-hidden="true">
-            <AlertIcon />
+            <BugIcon />
           </span>
           Incidental finding
         </span>

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -269,6 +269,22 @@ export const AlertIcon = (p: SVGProps<SVGSVGElement>) => (
   </Icon>
 );
 
+export const BugIcon = (p: SVGProps<SVGSVGElement>) => (
+  <Icon {...p}>
+    <path d="M12 20v-9" />
+    <path d="M14 7a4 4 0 0 1 4 4v3a6 6 0 0 1-12 0v-3a4 4 0 0 1 4-4z" />
+    <path d="M14.12 3.88 16 2" />
+    <path d="M21 21a4 4 0 0 0-3.81-4" />
+    <path d="M21 5a4 4 0 0 1-3.55 3.97" />
+    <path d="M22 13h-4" />
+    <path d="M3 21a4 4 0 0 1 3.81-4" />
+    <path d="M3 5a4 4 0 0 0 3.55 3.97" />
+    <path d="M6 13H2" />
+    <path d="m8 2 1.88 1.88" />
+    <path d="M9 7.13V6a3 3 0 1 1 6 0v1.13" />
+  </Icon>
+);
+
 export const MenuIcon = (p: SVGProps<SVGSVGElement>) => (
   <Icon {...p}>
     <path d="M4 6h16M4 12h16M4 18h16" />

--- a/web/src/pages/Findings.tsx
+++ b/web/src/pages/Findings.tsx
@@ -29,7 +29,7 @@ import { stripUnsafeChars } from "../lib/safeText";
 import { useDemoMode } from "../lib/demoMode";
 import { maskRepoPath } from "../lib/demoMask";
 import { Alert, Badge, Button, cx, EmptyState, ListSkeleton, PageHeader } from "../components/ui";
-import { AlertIcon, XIcon } from "../components/icons";
+import { BugIcon, XIcon } from "../components/icons";
 
 // The three rungs the page's segmented control exposes (the `all` bucket the API also accepts is
 // deliberately not a tab — the backlog is a triage queue, not an archive browser). `to_file` is
@@ -208,7 +208,7 @@ export function Findings() {
         titleNode={
           <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
             <span className="text-info" aria-hidden="true">
-              <AlertIcon />
+              <BugIcon />
             </span>
             Findings
           </h1>
@@ -280,7 +280,7 @@ export function Findings() {
       {!loading && backlog && (
         backlog.findings.length === 0 ? (
           <EmptyState
-            icon={<AlertIcon />}
+            icon={<BugIcon />}
             title={runAnchor ? "No findings for this run" : `Nothing under ${TAB_LABEL[bucket]}`}
             description="Switch buckets or clear a filter to see findings in another state."
           />


### PR DESCRIPTION
Implements issue #1139.

Closes #1139

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1139`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Findings-related navigation, page headers, cards, and empty states now use a bug icon for clearer visual distinction.
  * The existing sky/info tint is preserved.
  * Alert icons remain reserved for genuine warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->