### PR TITLE
docs(uzi-watcher): prefer working-clone HEAD over the lagging bare ref in PVC recovery

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -203,11 +203,10 @@ workflow-file pieces locally, because your own token has `workflow` scope (confi
 
 **A push-rejected run's work is usually NOT lost.** On hosted (k8s) workers the branch
 survives in the worker's persistent volume at `refs/uzi-runner/agent/issue-N` (the
-worker-side tracking ref — the branch tip with every commit); only the worker *container* is
-torn down, its data volume persists. Recovered #422's full 12 commits this way, 2026-08-20.
-Needs kube access to your deployment's worker namespace — **read the context and namespace
-from your own kubeconfig; they are deployment-specific, do not hard-code them** (and this is
-a public file).
+worker-side tracking ref); only the worker *container* is torn down, its data volume
+persists. Recovered #422's full 12 commits this way, 2026-08-20. Needs kube access to your
+deployment's worker namespace — **read the context and namespace from your own kubeconfig;
+they are deployment-specific, do not hard-code them** (and this is a public file).
 
 1. **Find the worker — but do NOT trust the run's *current* `worker_id` after a
    resume.** `uzi run get RUN --json | jq -r .worker_id` names the worker the run is
@@ -224,11 +223,15 @@ a public file).
    run was re-claimed on a fresh worker and cold-started from the default branch while its
    full reviewed tip sat on the previous worker's PVC; `jq .worker_id` pointed at the cold
    worker.) Its pod is `uzi-hw-WORKER_ID-*` in the worker namespace.
-2. **Bundle the branch out** of the bare clone on the worker's data volume, base excluded so
-   it stays small: `git --git-dir=BARE bundle create /tmp/r.bundle
-   refs/uzi-runner/agent/issue-N ^MERGEBASE` (where `MERGEBASE` = `git
-   --git-dir=BARE merge-base refs/uzi-runner/agent/issue-N refs/remotes/origin/main`),
-   then `kubectl cp` it out.
+2. **Bundle the branch out**, base excluded so it stays small. **Prefer the working-clone
+   HEAD while its pod exists**: it is the live tip and also holds uncommitted/untracked work;
+   the bare tracking ref only advances at park/shutdown/finalize (`fetchBackBestEffort`), so
+   it lags after a hard mid-milestone kill. Easiest: `scripts/backup-runs.sh RUN`. By hand:
+   `git --git-dir=/data/runner/<slug>/issue-N/.git bundle create /tmp/r.bundle <branch>
+   --not origin/main`. Only when the current worker has no clone (cold-reassignment, step 1)
+   or the clone is gone, use the bare ref: `git --git-dir=BARE bundle create /tmp/r.bundle
+   refs/uzi-runner/agent/issue-N ^MERGEBASE` (`MERGEBASE` = `git --git-dir=BARE merge-base
+   refs/uzi-runner/agent/issue-N refs/remotes/origin/main`). Then `kubectl cp` it out.
 3. **Fetch into a branch + an ISOLATED worktree** (never the `main` worktree): `git fetch
    BUNDLE 'refs/uzi-runner/agent/issue-N:refs/heads/recover/issue-N'`; `git worktree
    add DIR recover/issue-N`.
@@ -245,7 +248,8 @@ a public file).
 
 The remote `refs/uzi-checkpoints/agent/issue-N` ref is the other recovery source, but a
 behind-on-workflows run leaves none (its checkpoint push hit the same rejection). The PVC
-tracking ref is the reliable source.
+tracking ref is the reliable source once the run has checkpointed; before that, prefer the
+working-clone HEAD (step 2).
 
 The steps above are the **issue-run** shape; a **task run** (`uzi handoff`) uses
 `uzi/task/<RUN>` / `refs/uzi-runner/uzi/task/<RUN>` and often has its work entirely

--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -223,13 +223,17 @@ they are deployment-specific, do not hard-code them** (and this is a public file
    run was re-claimed on a fresh worker and cold-started from the default branch while its
    full reviewed tip sat on the previous worker's PVC; `jq .worker_id` pointed at the cold
    worker.) Its pod is `uzi-hw-WORKER_ID-*` in the worker namespace.
