### PR TITLE
fix(e2e): stop the autofix poller racing the manual ci-fix in agent-mr-fix-crosskind

### DIFF
--- a/e2e/phases/32-agent-mr-fix-crosskind.sh
+++ b/e2e/phases/32-agent-mr-fix-crosskind.sh
@@ -7,14 +7,29 @@
 # requires: env:E2E_FORGE_POLL_INTERVAL=2s
 # provides: -
 # handoff:  -
-# mutates:  -
-# restores: -
+# mutates:  admin setting ci_autofix_enabled -> false (this phase drives the MANUAL
+#           ci-fix path, so the autofix poller must not race it — see the note below)
+# restores: admin setting ci_autofix_enabled -> true (the shipped default)
 # 6) Agent-MR fix + cross-kind race. An issue run leaves an open MR on
 #    agent/issue-N; a red pipeline on that MR gets a ci_fix run whose commits land
 #    on the SAME branch (the existing MR updates, no second MR) and whose
 #    verification stamps on it. While that ci_fix is active, an issue run on the
 #    same issue is refused (they would share the worktree).
 say "PRD #6: agent-MR same-branch fix + cross-kind race"
+
+# This phase drives the MANUAL ci-fix path (POST /ci-fix-runs below) plus the
+# cross-kind race, and needs to be the ONLY creator of a ci_fix on the agent branch.
+# Since #1109 the admin setting ci_autofix_enabled defaults ON, so the CIAutoFix
+# poller auto-opens a ci_fix on any agent/issue-N branch carrying a red pipeline --
+# exactly the red pipeline this phase posts below. That auto-run races the phase's
+# own manual POST and one loses with a 409 (one ci_fix per ref), flaking the phase
+# intermittently (the "no fail message; last output: curl 409" nightly failures,
+# issue #1155). Disable the poller for the duration; the trap restores it even if an
+# assertion below fails and exits this phase's subshell early. Other ci-fix phases
+# post on ref=main, which the agent/issue-N-only detector ignores, so only this one
+# needs it.
+apiput /api/admin/settings '{"settings":{"ci_autofix_enabled":"false"}}' >/dev/null
+trap 'apiput /api/admin/settings '\''{"settings":{"ci_autofix_enabled":"true"}}'\'' >/dev/null 2>&1 || true' EXIT
 
 AIID="$(apipost "/api/repos/$REPO_ID/issues" \
   '{"title":"E2E agent-MR fix","description":"implements prds/6-ci-status-integration.md"}' | jq -r '.card.iid')"
@@ -56,4 +71,8 @@ pass "agent-branch ci_fix landed on $AGENTBRANCH, reused MR !$AMR, opened no sec
 fake_post "/_e2e/pipelines" "{\"ref\":\"$AGENTBRANCH\",\"status\":\"success\"}" >/dev/null
 wait_verdict "$AFIX" verified 20
 pass "agent-branch fix pipeline passed -> run $AFIX stamped verified"
+
+# Restore the poller and drop the fail-safe trap now that the explicit restore ran.
+apiput /api/admin/settings '{"settings":{"ci_autofix_enabled":"true"}}' >/dev/null
+trap - EXIT
 


### PR DESCRIPTION
## What

Fixes the intermittent nightly compose-E2E failure in the `agent-mr-fix-crosskind` phase (**#1155**), which showed up as a phase FAIL with **"no fail message; last output: `curl: (22) The requested URL returned error: 409`"** and every labelled assertion still `PASS`.

## Root cause (verified)

- Phase 32 drives the **manual** ci-fix path: it posts a red pipeline on `agent/issue-N`, then `POST /ci-fix-runs` on that same ref, then tests the cross-kind race.
- **#1109** made `ci_autofix_enabled` default **ON**. The `CIAutoFix` detector matches `agent/issue-N` refs (`api/internal/poller/ci_autofix.go`), so it now auto-opens a `ci_fix` on the very red pipeline the phase posts.
- That auto-run races the phase's own manual `POST /ci-fix-runs`, and one loses with a **409** (one ci_fix per ref, intended dedup).
- `apipost` uses `curl -fsS` (exit 22 on 409) and the harness runs under `set -euo pipefail`, so the stray 409 aborts the phase. Intermittent because it depends on poller-vs-POST timing.

**No product bug** — the 409-on-duplicate and the autofix-on-a-red-agent-branch are both correct shipped behaviour. This is test-harness determinism only.

## Fix

Disable `ci_autofix` for the duration of this phase (it exercises the *manual* ci-fix path; the poller is orthogonal interference), restored via a fail-safe `trap`, mirroring how phases 35/71 gate `judge`/`mr_rework`. No E2E phase tests the autofix poller, so nothing is lost. The other ci-fix phases (31/05/06) post on `ref=main`, which the `agent/issue-N`-only detector ignores, so only this phase needs it.

## Validation

- `shellcheck -x` clean (0.11.0).
- E2E is nightly (not a PR/tag gate), so CI here does not exercise it; final proof is the next nightly compose-E2E going green. A single local run is not a reliable validator for a race (the phase passes most of the time even unfixed).

Fixes #1155