### PR TITLE
docs(codex-credentials): drop em dashes from user-facing Codex copy (#1177 review)

### DIFF
--- a/api/internal/uzidocs/embed/codex-credentials.md
+++ b/api/internal/uzidocs/embed/codex-credentials.md
@@ -8,7 +8,7 @@ audience: user
 
 **Settings → OpenAI / Codex credentials** lets you import an existing
 **Codex CLI / ChatGPT-subscription login** into uzi. It is not an OpenAI
-API key — that has its own field on the same card.
+API key; that has its own field on the same card.
 
 **Codex credentials do not yet start runs.** Saving one is dark: uzi stores
 and seals it, but no run, worker, or judge can spend it. You still need an
@@ -26,10 +26,10 @@ The **Codex login** field wants a flat JSON object, not a raw token:
 
 - **`access_token`** is the only thing required to save the credential.
 - **`refresh_token`** isn't checked at save time, but uzi needs it later to
-  renew the login once it expires — paste both together now rather than
+  renew the login once it expires, so paste both together now rather than
   going back for the refresh token afterwards.
 
-Do not paste a bare token string, and do not paste an OpenAI API key here —
+Do not paste a bare token string, and do not paste an OpenAI API key here;
 use the **OpenAI API key** field beside it for that.
 
 ## 1. Sign in with the Codex CLI
@@ -46,7 +46,7 @@ codex login status
 
 ## 2. Get the value safely
 
-The Codex CLI's own credential file, `~/.codex/auth.json`, is **nested** —
+The Codex CLI's own credential file, `~/.codex/auth.json`, is **nested**:
 your tokens live under a `tokens` object alongside other fields:
 
 ```json
@@ -62,7 +62,7 @@ your tokens live under a `tokens` object alongside other fields:
 }
 ```
 
-uzi wants the **flat** shape above, not the whole file — pasting the whole
+uzi wants the **flat** shape above, not the whole file; pasting the whole
 file fails with "codex login must contain a non-empty access_token",
 because the top level has no `access_token` of its own.
 
@@ -97,12 +97,12 @@ file-backed storage.
 
 ## Keep it secret
 
-The value you paste is a renewable credential, not a one-time code — treat
+The value you paste is a renewable credential, not a one-time code, so treat
 it like a password. Don't commit it, log it, paste it into an issue, or
 share it in chat.
 
 uzi seals it at rest the moment you save and never shows it again in the
-UI, an API response, or a log — not even to you. If you need to change it,
+UI, an API response, or a log, not even to you. If you need to change it,
 use **Replace value** to paste a new one; there is nothing to reveal or
 edit in place.
 
@@ -112,7 +112,7 @@ Each stored Codex credential shows one of four statuses:
 
 | Status | Meaning |
 |---|---|
-| `staging` | Saved and encrypted; the provider identity has not been verified yet. This build has no automatic verification — a `staging` credential can stay `staging` indefinitely. |
+| `staging` | Saved and encrypted; the provider identity has not been verified yet. This build has no automatic verification, so a `staging` credential can stay `staging` indefinitely. |
 | `linked` | The provider identity has been verified. |
 | `failed` | Verification failed. Replace the value, or re-add the login. |
-| `static` | An OpenAI API key, not a Codex login — provider-account linking doesn't apply to a key. |
+| `static` | An OpenAI API key, not a Codex login; provider-account linking doesn't apply to a key. |

--- a/docs/codex-credentials.md
+++ b/docs/codex-credentials.md
@@ -8,7 +8,7 @@ audience: user
 
 **Settings → OpenAI / Codex credentials** lets you import an existing
 **Codex CLI / ChatGPT-subscription login** into uzi. It is not an OpenAI
-API key — that has its own field on the same card.
+API key; that has its own field on the same card.
 
 **Codex credentials do not yet start runs.** Saving one is dark: uzi stores
 and seals it, but no run, worker, or judge can spend it. You still need an
@@ -26,10 +26,10 @@ The **Codex login** field wants a flat JSON object, not a raw token:
 
 - **`access_token`** is the only thing required to save the credential.
 - **`refresh_token`** isn't checked at save time, but uzi needs it later to
-  renew the login once it expires — paste both together now rather than
+  renew the login once it expires, so paste both together now rather than
   going back for the refresh token afterwards.
 
-Do not paste a bare token string, and do not paste an OpenAI API key here —
+Do not paste a bare token string, and do not paste an OpenAI API key here;
 use the **OpenAI API key** field beside it for that.
 
 ## 1. Sign in with the Codex CLI
@@ -46,7 +46,7 @@ codex login status
 
 ## 2. Get the value safely
 
-The Codex CLI's own credential file, `~/.codex/auth.json`, is **nested** —
+The Codex CLI's own credential file, `~/.codex/auth.json`, is **nested**:
 your tokens live under a `tokens` object alongside other fields:
 
 ```json
@@ -62,7 +62,7 @@ your tokens live under a `tokens` object alongside other fields:
 }
 ```
 
-uzi wants the **flat** shape above, not the whole file — pasting the whole
+uzi wants the **flat** shape above, not the whole file; pasting the whole
 file fails with "codex login must contain a non-empty access_token",
 because the top level has no `access_token` of its own.
 
@@ -97,12 +97,12 @@ file-backed storage.
 
 ## Keep it secret
 
-The value you paste is a renewable credential, not a one-time code — treat
+The value you paste is a renewable credential, not a one-time code, so treat
 it like a password. Don't commit it, log it, paste it into an issue, or
 share it in chat.
 
 uzi seals it at rest the moment you save and never shows it again in the
-UI, an API response, or a log — not even to you. If you need to change it,
+UI, an API response, or a log, not even to you. If you need to change it,
 use **Replace value** to paste a new one; there is nothing to reveal or
 edit in place.
 
@@ -112,7 +112,7 @@ Each stored Codex credential shows one of four statuses:
 
 | Status | Meaning |
 |---|---|
-| `staging` | Saved and encrypted; the provider identity has not been verified yet. This build has no automatic verification — a `staging` credential can stay `staging` indefinitely. |
+| `staging` | Saved and encrypted; the provider identity has not been verified yet. This build has no automatic verification, so a `staging` credential can stay `staging` indefinitely. |
 | `linked` | The provider identity has been verified. |
 | `failed` | Verification failed. Replace the value, or re-add the login. |
-| `static` | An OpenAI API key, not a Codex login — provider-account linking doesn't apply to a key. |
+| `static` | An OpenAI API key, not a Codex login; provider-account linking doesn't apply to a key. |

--- a/web/src/components/CodexCredentials.tsx
+++ b/web/src/components/CodexCredentials.tsx
@@ -31,12 +31,12 @@ import { CODEX_DARK_COPY } from "./codexCredentialsCopy";
 // vaultLockedMessage is the shared copy for a 409 vault_locked: the global handler
 // has already refreshed the session, so the unlock banner is showing above.
 const VAULT_LOCKED =
-  "Your vault is locked — unlock it with the banner above, then save again.";
+  "Your vault is locked; unlock it with the banner above, then save again.";
 
 // D6's reason, in one place: rendered as a tooltip AND as the screen-reader
 // description the disabled-looking Delete points at, so the two cannot drift.
 const D6_HINT =
-  "Make another credential the default first — every account needs one default while any credential exists.";
+  "Make another credential the default first; every account needs one default while any credential exists.";
 
 function errText(err: unknown, fallback: string): string {
   if (isVaultLocked(err)) return VAULT_LOCKED;
@@ -136,7 +136,7 @@ export function codexShapeError(raw: string): string | null {
     typeof (nested as Record<string, unknown>).access_token === "string" &&
     ((nested as Record<string, unknown>).access_token as string).trim() !== ""
   ) {
-    return "This looks like the whole ~/.codex/auth.json file. Uzi needs a flat object with just access_token and refresh_token — use the copy command in “How to get this”.";
+    return "This looks like the whole ~/.codex/auth.json file. Uzi needs a flat object with just access_token and refresh_token; use the copy command in “How to get this”.";
   }
   return "This JSON has no access_token. See “How to get this” below.";
 }
@@ -496,7 +496,7 @@ function AddCredentialForm({
                 </code>
                 .
               </p>
-              <p>Then copy JUST the two fields uzi needs — never the whole file:</p>
+              <p>Then copy JUST the two fields uzi needs, never the whole file:</p>
               <p>
                 <code className="block overflow-x-auto rounded bg-raised px-2 py-1 text-fg">
                   {

--- a/web/src/components/codexCredentialsCopy.test.ts
+++ b/web/src/components/codexCredentialsCopy.test.ts
@@ -11,7 +11,7 @@ import { CODEX_DARK_COPY } from "./codexCredentialsCopy";
 describe("CODEX_DARK_COPY (the one Codex-dark retirement flag)", () => {
   it("pins the not-used-for-runs sentence", () => {
     expect(CODEX_DARK_COPY.notUsedForRuns).toBe(
-      "Codex is not yet used to run agents — an Anthropic token is still what starts a run.",
+      "Codex is not yet used to run agents; an Anthropic token is still what starts a run.",
     );
   });
 

--- a/web/src/components/codexCredentialsCopy.ts
+++ b/web/src/components/codexCredentialsCopy.ts
@@ -6,7 +6,7 @@
 // from here so retirement stays a one-line change.
 export const CODEX_DARK_COPY = {
   notUsedForRuns:
-    "Codex is not yet used to run agents — an Anthropic token is still what starts a run.",
+    "Codex is not yet used to run agents; an Anthropic token is still what starts a run.",
   stagingNotAutoVerified:
     "This build does not verify Codex logins automatically.",
 } as const;


### PR DESCRIPTION
## Why

Follow-up to the `/code-review` pass on merged PR **#1177** (CodeRabbit was rate-limited, so the review was local). Of its findings:

- **Em dashes in user-facing content** (the `docs/codex-credentials.md` page, `audience: user`, and the card's UI strings) — the project convention avoids em dashes in user-facing content. **This PR fixes it.**
- **Mock "two defaults"** — *verified non-issue*: `ClearCodexDefaults` (`api/internal/store/queries/codex_credentials.sql`) scopes the codex default across the two **codex** kinds (`codex_auth` + `openai_api_key`), independent of anthropic; the card copy's "single default across both kinds" means those two codex kinds. The mock correctly has one anthropic default + one codex default.
- **Empty-paste message** — *verified non-issue*: the submit button is `disabled` on an empty/whitespace token, so `codexShapeError` never runs on empty input.

## Change

Replaced em dashes with commas, semicolons, and a colon (meaning preserved) in: the docs page + its embed mirror (`task docs:sync`), the four `CodexCredentials.tsx` UI strings, and `CODEX_DARK_COPY.notUsedForRuns` + its pinning test. Internal code comments keep their em dashes (the convention is about user-facing content). No behavior change.

Embed mirror re-synced (byte-identical, so `TestEmbeddedDocsMatchSource` stays green); copy string and its pinning test kept in lockstep.