### PR TITLE
docs(uzi-watcher): note mr_rework high-water skips cross-sequence inline findings

### DIFF
--- a/.claude/skills/uzi-watcher/SKILL.md
+++ b/.claude/skills/uzi-watcher/SKILL.md
@@ -385,6 +385,17 @@ by anything on the PR itself.
    runs carry **`repo_id` and `mr_iid`, never `issue_iid`** (their `branch`/`mr_web_url`/
    `source_run_id` may read null while running — do not key on those). A non-terminal one
    means uzi is on it.
+
+   **Handing a finding to `mr_rework` yourself: post it as a TOP-LEVEL PR comment, never an
+   inline one.** The trigger keys on ONE scalar high-water (`mr_rework_ledger.high_water`)
+   over GitHub's DISJOINT comment id sequences (top-level/issue vs inline-review vs
+   review-summary, `github_mr.go` Sources A/B/C). An inline finding is silently skipped when
+   a prior rework already consumed a higher-id top-level/issue comment (classically your own
+   `@coderabbitai review` nudges): its id sits below the mark, so GATE 3 in
+   `mr_review_watch.go` never fires and no run appears though the finding is the newest,
+   actionable comment. A fresh TOP-LEVEL PR comment lands above the mark and fires it.
+   Fail-safe (a skipped comment just falls back to human review), so the tell is silence, not
+   an error. Durable per-sequence-high-water fix tracked in #1199.
 2. **If uzi is (or is about to be) reworking, DEFER — do not fix locally, do not merge.**
    The trigger needs a green pipeline + settled review, so the run may not have spawned yet
    even though it will; if the findings are uzi-fixable (below) and the owner is opted in,


### PR DESCRIPTION
Adds a note to the `uzi-watcher` skill (the `mr_rework` coordination section) capturing a gotcha hit while driving PR #1192: when you hand a finding to `mr_rework` by posting a review, an **inline** review comment is silently skipped if a prior rework already consumed a higher-id **top-level/issue** comment (classically your own `@coderabbitai review` nudges).

Cause: GitHub numbers top-level/issue comments, inline-review comments, and review-summary bodies in **disjoint** id sequences (`github_mr.go` Sources A/B/C), but the poller's trigger keys on ONE scalar high-water (`mr_rework_ledger.high_water`), so a newer inline finding whose id is below the mark never fires GATE 3 in `mr_review_watch.go`. It is fail-safe (falls back to human review), so the only tell is silence.

Workaround the note documents: post the finding as a **top-level PR comment**, which lands with a fresh id above the mark and fires the rework.

The durable per-sequence-high-water fix is tracked separately in #1199.

Docs-only change to a dev skill; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
