### PR TITLE
Default reasoning effort to xhigh (uzi default) for users who haven't chosen a level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ through `[0.52.0]`.)
 
 ### Changed
 
+- **Default reasoning effort is now `xhigh` for users who have not chosen a level ([#1157](https://github.com/vtmocanu/uzi/issues/1157)).**
+  Runs whose owner never picked a reasoning-effort level now dispatch at uzi's own default of `xhigh` instead of the Claude Agent SDK's built-in `high`; an explicit choice (including `high`) is honored unchanged, and the Settings picker now labels the inherit and `xhigh` options as the uzi default.
+
 - **The Findings surface in the web UI now uses a bug glyph instead of the warning triangle ([#1139](https://github.com/vtmocanu/uzi/issues/1139)).**
   The sidebar nav item, page header, empty state, and run-view finding card for Findings ("off-task bugs your workers flagged mid-run") switch from the AlertIcon warning triangle to a new BugIcon, keeping the sky/info tint; AlertIcon stays the genuine-warning glyph everywhere else (e.g. the missing-sweep-labels notice).
 

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -448,11 +448,14 @@ export interface ClaimConfig {
   default_model?: string;
   /** The run owner's per-user default reasoning effort (PRD #617). When present it
    *  is applied to the SDK's top-level `Options.effort` for the main thread and
-   *  inherited by the implement-turn/subagent options via the baseOptions spread;
-   *  absent when the owner set no default, so the worker omits the key entirely and
-   *  the SDK default (`high`) applies. Typed as the SDK's own EffortLevel so the
-   *  worker tracks the SDK's closed set (mirror of the Go `agenttmpl.EffortLevels`
-   *  and the web EffortSelect list — no shared source, keep in lockstep). */
+   *  inherited by the implement-turn/subagent options via the baseOptions spread. The
+   *  API now populates this for every issue/chat claim — the owner's explicit choice,
+   *  or the uzi default `xhigh` for an owner who never chose (issue #1157); it is
+   *  absent only from an un-upgraded API, in which case the worker omits the key and
+   *  the SDK applies its own fallback (the worker adds no default of its own). Typed as
+   *  the SDK's own EffortLevel so the worker tracks the SDK's closed set (mirror of the
+   *  Go `agenttmpl.EffortLevels` and the web EffortSelect list — no shared source, keep
+   *  in lockstep). */
   default_effort?: EffortLevel;
   /** The run owner's AI-attribution opt-out (issue #916), read live per claim. When
    *  false, the worker suppresses the Agent SDK's Co-Authored-By: Claude commit trailer
@@ -967,7 +970,9 @@ export interface ChatClaimConfig {
   max_turns: number;
   /** The owner's per-user default model (PRD #17); omitted when unset. */
   default_model?: string;
-  /** The owner's per-user default reasoning effort (PRD #617); omitted when unset. */
+  /** The owner's per-user default reasoning effort (PRD #617); the API populates it
+   *  with the owner's choice or the uzi default `xhigh` (issue #1157), and it is
+   *  optional only for an un-upgraded API. */
   default_effort?: EffortLevel;
 }
 

--- a/agent/src/sdk-executor.ts
+++ b/agent/src/sdk-executor.ts
@@ -958,9 +958,12 @@ export class SdkExecutor implements Executor {
     //
     // `leadModel` is computed above (before the plan-turn copy) so the PRD #305 own-roster
     // override can use it; here it only drives the top-level lead model. PRD #617 effort
-    // and issue #916 attribution are set ONLY when present (never an explicit undefined),
-    // so an unset owner is byte-identical to today: the adapter omits the key and the SDK
-    // default applies. Both reach the implement turn too, via the `baseConfig` spread.
+    // and issue #916 attribution are set ONLY when present in the config (never an explicit
+    // undefined); when a key is absent the adapter omits it and the SDK applies its own
+    // fallback. The runtime adds no default of its own — the API is the policy source and
+    // now populates effort with the owner's choice or the uzi default `xhigh` for an
+    // inheriting owner (issue #1157). Both reach the implement turn too, via the
+    // `baseConfig` spread.
     const effort = ctx.config?.default_effort;
     const baseConfig: ClaudeTurnConfig = {
       cwd: ctx.worktreePath,

--- a/agent/test/sdk-executor.test.ts
+++ b/agent/test/sdk-executor.test.ts
@@ -1787,9 +1787,10 @@ describe("SdkExecutor override_subagent_model (PRD #305 M4)", () => {
 
 describe("SdkExecutor reasoning effort on baseOptions (PRD #617)", () => {
   // The owner's per-user effort must land on options.effort on BOTH the plan turn
-  // and the implement turn (Decision 8 cascade via the baseOptions spread), and an
-  // unset owner must OMIT the key (never `effort: undefined`) so the SDK default
-  // (`high`) applies.
+  // and the implement turn (Decision 8 cascade via the baseOptions spread), and a
+  // config WITHOUT default_effort must OMIT the key (never `effort: undefined`) so the
+  // SDK applies its own fallback — the runtime adds no default; the API now supplies
+  // xhigh for an inheriting owner (issue #1157).
   /** Run a plan turn + one implement turn, returning the turns for inspection. */
   async function runTurns(overrides: Partial<RunContext>, verdict?: PlanVerdict) {
     const { queryFn, turns } = fakeTurns([

--- a/api/internal/agenttmpl/effort.go
+++ b/api/internal/agenttmpl/effort.go
@@ -13,16 +13,39 @@ import (
 // change one and change the other two.
 var EffortLevels = []string{"low", "medium", "high", "xhigh", "max"}
 
+// UziDefaultEffort is uzi's own default reasoning-effort level (issue #1157),
+// applied to a run whose owner has NOT chosen an explicit level (the per-user
+// default_effort column is NULL/blank). It replaces the Claude Agent SDK's own
+// built-in fallback (`high`) as the *effective* uzi default. It is a member of
+// EffortLevels; changing it must keep it inside that closed set.
+const UziDefaultEffort = "xhigh"
+
+// ResolveDefaultEffort resolves the owner's per-user default effort to the level a
+// run actually uses (issue #1157): the owner's explicit choice when set, or
+// UziDefaultEffort when the value is nil (NULL) or blank/whitespace-only (inherit).
+// Callers pass the per-user value (e.g. via textPtr over the NULLable column); the
+// resolver never returns "" — an inheriting owner rides the uzi default, not an
+// omitted key.
+func ResolveDefaultEffort(userEffort *string) string {
+	if userEffort == nil {
+		return UziDefaultEffort
+	}
+	if e := strings.TrimSpace(*userEffort); e != "" {
+		return e
+	}
+	return UziDefaultEffort
+}
+
 // ValidateEffort is the single source of truth for the per-user default-effort
 // rules (PRD #617). It lives in this neutral, dependency-free package so every
 // surface can share it without an import cycle, mirroring ValidateModel.
 //
 // A blank (or whitespace-only) value means inherit and returns ("", nil): the
-// caller decides how to store "inherit" (NULL — we then omit the SDK `effort`
-// key, so the SDK default `high` applies). A non-blank value is trimmed and must
-// then EQUAL exactly one of EffortLevels (case-sensitive): trimming only strips
-// the ends, so an interior-whitespace value ("hi gh"), an unknown token, or a
-// differently-cased value ("HIGH") is rejected.
+// caller stores "inherit" as NULL, and inherit resolves to the uzi default
+// (UziDefaultEffort = `xhigh`) at claim assembly (see ResolveDefaultEffort). A
+// non-blank value is trimmed and must then EQUAL exactly one of EffortLevels
+// (case-sensitive): trimming only strips the ends, so an interior-whitespace value
+// ("hi gh"), an unknown token, or a differently-cased value ("HIGH") is rejected.
 func ValidateEffort(raw string) (string, error) {
 	e := strings.TrimSpace(raw)
 	if e == "" {

--- a/api/internal/agenttmpl/effort_test.go
+++ b/api/internal/agenttmpl/effort_test.go
@@ -46,3 +46,42 @@ func TestValidateEffort(t *testing.T) {
 		}
 	}
 }
+
+// TestUziDefaultEffort pins uzi's effective default reasoning effort (issue #1157)
+// to xhigh — the level an inheriting owner rides in place of the SDK's own `high`.
+func TestUziDefaultEffort(t *testing.T) {
+	if UziDefaultEffort != "xhigh" {
+		t.Errorf("UziDefaultEffort = %q, want \"xhigh\"", UziDefaultEffort)
+	}
+}
+
+// TestResolveDefaultEffort covers the inherit-vs-explicit resolution (issue #1157):
+// nil (NULL) and blank/whitespace-only values ride the uzi default; an explicit
+// level is returned trimmed and verbatim, never "".
+func TestResolveDefaultEffort(t *testing.T) {
+	strptr := func(s string) *string { return &s }
+
+	// Inherit cases: nil pointer and blank/whitespace-only values → the uzi default.
+	if got := ResolveDefaultEffort(nil); got != UziDefaultEffort {
+		t.Errorf("ResolveDefaultEffort(nil) = %q, want %q", got, UziDefaultEffort)
+	}
+	for _, in := range []string{"", "   ", "\t"} {
+		if got := ResolveDefaultEffort(strptr(in)); got != UziDefaultEffort {
+			t.Errorf("ResolveDefaultEffort(%q) = %q, want %q (inherit)", in, got, UziDefaultEffort)
+		}
+	}
+
+	// Explicit levels are returned verbatim; surrounding whitespace is trimmed.
+	for in, want := range map[string]string{
+		"low":    "low",
+		"medium": "medium",
+		"high":   "high",
+		"xhigh":  "xhigh",
+		"max":    "max",
+		" low ":  "low",
+	} {
+		if got := ResolveDefaultEffort(strptr(in)); got != want {
+			t.Errorf("ResolveDefaultEffort(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/api/internal/handler/agent_templates.go
+++ b/api/internal/handler/agent_templates.go
@@ -786,9 +786,9 @@ func validateModel(raw *string) (pgtype.Text, error) {
 // validateEffort is the thin HTTP-facing wrapper over agenttmpl.ValidateEffort
 // (the single source of the closed-enum effort rules, PRD #617), used by the
 // per-user default-effort endpoint. A nil pointer or a blank value becomes NULL
-// (inherit — we then omit the SDK effort key, so the SDK default `high` applies);
-// a valid level becomes a set pgtype.Text; anything else is an error (mapped to
-// 400 by the caller).
+// (inherit — stored as NULL; resolved to the uzi default `xhigh` at claim
+// assembly, issue #1157); a valid level becomes a set pgtype.Text; anything else
+// is an error (mapped to 400 by the caller).
 func validateEffort(raw *string) (pgtype.Text, error) {
 	if raw == nil {
 		return pgtype.Text{}, nil

--- a/api/internal/store/queries/users.sql
+++ b/api/internal/store/queries/users.sql
@@ -147,8 +147,8 @@ UPDATE users SET default_model = @default_model WHERE id = @id
 RETURNING default_model;
 
 -- name: GetUserDefaultEffort :one
--- The current user's per-user default reasoning effort (PRD #617); NULL = inherit
--- (we omit the SDK effort key, so the SDK default `high` applies). Read at issue-
+-- The current user's per-user default reasoning effort (PRD #617); NULL = inherit,
+-- resolved to the uzi default `xhigh` at claim assembly (issue #1157). Read at issue-
 -- and chat-run claim assembly, keyed on the run owner. Selects only the column.
 SELECT default_effort FROM users WHERE id = $1;
 

--- a/api/internal/store/users.sql.go
+++ b/api/internal/store/users.sql.go
@@ -317,8 +317,8 @@ const getUserDefaultEffort = `-- name: GetUserDefaultEffort :one
 SELECT default_effort FROM users WHERE id = $1
 `
 
-// The current user's per-user default reasoning effort (PRD #617); NULL = inherit
-// (we omit the SDK effort key, so the SDK default `high` applies). Read at issue-
+// The current user's per-user default reasoning effort (PRD #617); NULL = inherit,
+// resolved to the uzi default `xhigh` at claim assembly (issue #1157). Read at issue-
 // and chat-run claim assembly, keyed on the run owner. Selects only the column.
 func (q *Queries) GetUserDefaultEffort(ctx context.Context, id uuid.UUID) (pgtype.Text, error) {
 	row := q.db.QueryRow(ctx, getUserDefaultEffort, id)

--- a/api/internal/uzidocs/embed/worker-effort.md
+++ b/api/internal/uzidocs/embed/worker-effort.md
@@ -7,8 +7,9 @@ audience: user
 # Reasoning effort
 
 Pick how hard the Claude Agent SDK reasons on your own runs — the lead
-orchestrator and the subagents that inherit it. This overrides the SDK
-default just for you. Other users' runs are unaffected.
+orchestrator and the subagents that inherit it. This sets your own
+reasoning effort, overriding uzi's default just for you. Other users' runs
+are unaffected.
 
 ## Effort levels
 
@@ -17,11 +18,13 @@ default just for you. Other users' runs are unaffected.
 - `high`
 - `xhigh`
 - `max`
-- **Inherit** (the default)
+- **Inherit** (uzi default: `xhigh`)
 
-**Unset means the SDK default (`high`).** When you leave it on Inherit, uzi
-sends no effort setting at all, so the Claude Agent SDK's own default
-(`high`) applies — exactly as before this setting existed.
+**Unset means the uzi default (`xhigh`).** When you leave it on Inherit, uzi
+applies its own default reasoning effort — `xhigh` — to your runs. (This is
+deeper reasoning than the Claude Agent SDK's own built-in fallback of
+`high`; uzi now sets the level explicitly for you rather than leaving it
+unset.)
 
 ## Good to know
 
@@ -48,4 +51,4 @@ sends no effort setting at all, so the Claude Agent SDK's own default
    **Inherit**.
 3. Click **Save effort**. It applies starting with your next run.
 
-Leave it on **Inherit** to use the SDK default (`high`).
+Leave it on **Inherit** to use the uzi default (`xhigh`).

--- a/api/internal/workersvc/chat.go
+++ b/api/internal/workersvc/chat.go
@@ -131,8 +131,9 @@ type ChatClaimConfig struct {
 	TurnTimeoutSeconds int     `json:"turn_timeout_seconds"`
 	MaxTurns           int     `json:"max_turns"`
 	DefaultModel       *string `json:"default_model,omitempty"`
-	// DefaultEffort is the owner's per-user default reasoning effort (PRD #617),
-	// omitted when unset (NULL ⇒ the worker never sets the SDK effort key).
+	// DefaultEffort carries the owner's per-user reasoning effort (PRD #617), or the
+	// uzi default `xhigh` when the owner has not chosen (NULL, issue #1157) — so it is
+	// populated on every chat claim now.
 	DefaultEffort *string `json:"default_effort,omitempty"`
 }
 
@@ -238,7 +239,7 @@ func (s *Service) assembleChatClaim(ctx context.Context, run store.Run) (*ChatCl
 			TurnTimeoutSeconds: int(s.p.WorkerChatTurnTimeout.Seconds()),
 			MaxTurns:           s.p.ChatMaxTurns,
 			DefaultModel:       textPtr(defaultModel),
-			DefaultEffort:      textPtr(defaultEffort),
+			DefaultEffort:      resolveEffortPtr(defaultEffort),
 		},
 	}, nil
 }

--- a/api/internal/workersvc/chat_test.go
+++ b/api/internal/workersvc/chat_test.go
@@ -53,10 +53,11 @@ func TestClaimChatSucceedsWithoutForgeConnection(t *testing.T) {
 	}
 }
 
-// TestClaimChatOmitsDefaultEffortWhenOwnerHasNone: with the owner's per-user default
-// effort left NULL the chat claim's Config.DefaultEffort is nil and omitted from the
-// wire (PRD #617), so the worker never sets the SDK effort key.
-func TestClaimChatOmitsDefaultEffortWhenOwnerHasNone(t *testing.T) {
+// TestClaimChatDefaultsEffortToXhighWhenOwnerHasNone: with the owner's per-user
+// default effort left NULL (inherit), the chat claim resolves it to the uzi default
+// `xhigh` (issue #1157) rather than omitting the field, so the worker applies xhigh
+// instead of the SDK's own `high` fallback.
+func TestClaimChatDefaultsEffortToXhighWhenOwnerHasNone(t *testing.T) {
 	box := newBox(t)
 	sealedTok, _ := box.Seal([]byte("anthropic-chat-effomit-abcdef1234567890"))
 	uid := uuid.New()
@@ -70,15 +71,15 @@ func TestClaimChatOmitsDefaultEffortWhenOwnerHasNone(t *testing.T) {
 	if err != nil || payload == nil {
 		t.Fatalf("ClaimChat: payload=%v err=%v", payload, err)
 	}
-	if payload.Config.DefaultEffort != nil {
-		t.Fatalf("expected nil default effort, got %q", *payload.Config.DefaultEffort)
+	if payload.Config.DefaultEffort == nil || *payload.Config.DefaultEffort != "xhigh" {
+		t.Fatalf("expected default effort xhigh for an inheriting owner, got %+v", payload.Config.DefaultEffort)
 	}
 	raw, err := json.Marshal(payload.Config)
 	if err != nil {
 		t.Fatalf("marshal config: %v", err)
 	}
-	if strings.Contains(string(raw), "default_effort") {
-		t.Fatalf("unset default_effort should be omitted from the chat payload; got %s", raw)
+	if !strings.Contains(string(raw), `"default_effort":"xhigh"`) {
+		t.Fatalf("inheriting owner should carry default_effort xhigh on the chat payload; got %s", raw)
 	}
 }
 

--- a/api/internal/workersvc/claim.go
+++ b/api/internal/workersvc/claim.go
@@ -386,13 +386,13 @@ type ClaimConfig struct {
 	QuestionMax            int     `json:"question_max"`
 	QuestionTimeoutSeconds int     `json:"question_timeout_seconds"`
 	DefaultModel           *string `json:"default_model,omitempty"`
-	// DefaultEffort is the owner's per-user default reasoning effort (PRD #617):
-	// the SDK effort level the worker applies to the lead/main thread. omitempty:
-	// omitted when the owner has no default (NULL), so the worker never sets the
-	// SDK effort key and the SDK default (`high`) applies — byte-identical to
-	// today's wire for every run without an effort set. Unlike DefaultModel there
-	// is no per-run/per-schedule freeze; the owner's per-user value is the only
-	// source.
+	// DefaultEffort is the SDK effort level the worker applies to the lead/main
+	// thread: the owner's explicit per-user reasoning effort (PRD #617), or the uzi
+	// default `xhigh` (issue #1157) when the owner has not chosen (NULL). It is
+	// populated for every issue-lane claim assembled through resolveEffortPtr; the
+	// judge lane shares this struct but leaves it nil (omitted), so judge runs keep
+	// riding the SDK's own fallback. omitempty is retained. Unlike DefaultModel there
+	// is no per-run/per-schedule freeze; the owner's per-user value is the only source.
 	DefaultEffort *string `json:"default_effort,omitempty"`
 	// AttributionEnabled is the run owner's AI-attribution opt-out (issue #916), read
 	// LIVE from the owner's users row on every claim. When false, the worker suppresses

--- a/api/internal/workersvc/claim_assembly.go
+++ b/api/internal/workersvc/claim_assembly.go
@@ -181,10 +181,11 @@ func (s *Service) assembleClaim(ctx context.Context, wkr store.Worker, run store
 		defaultModel = run.Model
 	}
 
-	// The run owner's per-user default reasoning effort (PRD #617). NULL ⇒ nil ⇒
-	// omitted from the payload, so the worker never sets the SDK effort key and the
-	// SDK default (`high`) applies. Unlike DefaultModel there is no per-schedule
-	// freeze — the owner's per-user value is the only source.
+	// The run owner's per-user default reasoning effort (PRD #617). NULL now
+	// resolves to the uzi default `xhigh` at this sink (via resolveEffortPtr /
+	// agenttmpl.ResolveDefaultEffort, issue #1157); an explicit choice is carried
+	// verbatim. Unlike DefaultModel there is no per-schedule freeze — the owner's
+	// per-user value is the only source.
 	defaultEffort, err := s.q.GetUserDefaultEffort(ctx, run.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("default effort lookup: %w", err)
@@ -435,7 +436,7 @@ func (s *Service) assembleClaim(ctx context.Context, wkr store.Worker, run store
 			QuestionMax:            s.p.QuestionMax,
 			QuestionTimeoutSeconds: s.p.QuestionTimeoutSeconds,
 			DefaultModel:           textPtr(defaultModel),
-			DefaultEffort:          textPtr(defaultEffort),
+			DefaultEffort:          resolveEffortPtr(defaultEffort),
 			AttributionEnabled:     attributionEnabled,
 			// PRD #305 M3: deliver the flag frozen onto the run at fire time (M1). Read
 			// straight off the run row — not re-derived from the schedule. false for every

--- a/api/internal/workersvc/pgparams.go
+++ b/api/internal/workersvc/pgparams.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/vtmocanu/uzi/api/internal/agenttmpl"
 	"github.com/vtmocanu/uzi/api/internal/pgconv"
 	"github.com/vtmocanu/uzi/api/internal/termsafe"
 )
@@ -86,6 +87,16 @@ func textPtr(t pgtype.Text) *string {
 	}
 	s := t.String
 	return &s
+}
+
+// resolveEffortPtr resolves the owner's per-user default reasoning effort to the
+// level the worker applies (PRD #617 + issue #1157): the owner's explicit choice,
+// or the uzi default (xhigh) when the column is NULL/blank. The wire field stays
+// *string+omitempty but is now ALWAYS populated — a NULL owner rides xhigh, not an
+// omitted effort key.
+func resolveEffortPtr(t pgtype.Text) *string {
+	e := agenttmpl.ResolveDefaultEffort(textPtr(t))
+	return &e
 }
 
 // coalesceInt returns the persisted int4 when present and def otherwise (PRD #122

--- a/api/internal/workersvc/service.go
+++ b/api/internal/workersvc/service.go
@@ -704,8 +704,8 @@ type Store interface {
 	SetUserJudgeAnthropicBinding(ctx context.Context, arg store.SetUserJudgeAnthropicBindingParams) (store.User, error)
 	GetUserDefaultModel(ctx context.Context, id uuid.UUID) (pgtype.Text, error)
 	// Per-user default reasoning effort (PRD #617): read at issue- and chat-run
-	// claim assembly, keyed on the run owner. NULL ⇒ inherit (worker omits the SDK
-	// effort key, so the SDK default `high` applies).
+	// claim assembly, keyed on the run owner. NULL ⇒ inherit, resolved to the uzi
+	// default `xhigh` at claim assembly (issue #1157).
 	GetUserDefaultEffort(ctx context.Context, id uuid.UUID) (pgtype.Text, error)
 	// Per-user AI-attribution opt-out (issue #916): read LIVE at standard run-claim
 	// assembly, keyed on the run owner, so flipping the toggle takes effect on the

--- a/api/internal/workersvc/service_test.go
+++ b/api/internal/workersvc/service_test.go
@@ -1911,10 +1911,11 @@ func TestClaimFailsOnDefaultModelLookupError(t *testing.T) {
 	}
 }
 
-// TestClaimOmitsDefaultEffortWhenOwnerHasNone mirrors the default_model omit test
-// (PRD #617): with the owner's per-user default effort left NULL the field is nil
-// and omitted from the wire, so the worker never sets the SDK effort key.
-func TestClaimOmitsDefaultEffortWhenOwnerHasNone(t *testing.T) {
+// TestClaimDefaultsEffortToXhighWhenOwnerHasNone: with the owner's per-user default
+// effort left NULL (inherit), the claim resolves it to the uzi default `xhigh`
+// (issue #1157) rather than omitting the field, so the worker applies xhigh instead
+// of the SDK's own `high` fallback.
+func TestClaimDefaultsEffortToXhighWhenOwnerHasNone(t *testing.T) {
 	box := newBox(t)
 	sealedPAT, _ := box.Seal([]byte("bot-pat-EFFOMIT-abcdef1234567890"))
 	sealedTok, _ := box.Seal([]byte("anthropic-EFFOMIT-abcdef1234567890"))
@@ -1934,16 +1935,16 @@ func TestClaimOmitsDefaultEffortWhenOwnerHasNone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
-	if payload.Config.DefaultEffort != nil {
-		t.Fatalf("expected nil default effort, got %q", *payload.Config.DefaultEffort)
+	if payload.Config.DefaultEffort == nil || *payload.Config.DefaultEffort != "xhigh" {
+		t.Fatalf("expected default effort xhigh for an inheriting owner, got %+v", payload.Config.DefaultEffort)
 	}
-	// omitempty: an unset default must not appear on the wire at all.
+	// The uzi default now rides the wire for a NULL owner.
 	b, err := json.Marshal(payload.Config)
 	if err != nil {
 		t.Fatalf("marshal config: %v", err)
 	}
-	if strings.Contains(string(b), "default_effort") {
-		t.Fatalf("unset default_effort should be omitted from the payload; got %s", b)
+	if !strings.Contains(string(b), `"default_effort":"xhigh"`) {
+		t.Fatalf("inheriting owner should carry default_effort xhigh on the wire; got %s", b)
 	}
 }
 

--- a/api/internal/workersvc/testdata/claim_ci_fix_wire.json
+++ b/api/internal/workersvc/testdata/claim_ci_fix_wire.json
@@ -57,6 +57,7 @@
     "plan_max_revisions": 3,
     "question_max": 5,
     "question_timeout_seconds": 86400,
+    "default_effort": "xhigh",
     "attribution_enabled": true,
     "skill_max_bytes": 65536,
     "skills_max_per_run": 32,

--- a/docs/worker-effort.md
+++ b/docs/worker-effort.md
@@ -7,8 +7,9 @@ audience: user
 # Reasoning effort
 
 Pick how hard the Claude Agent SDK reasons on your own runs — the lead
-orchestrator and the subagents that inherit it. This overrides the SDK
-default just for you. Other users' runs are unaffected.
+orchestrator and the subagents that inherit it. This sets your own
+reasoning effort, overriding uzi's default just for you. Other users' runs
+are unaffected.
 
 ## Effort levels
 
@@ -17,11 +18,13 @@ default just for you. Other users' runs are unaffected.
 - `high`
 - `xhigh`
 - `max`
-- **Inherit** (the default)
+- **Inherit** (uzi default: `xhigh`)
 
-**Unset means the SDK default (`high`).** When you leave it on Inherit, uzi
-sends no effort setting at all, so the Claude Agent SDK's own default
-(`high`) applies — exactly as before this setting existed.
+**Unset means the uzi default (`xhigh`).** When you leave it on Inherit, uzi
+applies its own default reasoning effort — `xhigh` — to your runs. (This is
+deeper reasoning than the Claude Agent SDK's own built-in fallback of
+`high`; uzi now sets the level explicitly for you rather than leaving it
+unset.)
 
 ## Good to know
 
@@ -48,4 +51,4 @@ sends no effort setting at all, so the Claude Agent SDK's own default
    **Inherit**.
 3. Click **Save effort**. It applies starting with your next run.
 
-Leave it on **Inherit** to use the SDK default (`high`).
+Leave it on **Inherit** to use the uzi default (`xhigh`).

--- a/web/src/components/EffortSelect.test.tsx
+++ b/web/src/components/EffortSelect.test.tsx
@@ -30,6 +30,23 @@ describe("EffortSelect", () => {
     expect(values).toEqual(["", "low", "medium", "high", "xhigh", "max"]);
   });
 
+  // Copy guard (issue #1157): the visible option LABELS surface uzi's default effort
+  // (xhigh) — the Inherit option and the xhigh option carry the "uzi default" copy,
+  // the other four render their bare value. The option VALUES are unchanged (asserted
+  // above), so this is a pure label check via the rendered <option>s' text.
+  it("labels the Inherit and xhigh options with the uzi default copy", () => {
+    render(<Harness initial="" />);
+    const labels = Array.from(combo().options).map((o) => o.text);
+    expect(labels).toEqual([
+      "Inherit (uzi default: xhigh)",
+      "low",
+      "medium",
+      "high",
+      "xhigh (uzi default)",
+      "max",
+    ]);
+  });
+
   it("selecting a level fires onChange with that level", () => {
     render(<Harness initial="" />);
     fireEvent.change(combo(), { target: { value: "low" } });

--- a/web/src/components/EffortSelect.tsx
+++ b/web/src/components/EffortSelect.tsx
@@ -22,10 +22,10 @@ export function EffortSelect({
 }) {
   return (
     <Select id={id} value={value} onChange={(e) => onChange(e.target.value)}>
-      <option value="">Inherit (SDK default: high)</option>
+      <option value="">Inherit (uzi default: xhigh)</option>
       {EFFORT_LEVELS.map((lvl) => (
         <option key={lvl} value={lvl}>
-          {lvl}
+          {lvl === "xhigh" ? "xhigh (uzi default)" : lvl}
         </option>
       ))}
     </Select>

--- a/web/src/lib/apiTypes.ts
+++ b/web/src/lib/apiTypes.ts
@@ -87,9 +87,9 @@ export interface SecretMeta {
 // #21).
 export interface UserSettings {
   default_model: string | null;
-  /** Per-user default reasoning effort (PRD #617); null means inherit — the worker
-   *  omits the SDK effort key, so the SDK default (`high`) applies. One of
-   *  low|medium|high|xhigh|max when set. */
+  /** Per-user default reasoning effort (PRD #617); null means the user has not chosen
+   *  (inherit), which resolves to the uzi default (`xhigh`) at claim assembly (issue
+   *  #1157). One of low|medium|high|xhigh|max when set. */
   default_effort: string | null;
   /** Per-user judge model override (PRD #69 M2); null means inherit the instance
    *  judge_model (which itself falls back to opus). Written through PUT /me/settings

--- a/web/src/pages/RunDefaults.tsx
+++ b/web/src/pages/RunDefaults.tsx
@@ -208,8 +208,8 @@ export function RunDefaults() {
   const [savedSummaryModel, setSavedSummaryModel] = useState("");
   const [summaryModelBusy, setSummaryModelBusy] = useState(false);
 
-  // Per-user default reasoning effort (PRD #617 M5): "" = inherit (the worker omits
-  // the SDK effort key, so the SDK default `high` applies). Its own saved/busy pair,
+  // Per-user default reasoning effort (PRD #617 M5): "" = inherit (a NULL/inherit value
+  // resolves to the uzi default `xhigh` at claim assembly, issue #1157). Its own saved/busy pair,
   // independent of the models above — same /me/settings endpoint, own field. Unlike
   // the model cards there is NO warning gate: the effort enum is closed, so the
   // dropdown can only ever emit a valid token or "".
@@ -345,7 +345,7 @@ export function RunDefaults() {
       setSavedEffort(eff);
       setNotice(
         eff === ""
-          ? "Reasoning effort cleared. Your runs use the SDK default (high)."
+          ? "Reasoning effort cleared. Your runs use the uzi default (xhigh)."
           : `Reasoning effort set to ${eff}. It applies to your next run.`,
       );
     } catch (err) {
@@ -736,13 +736,13 @@ export function RunDefaults() {
       {/* Per-user default reasoning effort (PRD #617 M5). A CLOSED dropdown — the SDK
           reasoning-effort levels plus Inherit — with no custom mode and no warning
           surface, because the enum is closed and the control can only emit a valid
-          level or "" (inherit). Leave it on Inherit to use the SDK default (high). */}
+          level or "" (inherit). Leave it on Inherit to use the uzi default (xhigh). */}
       <Card className="space-y-5">
         <div>
           <SectionTitle>Reasoning effort</SectionTitle>
           <p className="mt-2 text-sm text-muted">
             The Agent SDK reasoning-effort level your runs use. Leave it on{" "}
-            <em>Inherit</em> to use the SDK default (<code className="rounded bg-raised px-1 py-0.5 text-fg">high</code>).
+            <em>Inherit</em> to use the uzi default (<code className="rounded bg-raised px-1 py-0.5 text-fg">xhigh</code>).
             Higher levels reason more deeply and cost more; a level a given model does not
             support is silently downgraded to the nearest one it does. It applies to your
             own runs only; other users are unaffected.


### PR DESCRIPTION
Implements issue #1157.

Closes #1157

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1157`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reasoning effort now defaults to **xhigh** when no user setting is provided.
  * Explicitly selected effort levels remain unchanged.
  * Claims consistently include the resolved default effort.

* **User Interface**
  * Settings now identify both **Inherit** and **xhigh** as the uzi default.
  * Run-default messaging reflects the updated default.

* **Documentation**
  * Updated guidance throughout the product to explain the **xhigh** default and inheritance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->