### PR TITLE
Make Codex credential import and status badges self-explanatory

### DIFF
--- a/api/internal/uzidocs/embed/codex-credentials.md
+++ b/api/internal/uzidocs/embed/codex-credentials.md
@@ -1,0 +1,118 @@
+---
+title: Codex credentials
+order: 41
+audience: user
+---
+
+# Codex credentials
+
+**Settings → OpenAI / Codex credentials** lets you import an existing
+**Codex CLI / ChatGPT-subscription login** into uzi. It is not an OpenAI
+API key — that has its own field on the same card.
+
+**Codex credentials do not yet start runs.** Saving one is dark: uzi stores
+and seals it, but no run, worker, or judge can spend it. You still need an
+[Anthropic token](./anthropic-token.md) for anything to actually run.
+This page exists so that when Codex execution lands, your login is already
+on file.
+
+## What the field accepts
+
+The **Codex login** field wants a flat JSON object, not a raw token:
+
+```json
+{ "access_token": "...", "refresh_token": "..." }
+```
+
+- **`access_token`** is the only thing required to save the credential.
+- **`refresh_token`** isn't checked at save time, but uzi needs it later to
+  renew the login once it expires — paste both together now rather than
+  going back for the refresh token afterwards.
+
+Do not paste a bare token string, and do not paste an OpenAI API key here —
+use the **OpenAI API key** field beside it for that.
+
+## 1. Sign in with the Codex CLI
+
+```sh
+codex login
+```
+
+Confirm it took:
+
+```sh
+codex login status
+```
+
+## 2. Get the value safely
+
+The Codex CLI's own credential file, `~/.codex/auth.json`, is **nested** —
+your tokens live under a `tokens` object alongside other fields:
+
+```json
+{
+  "OPENAI_API_KEY": null,
+  "auth_mode": "chatgpt",
+  "tokens": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "account_id": "...",
+    "id_token": "..."
+  }
+}
+```
+
+uzi wants the **flat** shape above, not the whole file — pasting the whole
+file fails with "codex login must contain a non-empty access_token",
+because the top level has no `access_token` of its own.
+
+Use `jq` to project just the two fields you need straight to your
+clipboard, so the secret never appears in your visible terminal output:
+
+**macOS**
+
+```sh
+jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | pbcopy
+```
+
+**Linux (X11)**
+
+```sh
+jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | xclip -selection clipboard
+```
+
+**Linux (Wayland)**
+
+```sh
+jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | wl-copy
+```
+
+Paste the clipboard contents straight into the **Codex login** field.
+
+### If `~/.codex/auth.json` is missing
+
+If `~/.codex/auth.json` does not exist after `codex login`, your Codex CLI
+is configured to store credentials elsewhere; check its docs for
+file-backed storage.
+
+## Keep it secret
+
+The value you paste is a renewable credential, not a one-time code — treat
+it like a password. Don't commit it, log it, paste it into an issue, or
+share it in chat.
+
+uzi seals it at rest the moment you save and never shows it again in the
+UI, an API response, or a log — not even to you. If you need to change it,
+use **Replace value** to paste a new one; there is nothing to reveal or
+edit in place.
+
+## Status legend
+
+Each stored Codex credential shows one of four statuses:
+
+| Status | Meaning |
+|---|---|
+| `staging` | Saved and encrypted; the provider identity has not been verified yet. This build has no automatic verification — a `staging` credential can stay `staging` indefinitely. |
+| `linked` | The provider identity has been verified. |
+| `failed` | Verification failed. Replace the value, or re-add the login. |
+| `static` | An OpenAI API key, not a Codex login — provider-account linking doesn't apply to a key. |