-2. **Bundle the branch out**, base excluded so it stays small. **Prefer the working-clone
-   HEAD while its pod exists**: it is the live tip and also holds uncommitted/untracked work;
-   the bare tracking ref only advances at park/shutdown/finalize (`fetchBackBestEffort`), so
-   it lags after a hard mid-milestone kill. Easiest: `scripts/backup-runs.sh RUN`. By hand:
-   `git --git-dir=/data/runner/<slug>/issue-N/.git bundle create /tmp/r.bundle <branch>
-   --not origin/main`. Only when the current worker has no clone (cold-reassignment, step 1)
-   or the clone is gone, use the bare ref: `git --git-dir=BARE bundle create /tmp/r.bundle
+2. **Bundle the branch out**, base excluded so it stays small. The bare tracking ref
+   advances only at checkpoint boundaries (milestone/iteration checkpoints, park, shutdown via
+   `fetchBackBestEffort`; finalize via `fetchAgentBranch`), not on every commit, so after a
+   hard mid-milestone kill the **working-clone branch HEAD** is the fresher committed tip. For
+   a run still claimed on the worker holding the clone, `scripts/backup-runs.sh RUN` is easiest
+   and also saves the uncommitted patch + untracked files separately. By hand (committed
+   history only; add `git -C <clone> diff HEAD` and an untracked tar for WIP):
+   `git --git-dir=/data/runner/<slug>/issue-N/.git bundle create /tmp/r.bundle <branch> --not
+   origin/main`. Use the bare ref when the current worker has no clone (cold-reassignment,
+   step 1 — `backup-runs.sh` searches only the current `worker_id` and skips terminal runs) or
+   the clone is gone: `git --git-dir=BARE bundle create /tmp/r.bundle
    refs/uzi-runner/agent/issue-N ^MERGEBASE` (`MERGEBASE` = `git --git-dir=BARE merge-base
    refs/uzi-runner/agent/issue-N refs/remotes/origin/main`). Then `kubectl cp` it out.
 3. **Fetch into a branch + an ISOLATED worktree** (never the `main` worktree): `git fetch


### PR DESCRIPTION
## What

Two docs-only changes.

### 1. uzi-watcher skill: prefer working-clone HEAD in PVC recovery

The "Recovering a failed run's work from the worker PVC" section called `refs/uzi-runner/<branch>` "the branch tip with every commit". That holds only after a clean stop: the runner advances that bare tracking ref on the park/shutdown/finalize paths (`fetchBackBestEffort` in `agent/src/runner.ts`), not on every commit, so after a hard mid-milestone kill (worker_lost, OOM, evicted pod) it lags the live tip.

- Drop the inaccurate "branch tip with every commit" phrasing.
- Step 2 now prefers the working-clone HEAD while the pod exists (`scripts/backup-runs.sh RUN`, or a manual bundle from `/data/runner/<slug>/issue-N`): it is the live tip and also carries uncommitted/untracked work the bare bundle misses.
- The bare tracking ref stays the documented fallback for cold-reassignment (current worker has no clone) or once the clone is gone.

The skill already ships `backup-runs.sh` / `backup-loop.sh`, which capture the working-clone HEAD correctly; this realigns the prose with what the scripts do.

### 2. Unblock main: mark the forward ADR reference in prds/1184

`prds/1184-admin-judge-scope.md` names the ADR it will create (`adr/1184-admin-judge-scope.md`); check-docs treats a backticked `adr/` path as a must-exist artifact and fails. That PRD landed with `[skip ci]`, so main's CI never ran the check, and the first PR since reddens on it, blocking every open PR. Adds the documented `check-docs:ignore-path` marker (the sanctioned opt-out for a forward reference to a not-yet-created artifact) to the two lines.

## Scope

`.claude/skills/uzi-watcher/SKILL.md` + `prds/1184-admin-judge-scope.md`. No code.