### PR TITLE
fix(ci): bound npm-audit-gate retry env knobs (#1175 CodeRabbit follow-up)

### DIFF
--- a/scripts/npm-audit-gate.sh
+++ b/scripts/npm-audit-gate.sh
@@ -209,10 +209,14 @@ registry_unreachable() {  # $1 = output file; rc 0 iff it looks like a registry 
 # classification below is identical on the last attempt as on the first.
 attempts="${UZI_NPM_AUDIT_ATTEMPTS:-3}"
 backoff="${UZI_NPM_AUDIT_BACKOFF_SECONDS:-2}"
-# Coerce a non-integer override back to the default so a bad env value cannot
-# error the gate under set -eu.
-case "$attempts" in ''|*[!0-9]*) attempts=3 ;; esac
-case "$backoff"  in ''|*[!0-9]*) backoff=2  ;; esac
+# Coerce a non-integer OR out-of-range override back to the default: these knobs
+# exist only to let a test shrink the sleeps, so a huge attempts count (retry for
+# an impractical duration) or a huge backoff (block the first retry for years) is a
+# fat-finger, not a real request. Empty/non-numeric AND above-max both fall back to
+# the default, applied independently to each (#1166 review, CodeRabbit). The trailing
+# `|| default` keeps these set -eu safe.
+case "$attempts" in ''|*[!0-9]*) attempts=3 ;; *) [ "$attempts" -ge 1 ] && [ "$attempts" -le 10 ] || attempts=3 ;; esac
+case "$backoff"  in ''|*[!0-9]*) backoff=2  ;; *) [ "$backoff" -le 60 ] || backoff=2 ;; esac
 attempt=1
 rc=0
 while : ; do
@@ -231,7 +235,9 @@ while : ; do
   echo "npm-audit-gate: $PKG_DIR -- registry unreachable on attempt $attempt of $attempts; retrying in ${backoff}s." >&2
   sleep "$backoff" || true
   attempt=$((attempt + 1))
-  backoff=$((backoff * 2))
+  # Capped exponential backoff: double, but never above the per-sleep ceiling, so a
+  # sustained outage cannot balloon into an arbitrarily long sleep even at the bound.
+  backoff=$((backoff * 2)); [ "$backoff" -le 60 ] || backoff=60
 done
 
 cat "$TMP/out"


### PR DESCRIPTION
## Why

Follow-up to a **CodeRabbit Major finding on PR #1175** (`scripts/npm-audit-gate.sh:215`, *"Bound both retry configuration values"*) that merged before it was addressed. `UZI_NPM_AUDIT_ATTEMPTS` / `UZI_NPM_AUDIT_BACKOFF_SECONDS` were coerced only for empty/non-numeric values, so a digit-only fat-finger passed through: a huge attempts count retries for an impractical duration, and a huge backoff blocks the first retry for a very long time and then doubles.

## Fix

- Empty/non-numeric **and above-max** both fall back to the default, applied independently: `attempts` valid in `[1,10]`, `backoff` `<= 60`, else default (`3` / `2`). `backoff=0` stays allowed (tests use it for instant retries).
- The doubling is clamped to a per-sleep ceiling (`60`s) so a sustained outage can't balloon into an arbitrarily long sleep even at the bound (capped exponential backoff).

These knobs exist only so a test can shrink the sleeps, so an out-of-range value is a mistake, not a request. Preserves everything else: exit-2 fail-closed, no `--silent`, findings fail closed on the first observation, `set -eu` safe (`|| default` idiom).

Verified: standalone coercion test — `(99999,99999)→(3,2)`, `(11,61)→(3,2)`, `(10,60)` and `(5,10)` kept, `(0,0)→attempts=3,backoff=0`. `shellcheck -x` clean.