--- a/docs/codex-credentials.md
+++ b/docs/codex-credentials.md
@@ -1,0 +1,118 @@
+---
+title: Codex credentials
+order: 41
+audience: user
+---
+
+# Codex credentials
+
+**Settings → OpenAI / Codex credentials** lets you import an existing
+**Codex CLI / ChatGPT-subscription login** into uzi. It is not an OpenAI
+API key — that has its own field on the same card.
+
+**Codex credentials do not yet start runs.** Saving one is dark: uzi stores
+and seals it, but no run, worker, or judge can spend it. You still need an
+[Anthropic token](./anthropic-token.md) for anything to actually run.
+This page exists so that when Codex execution lands, your login is already
+on file.
+
+## What the field accepts
+
+The **Codex login** field wants a flat JSON object, not a raw token:
+
+```json
+{ "access_token": "...", "refresh_token": "..." }
+```
+
+- **`access_token`** is the only thing required to save the credential.
+- **`refresh_token`** isn't checked at save time, but uzi needs it later to
+  renew the login once it expires — paste both together now rather than
+  going back for the refresh token afterwards.
+
+Do not paste a bare token string, and do not paste an OpenAI API key here —
+use the **OpenAI API key** field beside it for that.
+
+## 1. Sign in with the Codex CLI
+
+```sh
+codex login
+```
+
+Confirm it took:
+
+```sh
+codex login status
+```
+
+## 2. Get the value safely
+
+The Codex CLI's own credential file, `~/.codex/auth.json`, is **nested** —
+your tokens live under a `tokens` object alongside other fields:
+
+```json
+{
+  "OPENAI_API_KEY": null,
+  "auth_mode": "chatgpt",
+  "tokens": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "account_id": "...",
+    "id_token": "..."
+  }
+}
+```
+
+uzi wants the **flat** shape above, not the whole file — pasting the whole
+file fails with "codex login must contain a non-empty access_token",
+because the top level has no `access_token` of its own.
+
+Use `jq` to project just the two fields you need straight to your
+clipboard, so the secret never appears in your visible terminal output:
+
+**macOS**
+
+```sh
+jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | pbcopy
+```
+
+**Linux (X11)**
+
+```sh
+jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | xclip -selection clipboard
+```
+
+**Linux (Wayland)**
+
+```sh
+jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | wl-copy
+```
+
+Paste the clipboard contents straight into the **Codex login** field.
+
+### If `~/.codex/auth.json` is missing
+
+If `~/.codex/auth.json` does not exist after `codex login`, your Codex CLI
+is configured to store credentials elsewhere; check its docs for
+file-backed storage.
+
+## Keep it secret
+
+The value you paste is a renewable credential, not a one-time code — treat
+it like a password. Don't commit it, log it, paste it into an issue, or
+share it in chat.
+
+uzi seals it at rest the moment you save and never shows it again in the
+UI, an API response, or a log — not even to you. If you need to change it,
+use **Replace value** to paste a new one; there is nothing to reveal or
+edit in place.
+
+## Status legend
+
+Each stored Codex credential shows one of four statuses:
+
+| Status | Meaning |
+|---|---|
+| `staging` | Saved and encrypted; the provider identity has not been verified yet. This build has no automatic verification — a `staging` credential can stay `staging` indefinitely. |
+| `linked` | The provider identity has been verified. |
+| `failed` | Verification failed. Replace the value, or re-add the login. |
+| `static` | An OpenAI API key, not a Codex login — provider-account linking doesn't apply to a key. |

--- a/web/src/components/CodexCredentials.test.tsx
+++ b/web/src/components/CodexCredentials.test.tsx
@@ -6,8 +6,16 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { CodexCredentials } from "./CodexCredentials";
+import { CodexCredentials, codexShapeError } from "./CodexCredentials";
+// Imported from the single "dark" flag so these tests PROVE the copy comes from
+// there, not from an inlined duplicate (issue #1174 item 6).
+import { CODEX_DARK_COPY } from "./codexCredentialsCopy";
 import { api, type SecretMeta } from "../lib/api";
