### PR TITLE
Judge lane inherits the user's reasoning-effort setting (default_effort → xhigh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ through `[0.52.0]`.)
 - **Default reasoning effort is now `xhigh` for users who have not chosen a level ([#1157](https://github.com/vtmocanu/uzi/issues/1157)).**
   Runs whose owner never picked a reasoning-effort level now dispatch at uzi's own default of `xhigh` instead of the Claude Agent SDK's built-in `high`; an explicit choice (including `high`) is honored unchanged, and the Settings picker now labels the inherit and `xhigh` options as the uzi default.
 
+- **The retrospective judge lane now inherits the run owner's reasoning-effort setting ([#1162](https://github.com/vtmocanu/uzi/issues/1162)).**
+  A judge run over your finished runs now dispatches at your chosen reasoning-effort level (uzi default `xhigh` when you haven't chosen one), instead of falling through to the Claude Agent SDK's own built-in default of `high`; the `judge_model` setting is unchanged.
+
 - **The Findings surface in the web UI now uses a bug glyph instead of the warning triangle ([#1139](https://github.com/vtmocanu/uzi/issues/1139)).**
   The sidebar nav item, page header, empty state, and run-view finding card for Findings ("off-task bugs your workers flagged mid-run") switch from the AlertIcon warning triangle to a new BugIcon, keeping the sky/info tint; AlertIcon stays the genuine-warning glyph everywhere else (e.g. the missing-sweep-labels notice).
 

--- a/agent/src/claude-advice-harness.ts
+++ b/agent/src/claude-advice-harness.ts
@@ -69,6 +69,7 @@ export class ClaudeAdviceHarness implements AdviceHarness {
       spawnClaudeCodeProcess: (spawnOpts) => spawnDetached(spawnOpts) as unknown as SpawnedProcess,
     };
     if (request.model) options.model = request.model;
+    if (request.effort) options.effort = request.effort;
 
     let text = "";
     let terminalMsg: unknown;

--- a/agent/src/harness.ts
+++ b/agent/src/harness.ts
@@ -318,6 +318,8 @@ export interface AdviceRequest {
   systemPrompt: string;
   prompt: string;
   model?: string;
+  /** Reasoning effort; applied to the SDK query only when set. */
+  effort?: HarnessEffort;
   output: { kind: "text" } | { kind: "json"; schema: JsonObject };
   signal: AbortSignal;
   timeoutMs: number;

--- a/agent/src/judge-runner.ts
+++ b/agent/src/judge-runner.ts
@@ -10,6 +10,8 @@
 
 import os from "node:os";
 
+import type { EffortLevel } from "@anthropic-ai/claude-agent-sdk";
+
 import type { WorkerClient } from "./client.js";
 import type { Logger } from "./log.js";
 import { fenceNonce } from "./prompt.js";
@@ -244,7 +246,7 @@ export class JudgeRunner {
         claim.known_improve_uzi_targets ?? [],
         claim.failure_class ?? null,
       );
-      const { text, result } = await this.runModel(token, model, prompt);
+      const { text, result } = await this.runModel(token, model, prompt, claim.config?.default_effort);
       return { review: calibrateReview(parseReview(text, model), claim.failure_class ?? null), usageMessage: result };
     } catch (err) {
       this.log.warn("judge model call failed; using deterministic fallback", {
@@ -259,7 +261,7 @@ export class JudgeRunner {
     }
   }
 
-  private async runModel(token: string, model: string, prompt: string): Promise<{ text: string; result?: EmittedMessage }> {
+  private async runModel(token: string, model: string, prompt: string, effort?: EffortLevel): Promise<{ text: string; result?: EmittedMessage }> {
     // The terminal success frame mapped to a run message (PRD #69 M6): mapSdkMessage
     // routes a result frame through mapResult, which carries event:"result" + modelUsage
     // — the only fields the API's foldRunUsage reads. Surfaced to execute() to post so a
@@ -269,6 +271,7 @@ export class JudgeRunner {
     const text = await runReadOnlyModelPass({
       token,
       model,
+      effort,
       systemPrompt: JUDGE_SYSTEM_PROMPT,
       prompt,
       homeRoot: this.homeRoot,

--- a/agent/src/model-pass.ts
+++ b/agent/src/model-pass.ts
@@ -17,6 +17,8 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
+import type { EffortLevel } from "@anthropic-ai/claude-agent-sdk";
+
 import { ClaudeAdviceHarness } from "./claude-advice-harness.js";
 import { uidSplitActive } from "./runner-uid.js";
 import { rmTreeForce } from "./rmtree.js";
@@ -35,6 +37,8 @@ export interface ReadOnlyModelPassOpts {
   token: string;
   /** The model id; applied to the query only when non-empty. */
   model?: string;
+  /** Reasoning effort; applied to the query only when set. */
+  effort?: EffortLevel;
   systemPrompt: string;
   prompt: string;
   /** Root under which the per-pass ephemeral SDK HOME is created. */
@@ -135,6 +139,7 @@ export async function runReadOnlyModelPass(opts: ReadOnlyModelPassOpts): Promise
     systemPrompt: opts.systemPrompt,
     prompt: opts.prompt,
     model: opts.model,
+    effort: opts.effort,
     output: { kind: "text" },
     signal: abort.signal,
     timeoutMs: opts.timeoutMs,

--- a/agent/test/judge-runner.test.ts
+++ b/agent/test/judge-runner.test.ts
@@ -8,6 +8,7 @@ import { stubJudgeQueryFn } from "../src/judge-runner-stub.js";
 import type { SdkQueryFn } from "../src/sdk-executor.js";
 import type { WorkerClient } from "../src/client.js";
 import type {
+  ClaimConfig,
   ClaimResponse,
   JudgeTraceResponse,
   OutgoingMessage,
@@ -893,5 +894,29 @@ describe("judge tool confinement (PRD #89 M-allow / auditor Medium)", () => {
     for (const t of DAEMON_REACHING) {
       assert.equal(await preToolUseDecision(options!, t), "deny", `${t} must be denied for the judge`);
     }
+  });
+
+  it("threads the claim's default_effort onto the judge SDK options", async () => {
+    const { client } = fakeClient(emptyTrace);
+    const { queryFn, captured } = capturingQueryFn(
+      JSON.stringify({ verdict: "ok", summary: "", recommendations: [] }),
+    );
+    const runner = new JudgeRunner(client, nullLogger(), { queryFn });
+    await runner.execute(judgeClaim({ config: { default_effort: "high" } as ClaimConfig }));
+
+    assert.ok(captured.options, "the judge must have called the model (so options were captured)");
+    assert.equal(captured.options!.effort, "high", "the owner's default_effort is applied to the judge query");
+  });
+
+  it("sets no effort on the judge SDK options when the claim carries no config", async () => {
+    const { client } = fakeClient(emptyTrace);
+    const { queryFn, captured } = capturingQueryFn(
+      JSON.stringify({ verdict: "ok", summary: "", recommendations: [] }),
+    );
+    const runner = new JudgeRunner(client, nullLogger(), { queryFn });
+    await runner.execute(judgeClaim());
+
+    assert.ok(captured.options, "the judge must have called the model (so options were captured)");
+    assert.ok(!("effort" in captured.options!), "no effort is set when the claim carries no default_effort");
   });
 });

--- a/agent/test/model-pass.test.ts
+++ b/agent/test/model-pass.test.ts
@@ -90,6 +90,16 @@ describe("runReadOnlyModelPass — isolation-shape characterization pin", () => 
     await runReadOnlyModelPass(baseOpts({ queryFn: noModel.queryFn, model: "" }));
     assert.ok(!("model" in noModel.seen.options!), "an empty model is not set on the options");
   });
+
+  it("sets options.effort only when an effort is passed", async () => {
+    const withEffort = capturingQueryFn([successResult()]);
+    await runReadOnlyModelPass(baseOpts({ queryFn: withEffort.queryFn, effort: "xhigh" }));
+    assert.equal(withEffort.seen.options!.effort, "xhigh");
+
+    const noEffort = capturingQueryFn([successResult()]);
+    await runReadOnlyModelPass(baseOpts({ queryFn: noEffort.queryFn }));
+    assert.ok(!("effort" in noEffort.seen.options!), "no effort is set on the options when none is passed");
+  });
 });
 
 describe("runReadOnlyModelPass — onResult contract (differential pin)", () => {

--- a/api/internal/uzidocs/embed/judge.md
+++ b/api/internal/uzidocs/embed/judge.md
@@ -84,6 +84,12 @@ instance is set to. Your admin can also pin a cheaper instance-wide default (`ha
 works, but your own override only changes your runs, while the admin's is
 the fallback for everyone who hasn't set one.
 
+The judge's reasoning effort follows your own [reasoning effort](./worker-effort.md)
+setting (uzi default `xhigh` when you haven't chosen a level) — previously the
+judge call fell through to the Claude Agent SDK's own built-in default of
+`high` instead. The `judge_model` picker above is unaffected; this only
+changes how hard the judge model reasons.
+
 Opus runs roughly **5–15× the cost of haiku** per retrospective. If your
 Anthropic token is a **subscription plan** rather than a metered console key,
 an opus judge spends **plan/rate-limit quota, not dollars** — under enforced

--- a/api/internal/uzidocs/embed/worker-effort.md
+++ b/api/internal/uzidocs/embed/worker-effort.md
@@ -43,6 +43,10 @@ unset.)
   model](./worker-model.md) — see that page. There is no per-schedule
   effort override and no CLI setter; the Settings control below is the
   only place to change it.
+- **Also governs the [judge](./judge.md) lane.** The retrospective judge run
+  over your finished runs now uses this same setting (uzi default `xhigh`
+  when you haven't chosen a level), instead of the Claude Agent SDK's own
+  built-in default of `high`.
 
 ## Set your reasoning effort
 

--- a/api/internal/workersvc/claim.go
+++ b/api/internal/workersvc/claim.go
@@ -390,9 +390,12 @@ type ClaimConfig struct {
 	// thread: the owner's explicit per-user reasoning effort (PRD #617), or the uzi
 	// default `xhigh` (issue #1157) when the owner has not chosen (NULL). It is
 	// populated for every issue-lane claim assembled through resolveEffortPtr; the
-	// judge lane shares this struct but leaves it nil (omitted), so judge runs keep
-	// riding the SDK's own fallback. omitempty is retained. Unlike DefaultModel there
-	// is no per-run/per-schedule freeze; the owner's per-user value is the only source.
+	// judge lane (issue #1157) now ALSO populates it best-effort through the same
+	// resolveEffortPtr, inheriting the owner's per-user default_effort (uzi default
+	// `xhigh` when NULL) just like the run/chat lanes, so judge runs carry the owner's
+	// effort rather than riding the SDK's own fallback. omitempty is retained. Unlike
+	// DefaultModel there is no per-run/per-schedule freeze; the owner's per-user value
+	// is the only source.
 	DefaultEffort *string `json:"default_effort,omitempty"`
 	// AttributionEnabled is the run owner's AI-attribution opt-out (issue #916), read
 	// LIVE from the owner's users row on every claim. When false, the worker suppresses

--- a/api/internal/workersvc/judge.go
+++ b/api/internal/workersvc/judge.go
@@ -1190,6 +1190,17 @@ func (s *Service) assembleJudgeClaim(ctx context.Context, run store.Run) (*Claim
 		knownTargets = kt
 	}
 
+	// The owner's per-user default reasoning effort (issue #1157): resolve it to the level
+	// the judge SDK call uses — the owner's explicit choice, or the uzi default xhigh when
+	// NULL/blank. Best-effort to preserve the judge's no-spurious-fail design (audit H2): on a
+	// read error, log and fall back to xhigh (resolveEffortPtr on the zero pgtype.Text yields it),
+	// exactly as the judge-model read above falls back rather than failing the claim.
+	defaultEffort, err := s.q.GetUserDefaultEffort(ctx, run.UserID)
+	if err != nil {
+		slog.Warn("judge claim: read user default effort", "user", run.UserID.String(), "error", err)
+		// defaultEffort is the zero pgtype.Text (invalid) here → resolveEffortPtr → xhigh
+	}
+
 	return &ClaimPayload{
 		RunID:                  run.ID.String(),
 		Kind:                   run.Kind,
@@ -1222,6 +1233,7 @@ func (s *Service) assembleJudgeClaim(ctx context.Context, run store.Run) (*Claim
 			PlanMaxRevisions:       s.p.PlanMaxRevisions,
 			QuestionMax:            s.p.QuestionMax,
 			QuestionTimeoutSeconds: s.p.QuestionTimeoutSeconds,
+			DefaultEffort:          resolveEffortPtr(defaultEffort),
 			ToolPackages:           []string{},
 			DeniedToolPackages:     toolprofile.DenylistNames(),
 		},

--- a/api/internal/workersvc/judge_m2_test.go
+++ b/api/internal/workersvc/judge_m2_test.go
@@ -2,12 +2,15 @@ package workersvc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/vtmocanu/uzi/api/internal/pgconv"
 	"github.com/vtmocanu/uzi/api/internal/store"
 )
 
@@ -109,5 +112,90 @@ func TestJudgeClaimUserModelReadErrorFallsBackToInstance(t *testing.T) {
 	}
 	if payload.JudgeModel == nil || *payload.JudgeModel != "haiku" {
 		t.Errorf("JudgeModel = %v, want the instance fallback haiku (never an empty model)", payload.JudgeModel)
+	}
+}
+
+// issue #1157: the judge lane now carries the run owner's per-user default reasoning
+// effort on the assembled claim, inheriting the uzi default `xhigh` when the owner has
+// not chosen (NULL), mirroring the run/chat lanes. It is best-effort: a read error must
+// NOT fail the judge claim (audit H2's no-spurious-fail posture).
+
+// TestJudgeClaimNullDefaultEffortUsesUziDefault: a NULL per-user default_effort resolves
+// to the uzi default xhigh on the claim, and serializes as default_effort:"xhigh".
+func TestJudgeClaimNullDefaultEffortUsesUziDefault(t *testing.T) {
+	box := newBox(t)
+	sealedTok, _ := box.Seal([]byte("anthropic-judge-token-abcdef1234567890"))
+	uid, target := uuid.New(), uuid.New()
+	fs := &fakeStore{
+		claimRun:  judgeRun(uid, target),
+		anthropic: sealedTok,
+		// defaultEffort left zero (NULL) ⇒ the uzi default xhigh.
+	}
+	svc := New(fs, box, testParams())
+	svc.SetSettings(fakeSettings{enabled: true, model: "haiku"})
+
+	payload, err := svc.Claim(context.Background(), store.Worker{ID: uuid.New(), UserID: uid})
+	if err != nil || payload == nil {
+		t.Fatalf("Claim: payload=%v err=%v", payload, err)
+	}
+	if payload.Config.DefaultEffort == nil || *payload.Config.DefaultEffort != "xhigh" {
+		t.Errorf("Config.DefaultEffort = %v, want the uzi default xhigh", payload.Config.DefaultEffort)
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal(payload): %v", err)
+	}
+	if !strings.Contains(string(b), `"default_effort":"xhigh"`) {
+		t.Errorf("marshaled claim missing default_effort:xhigh: %s", b)
+	}
+}
+
+// TestJudgeClaimExplicitDefaultEffortIsCarried: a set per-user default_effort is carried
+// through onto the judge claim verbatim.
+func TestJudgeClaimExplicitDefaultEffortIsCarried(t *testing.T) {
+	box := newBox(t)
+	sealedTok, _ := box.Seal([]byte("anthropic-judge-token-abcdef1234567890"))
+	uid, target := uuid.New(), uuid.New()
+	fs := &fakeStore{
+		claimRun:      judgeRun(uid, target),
+		anthropic:     sealedTok,
+		defaultEffort: pgconv.TextOrNull("high"),
+	}
+	svc := New(fs, box, testParams())
+	svc.SetSettings(fakeSettings{enabled: true, model: "haiku"})
+
+	payload, err := svc.Claim(context.Background(), store.Worker{ID: uuid.New(), UserID: uid})
+	if err != nil || payload == nil {
+		t.Fatalf("Claim: payload=%v err=%v", payload, err)
+	}
+	if payload.Config.DefaultEffort == nil || *payload.Config.DefaultEffort != "high" {
+		t.Errorf("Config.DefaultEffort = %v, want the owner's explicit high", payload.Config.DefaultEffort)
+	}
+}
+
+// TestJudgeClaimDefaultEffortReadErrorFallsBackToXhigh: a user-row read error must NOT
+// fail the judge claim and falls back to the uzi default xhigh best-effort, mirroring
+// TestJudgeClaimUserModelReadErrorFallsBackToInstance.
+func TestJudgeClaimDefaultEffortReadErrorFallsBackToXhigh(t *testing.T) {
+	box := newBox(t)
+	sealedTok, _ := box.Seal([]byte("anthropic-judge-token-abcdef1234567890"))
+	uid, target := uuid.New(), uuid.New()
+	fs := &fakeStore{
+		claimRun:         judgeRun(uid, target),
+		anthropic:        sealedTok,
+		defaultEffortErr: errors.New("db down"),
+	}
+	svc := New(fs, box, testParams())
+	svc.SetSettings(fakeSettings{enabled: true, model: "haiku"})
+
+	payload, err := svc.Claim(context.Background(), store.Worker{ID: uuid.New(), UserID: uid})
+	if err != nil {
+		t.Fatalf("Claim must not fail on a user default-effort read error: %v", err)
+	}
+	if payload == nil {
+		t.Fatal("expected a claim payload despite the user default-effort read error")
+	}
+	if payload.Config.DefaultEffort == nil || *payload.Config.DefaultEffort != "xhigh" {
+		t.Errorf("Config.DefaultEffort = %v, want the uzi default xhigh fallback", payload.Config.DefaultEffort)
 	}
 }

--- a/docs/judge.md
+++ b/docs/judge.md
@@ -84,6 +84,12 @@ instance is set to. Your admin can also pin a cheaper instance-wide default (`ha
 works, but your own override only changes your runs, while the admin's is
 the fallback for everyone who hasn't set one.
 
+The judge's reasoning effort follows your own [reasoning effort](./worker-effort.md)
+setting (uzi default `xhigh` when you haven't chosen a level) — previously the
+judge call fell through to the Claude Agent SDK's own built-in default of
+`high` instead. The `judge_model` picker above is unaffected; this only
+changes how hard the judge model reasons.
+
 Opus runs roughly **5–15× the cost of haiku** per retrospective. If your
 Anthropic token is a **subscription plan** rather than a metered console key,
 an opus judge spends **plan/rate-limit quota, not dollars** — under enforced

--- a/docs/worker-effort.md
+++ b/docs/worker-effort.md
@@ -43,6 +43,10 @@ unset.)
   model](./worker-model.md) — see that page. There is no per-schedule
   effort override and no CLI setter; the Settings control below is the
   only place to change it.
+- **Also governs the [judge](./judge.md) lane.** The retrospective judge run
+  over your finished runs now uses this same setting (uzi default `xhigh`
+  when you haven't chosen a level), instead of the Claude Agent SDK's own
+  built-in default of `high`.
 
 ## Set your reasoning effort
 


### PR DESCRIPTION
Implements issue #1162.

Closes #1162

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1162`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retrospective judge runs now follow the run owner’s configured reasoning-effort level.
  - When no level is configured, judge runs use uzi’s `xhigh` default.
  - Judge model selection remains unchanged.

- **Documentation**
  - Updated judge and worker-effort documentation to explain the reasoning-effort behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->