+
+// A valid codex_auth JSON paste — a flat object with access_token/refresh_token.
+// Dummy values only; never a real token. Used wherever a codex create/rotate must
+// actually reach the API (the wrong-shape pre-check would otherwise block it).
+const VALID_CODEX_JSON = '{"access_token":"dummy-access","refresh_token":"dummy-refresh"}';
 
 vi.mock("../lib/api", async (importActual) => {
   const actual = await importActual<typeof import("../lib/api")>();
@@ -43,7 +51,11 @@ function secret(over: Partial<SecretMeta> = {}): SecretMeta {
 
 const noop = async () => {};
 
-function renderCard(secrets: SecretMeta[], reload = noop) {
+function renderCard(
+  secrets: SecretMeta[],
+  reload = noop,
+  handlers: { onNotice?: (m: string) => void; onError?: (m: string) => void } = {},
+) {
   return render(
     <MemoryRouter>
       <CodexCredentials
@@ -51,8 +63,8 @@ function renderCard(secrets: SecretMeta[], reload = noop) {
         loading={false}
         busy={false}
         reload={reload}
-        onError={() => {}}
-        onNotice={() => {}}
+        onError={handlers.onError ?? (() => {})}
+        onNotice={handlers.onNotice ?? (() => {})}
       />
     </MemoryRouter>,
   );
@@ -103,15 +115,15 @@ describe("CodexCredentials", () => {
   it("creates a Codex login → calls createCodexAuth", async () => {
     mockApi.createCodexAuth.mockResolvedValue({ secret: secret() });
     renderCard([secret()]);
-    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login token"), {
-      target: { value: "codex-login-value" },
+    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login JSON"), {
+      target: { value: VALID_CODEX_JSON },
     });
     fireEvent.change(screen.getByLabelText("Codex login name"), {
       target: { value: "my-codex" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add Codex login" }));
     await waitFor(() =>
-      expect(mockApi.createCodexAuth).toHaveBeenCalledWith("codex-login-value", "my-codex", false),
+      expect(mockApi.createCodexAuth).toHaveBeenCalledWith(VALID_CODEX_JSON, "my-codex", false),
     );
   });
 
@@ -135,12 +147,12 @@ describe("CodexCredentials", () => {
     renderCard([]);
     // First mode: the Name fields collapse.
     expect(screen.queryByLabelText("Codex login name")).toBeNull();
-    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login token"), {
-      target: { value: "codex-first" },
+    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login JSON"), {
+      target: { value: VALID_CODEX_JSON },
     });
     fireEvent.click(screen.getByRole("button", { name: "Save Codex login" }));
     await waitFor(() =>
-      expect(mockApi.createCodexAuth).toHaveBeenCalledWith("codex-first", "default", false),
+      expect(mockApi.createCodexAuth).toHaveBeenCalledWith(VALID_CODEX_JSON, "default", false),
     );
   });
 
@@ -223,5 +235,180 @@ describe("CodexCredentials", () => {
       expect((el as HTMLInputElement).value).toBe("");
     });
     expect(container.textContent).not.toMatch(/sk-|ciphertext|sealed/i);
+  });
+
+  // ── issue #1174: inline help, the status legend, and the wrong-shape pre-check ──
+
+  it("shows inline help beside the codex field and a 'How to get this' disclosure", () => {
+    renderCard([secret()]);
+    // The codex field exists with the JSON placeholder.
+    expect(screen.getByPlaceholderText("Paste your Codex login JSON")).toBeTruthy();
+    // The help line explains it imports a login (JSON) and is NOT an OpenAI API key
+    // (the "not" is a <strong>, so read the paragraph's whole textContent).
+    const help = screen.getByText((c) => c.includes("imports an existing Codex CLI"));
+    expect(help.textContent).toMatch(/not/i);
+    expect(help.textContent).toMatch(/OpenAI\s+API\s+key/i);
+    expect(help.textContent).toMatch(/access_token/);
+    // The "How to get this" disclosure is a native <summary> (keyboard/touch/SR).
+    const summary = screen.getByText("How to get this", { selector: "summary" });
+    expect(summary.tagName).toBe("SUMMARY");
+    // The copy recipe names the login-status prereq and the do-not-share warning.
+    const details = summary.closest("details")!;
+    expect(within(details).getByText(/codex login status/)).toBeTruthy();
+    expect(within(details).getByText(/do not commit it, log it/i)).toBeTruthy();
+  });
+
+  it("renders a keyboard-reachable status legend explaining all four statuses, and keeps per-badge sr-only scaffolding", () => {
+    renderCard([secret()]);
+    const summary = screen.getByText("What do these statuses mean?");
+    expect(summary.tagName).toBe("SUMMARY");
+    const legend = summary.closest("details")!;
+    // All four status meanings are enumerated.
+    for (const status of ["staging", "linked", "failed", "static"]) {
+      expect(within(legend).getByText(status)).toBeTruthy();
+    }
+    expect(within(legend).getByText(/has not been verified/i)).toBeTruthy();
+    expect(within(legend).getByText(/No\s+provider\s+or\s+secret\s+details/i)).toBeTruthy();
+    // The closing dark note comes from the flag.
+    expect(
+      within(legend).getByText((c) => c.includes(CODEX_DARK_COPY.notUsedForRuns)),
+    ).toBeTruthy();
+    // The per-badge sr-only description + aria-describedby scaffolding is retained.
+    const badge = within(screen.getByTestId("codex-sec-1")).getByText("staging");
+    expect(badge.getAttribute("aria-describedby")).toBe("codex-status-sec-1");
+    const srOnly = document.getElementById("codex-status-sec-1");
+    expect(srOnly?.className).toContain("sr-only");
+    expect(srOnly?.textContent).toContain(CODEX_DARK_COPY.stagingNotAutoVerified);
+  });
+
+  it("renders all four status badges straight from codex_status", () => {
+    renderCard([
+      secret({ id: "sec-1", codex_status: "staging" }),
+      secret({ id: "sec-2", label: "l", is_default: false, codex_status: "linked" }),
+      secret({ id: "sec-3", label: "f", is_default: false, codex_status: "failed" }),
+      secret({
+        id: "sec-4",
+        kind: "openai_api_key",
+        label: "s",
+        is_default: false,
+        codex_status: "static",
+      }),
+    ]);
+    expect(within(screen.getByTestId("codex-sec-1")).getByText("staging")).toBeTruthy();
+    expect(within(screen.getByTestId("codex-sec-2")).getByText("linked")).toBeTruthy();
+    expect(within(screen.getByTestId("codex-sec-3")).getByText("failed")).toBeTruthy();
+    expect(within(screen.getByTestId("codex-sec-4")).getByText("static")).toBeTruthy();
+  });
+
+  // The wrong-shape pre-check: each bad paste shows its OWN message, sends NOTHING,
+  // and surfaces a help link. Driven in first mode so the Save button needs no Name.
+  it("blocks a raw-token paste with a raw-token message and does not call createCodexAuth", () => {
+    renderCard([]);
+    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login JSON"), {
+      target: { value: "sk-not-json-raw-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Codex login" }));
+    expect(screen.getByText(/not a raw token/i)).toBeTruthy();
+    expect(mockApi.createCodexAuth).not.toHaveBeenCalled();
+    expect(
+      screen.getAllByRole("link", { name: /how to get this/i }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("blocks the whole ~/.codex/auth.json paste with the flat-object message and sends nothing", () => {
+    renderCard([]);
+    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login JSON"), {
+      target: {
+        value: '{"tokens":{"access_token":"a","refresh_token":"b"},"OPENAI_API_KEY":null}',
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Codex login" }));
+    expect(screen.getByText(/looks like the whole/i)).toBeTruthy();
+    expect(mockApi.createCodexAuth).not.toHaveBeenCalled();
+  });
+
+  it("blocks a JSON object with no access_token and sends nothing", () => {
+    renderCard([]);
+    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login JSON"), {
+      target: { value: '{"refresh_token":"b"}' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Codex login" }));
+    expect(screen.getByText(/has no access_token/i)).toBeTruthy();
+    expect(mockApi.createCodexAuth).not.toHaveBeenCalled();
+  });
+
+  it("codexShapeError accepts a flat object and rejects the mistaken shapes (pure, secret-free)", () => {
+    // Valid: a flat object with a non-empty access_token → null (acceptable).
+    expect(codexShapeError('{"access_token":"a","refresh_token":"b"}')).toBeNull();
+    // The three rejected shapes each get their own message…
+    expect(codexShapeError("raw-token")).toMatch(/not a raw token/);
+    expect(codexShapeError('{"tokens":{"access_token":"a"}}')).toMatch(
+      /looks like the whole/,
+    );
+    expect(codexShapeError('{"foo":"bar"}')).toMatch(/has no access_token/);
+    // …and no message ever echoes the pasted value.
+    const secretish = "super-secret-value-1234";
+    expect(codexShapeError(secretish)).not.toContain(secretish);
+  });
+
+  it("blocks a wrong-shape codex_auth ROTATION inline and does not call patchCodexAuth", () => {
+    renderCard([
+      secret(),
+      secret({ id: "sec-2", label: "codex-2", is_default: false }),
+    ]);
+    // Target the codex_auth default for a value replacement.
+    fireEvent.change(screen.getByLabelText("Credential to replace"), {
+      target: { value: "sec-1" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Paste the replacement credential"), {
+      target: { value: "raw-token-not-json" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Replace value" }));
+    expect(screen.getByText(/not a raw token/i)).toBeTruthy();
+    expect(mockApi.patchCodexAuth).not.toHaveBeenCalled();
+  });
+
+  it("names the resulting status in the post-save notice — staging for a login", async () => {
+    mockApi.createCodexAuth.mockResolvedValue({ secret: secret() });
+    const onNotice = vi.fn();
+    renderCard([], noop, { onNotice });
+    fireEvent.change(screen.getByPlaceholderText("Paste your Codex login JSON"), {
+      target: { value: VALID_CODEX_JSON },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Codex login" }));
+    await waitFor(() =>
+      expect(onNotice).toHaveBeenCalledWith(
+        "Saved and encrypted. Status: staging (not verified). " +
+          CODEX_DARK_COPY.notUsedForRuns,
+      ),
+    );
+  });
+
+  it("names the resulting status in the post-save notice — static for an API key", async () => {
+    mockApi.createOpenAIApiKey.mockResolvedValue({ secret: secret() });
+    const onNotice = vi.fn();
+    renderCard([], noop, { onNotice });
+    fireEvent.change(screen.getByPlaceholderText("Paste your OpenAI API key"), {
+      target: { value: "sk-dummy-openai" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save OpenAI API key" }));
+    await waitFor(() =>
+      expect(onNotice).toHaveBeenCalledWith(
+        "Saved and encrypted. Status: static. " + CODEX_DARK_COPY.notUsedForRuns,
+      ),
+    );
+  });
+
+  it("routes the dark copy through the single flag (header/legend + staging hint)", () => {
+    renderCard([secret()]);
+    // The not-used-for-runs sentence appears (header + legend), sourced from the flag.
+    expect(
+      screen.getAllByText((c) => c.includes(CODEX_DARK_COPY.notUsedForRuns)).length,
+    ).toBeGreaterThan(0);
+    // The staging hint carries the staging flag sentence (sr-only description).
+    expect(
+      screen.getAllByText((c) => c.includes(CODEX_DARK_COPY.stagingNotAutoVerified))
+        .length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/web/src/components/CodexCredentials.test.tsx
+++ b/web/src/components/CodexCredentials.test.tsx
@@ -310,9 +310,13 @@ describe("CodexCredentials", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save Codex login" }));
     expect(screen.getByText(/not a raw token/i)).toBeTruthy();
     expect(mockApi.createCodexAuth).not.toHaveBeenCalled();
-    expect(
-      screen.getAllByRole("link", { name: /how to get this/i }).length,
-    ).toBeGreaterThan(0);
+    // The "How to get this" affordance is the disclosure <summary> (a single
+    // named control the message points at), not a link; the one docs link in the
+    // block is "Full guide".
+    expect(screen.getByText("How to get this", { selector: "summary" }).tagName).toBe(
+      "SUMMARY",
+    );
+    expect(screen.getByRole("link", { name: /full guide/i })).toBeTruthy();
   });
 
   it("blocks the whole ~/.codex/auth.json paste with the flat-object message and sends nothing", () => {

--- a/web/src/components/CodexCredentials.tsx
+++ b/web/src/components/CodexCredentials.tsx
@@ -465,15 +465,13 @@ function AddCredentialForm({
             (and{" "}
             <code className="rounded bg-raised px-1 py-0.5 text-fg">refresh_token</code>{" "}
             for renewal). It is <strong className="text-fg">not</strong> an OpenAI
-            API key.{" "}
-            <DocLink slug={DOC_CODEX_CREDENTIALS}>How to get this</DocLink>.
+            API key.
           </p>
           {shapeError && (
-            // The pre-check verdict, inline and value-free, pointing at both the
-            // guide and the disclosure just below.
+            // The pre-check verdict, inline and value-free. Its text ends with
+            // See "How to get this" below. — pointing at the disclosure just below.
             <p role="alert" className="text-danger">
-              {shapeError}{" "}
-              <DocLink slug={DOC_CODEX_CREDENTIALS}>How to get this</DocLink>.
+              {shapeError}
             </p>
           )}
           {/* Native <details>/<summary>: keyboard, touch and screen-reader reachable

--- a/web/src/components/CodexCredentials.tsx
+++ b/web/src/components/CodexCredentials.tsx
@@ -22,6 +22,11 @@ import { isVaultLocked } from "../lib/api";
 import { sanitizeLabel } from "../lib/sanitizeLabel";
 import { Badge, Button, Card, Field, Input, SectionTitle, Skeleton } from "./ui";
 import type { BadgeTone } from "./ui";
+import { DocLink } from "./DocLink";
+import { DOC_CODEX_CREDENTIALS } from "../lib/doclinks";
+// Every "dark" sentence on this card comes from ONE flag, so the milestone that
+// enables Codex routing flips it in a single place (issue #1174 item 6).
+import { CODEX_DARK_COPY } from "./codexCredentialsCopy";
 
 // vaultLockedMessage is the shared copy for a 409 vault_locked: the global handler
 // has already refreshed the session, so the unlock banner is showing above.
@@ -73,28 +78,67 @@ function statusBadge(
 ): { tone: BadgeTone; label: string; hint: string } | null {
   switch (status) {
     case "staging":
+      // The one place a `staging` login says WHY it is not yet linked: this build
+      // does not auto-verify (routed through the flag so retirement is one edit).
       return {
         tone: "info",
         label: "staging",
-        hint: "Saved; identity not yet verified. Codex is not used for runs yet.",
+        hint:
+          "Saved and encrypted; identity not yet verified. " +
+          CODEX_DARK_COPY.stagingNotAutoVerified,
       };
     case "linked":
       return { tone: "ok", label: "linked", hint: "Provider identity verified." };
     case "failed":
+      // Deliberately GENERIC — no provider or secret detail leaks into a diagnosis
+      // string that is rendered as a tooltip and read aloud by a screen reader.
       return {
         tone: "danger",
         label: "failed",
-        hint: "Could not verify; re-add the credential.",
+        hint: "Verification failed. Replace the value or re-add the login.",
       };
     case "static":
       return {
         tone: "neutral",
         label: "static",
-        hint: "Stored API key. Codex is not used for runs yet.",
+        hint: "API key stored; provider-account linking does not apply.",
       };
     default:
       return null;
   }
+}
+
+// codexShapeError is a PURE, IN-MEMORY pre-check for a codex_auth paste (issue
+// #1174 item 2 / AC 2). It exists to catch the two shapes a user actually pastes
+// by mistake — a raw token, and the WHOLE ~/.codex/auth.json file — and answer with
+// a specific, secret-free hint BEFORE any request leaves the browser. It returns a
+// message string, NEVER the pasted value, and logs/persists nothing; the server
+// validator stays the real backstop. Exported because the card and its test both
+// import it. NB: only a codex_auth value is JSON — an OpenAI API key is a raw
+// string, so the caller must NOT run this check on the openai_api_key path.
+export function codexShapeError(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "This field expects a JSON object with access_token and refresh_token, not a raw token. See “How to get this” below.";
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return "This field expects a JSON object with access_token and refresh_token. See “How to get this” below.";
+  }
+  const obj = parsed as Record<string, unknown>;
+  const top = obj.access_token;
+  if (typeof top === "string" && top.trim() !== "") return null;
+  const nested = obj.tokens;
+  if (
+    typeof nested === "object" &&
+    nested !== null &&
+    typeof (nested as Record<string, unknown>).access_token === "string" &&
+    ((nested as Record<string, unknown>).access_token as string).trim() !== ""
+  ) {
+    return "This looks like the whole ~/.codex/auth.json file. Uzi needs a flat object with just access_token and refresh_token — use the copy command in “How to get this”.";
+  }
+  return "This JSON has no access_token. See “How to get this” below.";
 }
 
 // codexDeleteWarning mirrors the Anthropic D5 delete confirmation, minus the
@@ -322,19 +366,41 @@ function AddCredentialForm({
   const [token, setToken] = useState("");
   const [label, setLabel] = useState("");
   const [addBusy, setAddBusy] = useState(false);
+  // The wrong-shape pre-check message (issue #1174 item 2 / AC 2) lives in LOCAL
+  // state and renders INLINE beneath this field, deliberately NOT on the shared
+  // onError banner: a paste-shape mistake is local to this field, and the shared
+  // banner is a surface where a value-adjacent message must never land. Cleared on
+  // every keystroke so a corrected paste is not shadowed by a stale message.
+  const [shapeError, setShapeError] = useState<string | null>(null);
+  // Only a Codex login is JSON; an OpenAI API key is a raw string. This gate decides
+  // both the inline help and whether the JSON shape check runs at all.
+  const isCodexLogin = kind === "codex_auth";
 
   // The Name field UNMOUNTS when the card collapses to first-credential mode, so a
   // label typed and never submitted would silently name the next credential through
-  // a field the user cannot see. Clearing both fields on the transition is the fix.
+  // a field the user cannot see. Clearing both fields on the transition is the fix;
+  // the shape message is cleared too so it cannot outlive the value that caused it.
   useEffect(() => {
     setToken("");
     setLabel("");
+    setShapeError(null);
   }, [first]);
 
   const add = async (e: FormEvent) => {
     e.preventDefault();
     onError("");
     onNotice("");
+    // Wrong-shape pre-check, for a codex_auth value ONLY. Runs in memory, echoes
+    // nothing, and on a bad shape shows the message inline and SENDS NOTHING — the
+    // server validator remains the backstop. An OpenAI API key skips this entirely.
+    if (isCodexLogin) {
+      const shape = codexShapeError(token);
+      if (shape !== null) {
+        setShapeError(shape);
+        return;
+      }
+    }
+    setShapeError(null);
     setAddBusy(true);
     try {
       // A user's FIRST codex credential is forced default server-side whatever we
@@ -343,8 +409,14 @@ function AddCredentialForm({
       await apiForKind(kind).create(token, first ? "default" : label.trim(), false);
       setToken("");
       setLabel("");
+      // Name the resulting lifecycle state (issue #1174 item 5): a login is born
+      // `staging` (not verified), a key is born `static`. The dark clause comes
+      // from the one flag so it retires everywhere at once.
       onNotice(
-        "Credential saved and sealed with your login password. Codex is not yet used for runs.",
+        isCodexLogin
+          ? "Saved and encrypted. Status: staging (not verified). " +
+              CODEX_DARK_COPY.notUsedForRuns
+          : "Saved and encrypted. Status: static. " + CODEX_DARK_COPY.notUsedForRuns,
       );
       await reload();
     } catch (err) {
@@ -366,12 +438,93 @@ function AddCredentialForm({
           placeholder={
             kind === "openai_api_key"
               ? "Paste your OpenAI API key"
-              : "Paste your Codex login token"
+              : "Paste your Codex login JSON"
           }
           value={token}
-          onChange={(e) => setToken(e.target.value)}
+          // A keystroke means the value changed, so a stale shape message (which
+          // described the OLD value) must go — never persisted, never re-checked.
+          onChange={(e) => {
+            setToken(e.target.value);
+            if (shapeError) setShapeError(null);
+          }}
         />
       </Field>
+      {isCodexLogin && (
+        // Codex-login help lives OUTSIDE the <Field> (which is a wrapping <label>)
+        // so the DocLink and the disclosure are not swallowed into the input's
+        // accessible name. The whole block is codex_auth-only: the OpenAI key field
+        // stays a bare raw-string paste.
+        <div className="space-y-2 text-xs">
+          {/* What this field IS, so a user does not paste an API key here: it
+              imports an EXISTING Codex CLI / ChatGPT-subscription login — a JSON
+              object with access_token (+ refresh_token for renewal). */}
+          <p className="text-muted">
+            This imports an existing Codex CLI / ChatGPT-subscription login — a JSON
+            object with{" "}
+            <code className="rounded bg-raised px-1 py-0.5 text-fg">access_token</code>{" "}
+            (and{" "}
+            <code className="rounded bg-raised px-1 py-0.5 text-fg">refresh_token</code>{" "}
+            for renewal). It is <strong className="text-fg">not</strong> an OpenAI
+            API key.{" "}
+            <DocLink slug={DOC_CODEX_CREDENTIALS}>How to get this</DocLink>.
+          </p>
+          {shapeError && (
+            // The pre-check verdict, inline and value-free, pointing at both the
+            // guide and the disclosure just below.
+            <p role="alert" className="text-danger">
+              {shapeError}{" "}
+              <DocLink slug={DOC_CODEX_CREDENTIALS}>How to get this</DocLink>.
+            </p>
+          )}
+          {/* Native <details>/<summary>: keyboard, touch and screen-reader reachable
+              with no JS. Summarizes the copy recipe; the full guide is the DocLink. */}
+          <details className="group">
+            <summary className="cursor-pointer list-none text-muted marker:content-none">
+              <span aria-hidden="true" className="text-faint group-open:hidden">
+                ▸{" "}
+              </span>
+              <span aria-hidden="true" className="hidden text-faint group-open:inline">
+                ▾{" "}
+              </span>
+              How to get this
+            </summary>
+            <div className="mt-2 space-y-2 text-muted">
+              <p>
+                First sign in with{" "}
+                <code className="rounded bg-raised px-1 py-0.5 text-fg">codex login</code>
+                , then confirm it with{" "}
+                <code className="rounded bg-raised px-1 py-0.5 text-fg">
+                  codex login status
+                </code>
+                .
+              </p>
+              <p>Then copy JUST the two fields uzi needs — never the whole file:</p>
+              <p>
+                <code className="block overflow-x-auto rounded bg-raised px-2 py-1 text-fg">
+                  {
+                    "jq -c '{access_token: .tokens.access_token, refresh_token: .tokens.refresh_token}' ~/.codex/auth.json | pbcopy"
+                  }
+                </code>
+              </p>
+              <p>
+                On Linux swap{" "}
+                <code className="rounded bg-raised px-1 py-0.5 text-fg">pbcopy</code>{" "}
+                for{" "}
+                <code className="rounded bg-raised px-1 py-0.5 text-fg">
+                  xclip -selection clipboard
+                </code>{" "}
+                or <code className="rounded bg-raised px-1 py-0.5 text-fg">wl-copy</code>
+                .
+              </p>
+              <p className="text-faint">
+                This is a renewable credential — do not commit it, log it, paste it
+                into issues, or otherwise share it.{" "}
+                <DocLink slug={DOC_CODEX_CREDENTIALS}>Full guide</DocLink>.
+              </p>
+            </div>
+          </details>
+        </div>
+      )}
       {!first && (
         <Field label="Name">
           <Input
@@ -413,6 +566,9 @@ export function CodexCredentials({
   const [rotateFor, setRotateFor] = useState("");
   const [rotateValue, setRotateValue] = useState("");
   const [rotateBusy, setRotateBusy] = useState(false);
+  // Same in-memory, value-free wrong-shape guard as the add form, for a codex_auth
+  // rotation (issue #1174 item 2 / AC 2). Inline, never the shared banner.
+  const [rotateShapeError, setRotateShapeError] = useState<string | null>(null);
 
   const first = secrets.length === 0;
   const anyBusy = busy || rotateBusy;
@@ -423,6 +579,17 @@ export function CodexCredentials({
     onNotice("");
     const row = secrets.find((s) => s.id === rotateFor);
     if (!row) return;
+    // A codex_auth rotation is JSON and gets the same pre-check as the add form; an
+    // OpenAI key is a raw string and skips it. On a bad shape: show inline, send
+    // nothing. The check runs in memory and never carries the pasted value.
+    if (row.kind === "codex_auth") {
+      const shape = codexShapeError(rotateValue);
+      if (shape !== null) {
+        setRotateShapeError(shape);
+        return;
+      }
+    }
+    setRotateShapeError(null);
     setRotateBusy(true);
     try {
       await apiForKind(row.kind).patch(rotateFor, { token: rotateValue });
@@ -442,9 +609,8 @@ export function CodexCredentials({
       <div>
         <SectionTitle>OpenAI / Codex credentials</SectionTitle>
         <p className="mt-2 text-sm text-muted">
-          Store your OpenAI Codex logins and API keys. Codex is not yet used to run
-          agents — an Anthropic token is still what starts a run. Paste a Codex login
-          token or an OpenAI API key, and give each one a name. A single{" "}
+          Store your OpenAI Codex logins and API keys. {CODEX_DARK_COPY.notUsedForRuns}{" "}
+          Paste a Codex login or an OpenAI API key, and give each one a name. A single{" "}
           <strong className="text-fg">default</strong> is shared across both kinds.
         </p>
       </div>
@@ -471,6 +637,54 @@ export function CodexCredentials({
         </div>
       )}
 
+      {/* A visible, keyboard/touch/screen-reader-reachable legend for the four
+          status badges (issue #1174 item 3). The per-badge title + sr-only text
+          answers "what does THIS badge mean" in place; this answers "what can a
+          badge mean" in one surface a keyboard or touch user can actually open. It
+          rides the same native <details>/<summary> idiom as RunUsage's breakdown,
+          so <details> conveys expanded state and the ▸/▾ is decorative only. */}
+      {!loading && !first && (
+        <details className="group">
+          <summary className="cursor-pointer list-none text-xs text-muted marker:content-none">
+            <span aria-hidden="true" className="text-faint group-open:hidden">
+              ▸{" "}
+            </span>
+            <span aria-hidden="true" className="hidden text-faint group-open:inline">
+              ▾{" "}
+            </span>
+            What do these statuses mean?
+          </summary>
+          <dl className="mt-2 space-y-2 text-xs text-muted">
+            <div>
+              <dt className="font-medium text-fg">staging</dt>
+              <dd>
+                Saved and encrypted, but the provider identity has not been verified.{" "}
+                {CODEX_DARK_COPY.stagingNotAutoVerified}
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-fg">linked</dt>
+              <dd>The provider identity has been verified.</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-fg">failed</dt>
+              <dd>
+                Verification failed. Replace the value or re-add the login. No
+                provider or secret details are shown.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-fg">static</dt>
+              <dd>
+                An API key is stored. Provider-account linking does not apply to API
+                keys.
+              </dd>
+            </div>
+          </dl>
+          <p className="mt-2 text-xs text-faint">{CODEX_DARK_COPY.notUsedForRuns}</p>
+        </details>
+      )}
+
       {/* Rotating a value is a separate form because the value is pasted, never
           edited: the API never returns it, so there is nothing to pre-fill. The
           route is chosen from the selected row's kind. */}
@@ -481,7 +695,12 @@ export function CodexCredentials({
               aria-label="Credential to replace"
               className="h-9 w-full rounded-md border border-edge bg-surface px-2 text-sm text-fg"
               value={rotateFor}
-              onChange={(e) => setRotateFor(e.target.value)}
+              // Switching the target row invalidates any shape message the previous
+              // row's paste produced.
+              onChange={(e) => {
+                setRotateFor(e.target.value);
+                setRotateShapeError(null);
+              }}
             >
               <option value="">Select a credential…</option>
               {secrets.map((s) => (
@@ -500,9 +719,20 @@ export function CodexCredentials({
                   autoComplete="off"
                   placeholder="Paste the replacement credential"
                   value={rotateValue}
-                  onChange={(e) => setRotateValue(e.target.value)}
+                  onChange={(e) => {
+                    setRotateValue(e.target.value);
+                    if (rotateShapeError) setRotateShapeError(null);
+                  }}
                 />
               </Field>
+              {rotateShapeError && (
+                // A codex_auth rotation with the wrong shape: inline, value-free,
+                // and pointing at the guide (only ever set for a codex_auth row).
+                <p role="alert" className="text-xs text-danger">
+                  {rotateShapeError}{" "}
+                  <DocLink slug={DOC_CODEX_CREDENTIALS}>How to get this</DocLink>.
+                </p>
+              )}
               <Button type="submit" disabled={anyBusy || rotateValue.trim() === ""}>
                 Replace value
               </Button>

--- a/web/src/components/codexCredentialsCopy.test.ts
+++ b/web/src/components/codexCredentialsCopy.test.ts
@@ -1,0 +1,23 @@
+// Pins the "dark" copy for the Codex credentials card (issue #1174 item 6). These
+// exact-equality assertions are the tripwire for the future milestone that ENABLES
+// Codex routing: flipping the flag in codexCredentialsCopy.ts must be a deliberate
+// edit that also updates this test, never an accidental drift. The card component
+// imports the same const, so a single source of truth backs both the UI and the
+// guard.
+
+import { describe, it, expect } from "vitest";
+import { CODEX_DARK_COPY } from "./codexCredentialsCopy";
+
+describe("CODEX_DARK_COPY (the one Codex-dark retirement flag)", () => {
+  it("pins the not-used-for-runs sentence", () => {
+    expect(CODEX_DARK_COPY.notUsedForRuns).toBe(
+      "Codex is not yet used to run agents — an Anthropic token is still what starts a run.",
+    );
+  });
+
+  it("pins the staging-not-auto-verified sentence", () => {
+    expect(CODEX_DARK_COPY.stagingNotAutoVerified).toBe(
+      "This build does not verify Codex logins automatically.",
+    );
+  });
+});

--- a/web/src/components/codexCredentialsCopy.ts
+++ b/web/src/components/codexCredentialsCopy.ts
@@ -1,0 +1,12 @@
+// Centralized "dark" copy for the Codex credentials card (issue #1174 item 6).
+// While parent #1106 is dark, saved Codex credentials do NOT start runs and a
+// `staging` login is NOT auto-verified in this build. The milestone that ENABLES
+// Codex routing removes/updates these in ONE place (and updates the pinning test
+// codexCredentialsCopy.test.ts). Do not inline these sentences elsewhere — import
+// from here so retirement stays a one-line change.
+export const CODEX_DARK_COPY = {
+  notUsedForRuns:
+    "Codex is not yet used to run agents — an Anthropic token is still what starts a run.",
+  stagingNotAutoVerified:
+    "This build does not verify Codex logins automatically.",
+} as const;

--- a/web/src/lib/doclinks.ts
+++ b/web/src/lib/doclinks.ts
@@ -8,6 +8,7 @@
 
 export const DOC_WORKER_SETUP = "worker-setup";
 export const DOC_ANTHROPIC_TOKEN = "anthropic-token";
+export const DOC_CODEX_CREDENTIALS = "codex-credentials";
 export const DOC_SLACK = "slack";
 export const DOC_REPO_AGENTS = "repo-agents";
 export const DOC_AGENT_TEMPLATES = "agent-templates";
@@ -24,6 +25,7 @@ export const DOC_GITHUB_PROJECT_SYNC = "github-project-sync";
 export const ALL_DOC_SLUGS = [
   DOC_WORKER_SETUP,
   DOC_ANTHROPIC_TOKEN,
+  DOC_CODEX_CREDENTIALS,
   DOC_SLACK,
   DOC_REPO_AGENTS,
   DOC_AGENT_TEMPLATES,

--- a/web/src/mocks/data/secrets.ts
+++ b/web/src/mocks/data/secrets.ts
@@ -63,4 +63,51 @@ export const mockSecrets: SecretMeta[] = [
     created_at: daysAgo(6),
     updated_at: minsAgo(14),
   },
+  // Codex credentials (PRD #1147 / issue #1174 item 10). Seeded so ALL FOUR status
+  // badges — and the legend that explains them — are browsable in the mock: the
+  // create path only ever births `staging`/`static`, so `linked` and `failed` are
+  // unreachable without fixture rows. This set is independent of the anthropic
+  // rows above: it carries its OWN single default (the linked login), no codex row
+  // is `auto_eligible` (there is no Codex auto-selection pool), and none of these
+  // touch the anthropic-only data.test.ts invariants.
+  {
+    id: "sec-codex-linked",
+    kind: "codex_auth",
+    label: "chatgpt-plus",
+    is_default: true,
+    auto_eligible: false,
+    codex_status: "linked",
+    created_at: daysAgo(20),
+    updated_at: daysAgo(2),
+  },
+  {
+    id: "sec-codex-staging",
+    kind: "codex_auth",
+    label: "pending-login",
+    is_default: false,
+    auto_eligible: false,
+    codex_status: "staging",
+    created_at: daysAgo(1),
+    updated_at: minsAgo(35),
+  },
+  {
+    id: "sec-codex-failed",
+    kind: "codex_auth",
+    label: "revoked-login",
+    is_default: false,
+    auto_eligible: false,
+    codex_status: "failed",
+    created_at: daysAgo(11),
+    updated_at: daysAgo(1),
+  },
+  {
+    id: "sec-openai-static",
+    kind: "openai_api_key",
+    label: "openai-key",
+    is_default: false,
+    auto_eligible: false,
+    codex_status: "static",
+    created_at: daysAgo(15),
+    updated_at: daysAgo(15),
+  },
 ];


### PR DESCRIPTION
Implements issue #1174.

Closes #1174

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1174`. Please review and merge manually — the agent never merges.