### PR TITLE
fix(agent): read repo skills from .agents/skills as a second real root (#1205)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -303,16 +303,24 @@ model); this section is the map. User-facing usage is
   there are no template rows, so every repo subagent receives the whole surviving
   set.
 - **Repo skills** (`agent/src/repo-skills.ts`), opt-in and default off. Only when
-  `ClaimRepo.skills_enabled`, the worker enumerates
-  `<clone>/.claude/skills/*/SKILL.md` after checkout, keeping only the `name` and
-  `description` frontmatter keys (every other key, e.g. `allowed-tools`, is
-  stripped, the security point) and re-synthesizing through the same escaped-YAML
-  materializer. Repo skills carry no allocation, so a surviving one attaches to
-  **every** template; they rank lowest (a name collision with any delivered skill
-  drops the repo skill) and are first evicted if the set exceeds
-  `skills_max_per_run`. This is the **only** clone-borne configuration the worker
-  reads (no hooks, settings, commands, or `CLAUDE.md`), which is why the toggle is
-  per repo: a repo's `.claude/` is exactly the config class `settingSources: []`
+  `ClaimRepo.skills_enabled`, the worker enumerates two real-directory roots after
+  checkout — `<clone>/.claude/skills/*/SKILL.md` (what Claude Code reads) and
+  `<clone>/.agents/skills/*/SKILL.md` (the cross-agent root Codex reads, issue
+  #1205) — keeping only the `name` and `description` frontmatter keys (every other
+  key, e.g. `allowed-tools`, is stripped, the security point) and re-synthesizing
+  through the same escaped-YAML materializer. Both roots run the identical
+  validation, symlink refusal included (each root, each skill dir, and each
+  `SKILL.md` must be a real directory/file, so a hostile repo cannot redirect
+  enumeration outside the clone); on a real-vs-real name collision `.claude/skills`
+  wins and the shadowed `.agents/skills` entry is recorded as a drop. The canonical cross-agent layout
+  keeps the real bodies under `.agents/skills` and projects `.claude/skills` as a
+  symlink, so the symlink-refusing guard reads the `.agents/skills` side. Repo
+  skills carry no allocation, so a surviving one attaches to **every** template;
+  they rank lowest (a name collision with any delivered skill drops the repo skill)
+  and are first evicted if the set exceeds `skills_max_per_run`. These two roots are
+  the **only** clone-borne configuration the worker reads (no hooks, settings,
+  commands, or `CLAUDE.md`), which is why the toggle is per repo: a repo's
+  `.claude/` (and `.agents/`) is exactly the config class `settingSources: []`
   keeps closed, so loading even this much requires the repo owner or an admin to
   vouch for that repo's review discipline.
 - **Trust boundary.** `settingSources: []` stays `[]` with or without repo skills

--- a/adr/0246-trusted-repo-instructions.md
+++ b/adr/0246-trusted-repo-instructions.md
@@ -293,3 +293,47 @@ content has been made safe to blindly follow.
   `repo_devbox_opt_in`, never both kinds together" — any future opt-in added
   to this endpoint must decide which of the two disjoint paths it belongs to,
   or add a third.
+
+## Addendum — issue #1205: `.agents/skills` as a second real skills root
+
+**Date**: 2026-09-08
+
+The repo-skills channel this ADR's Context describes (PRD #16 M6,
+`agent/src/repo-skills.ts`) originally read one root, `<clone>/.claude/skills`.
+The cross-agent skill layout keeps a single set of real skill bodies under
+`<clone>/.agents/skills/<name>/` (the root Codex reads) and projects them under
+`.claude/skills` (the root Claude Code reads) with a symlink — either per-skill
+(`.claude/skills/<name> -> ../../.agents/skills/<name>`) or whole-directory
+(`.claude/skills -> ../.agents/skills`). PR #1204 moved this repo to the
+whole-directory form. Because the enumerator **refuses every symlink** by
+design (the containment guard: the skills dir, each skill dir, and each
+`SKILL.md` must be a real directory/file), a repo on that layout had a
+`.claude/skills` that is a symlink, so the worker found **zero** repo skills for
+it even with `repo_skills_enabled` on.
+
+**Decision.** Enumerate a **second real-directory root**, `<clone>/.agents/skills`,
+under the **identical** validation already applied to `.claude/skills`
+(`enumerateRepoSkills` is reused verbatim per root; the merge lives in
+`collectRepoSkills`). On a name that resolves to a real skill under **both**
+roots, `.claude/skills` **wins** — it is the Claude-specific projection and the
+worker runs a Claude Code SDK agent — and the shadowed `.agents/skills` entry is
+recorded in the `dropped` list with a new reason code,
+`DROP_SHADOWED_BY_CLAUDE`, rather than silently discarded. In the canonical
+symlink layout this collision cannot occur (the `.claude/skills` side is a
+symlink and is skipped), so the precedence rule fires only on a hand-rolled
+dual-real layout; it is nonetheless deterministic and tested.
+
+**Why this does not widen the security seam.** The symlink refusal is
+**unchanged** for both roots, and no realpath-follow or symlink-follow logic was
+added. The seam this ADR and PRD #16 protect is "a hostile repo cannot redirect
+enumeration outside its own clone" — that is enforced by the `lstat` +
+`isDirectory()` / `isFile()` guard, which still rejects any symlinked root, skill
+dir, or `SKILL.md`. Adding `.agents/skills` adds one more **real** directory
+**inside the clone** to scan under exactly those checks; a real directory inside
+the clone was never the escape vector the guard exists to block. The
+capability-key stripping (only `name` + `description` survive), the name regex
+(path-safety), the size cap, and the lowest-precedence ranking are all applied
+per root unchanged. `settingSources: []` is likewise untouched — neither root is
+read through the SDK's project loader. The net effect is that a repo on the
+cross-agent layout loads the same skills it always intended to, through the same
+controlled, symlink-refusing channel.

--- a/agent/src/repo-skills.ts
+++ b/agent/src/repo-skills.ts
@@ -10,6 +10,21 @@
 // by the same materializer the delivered skills use. Names must pass the skill
 // regex (which also makes them path-safe: no separators, no dots), and symlinks
 // are never followed, so a hostile repo cannot read outside its own tree.
+//
+// Issue #1205: skills are read from TWO real-directory roots — `.claude/skills`
+// (what Claude Code reads) and `.agents/skills` (what Codex reads) — under the
+// IDENTICAL validation. The cross-agent layout keeps the skill bodies in a real
+// `.agents/skills/<name>/` and projects them under `.claude/skills` with a symlink
+// (per-skill or whole-dir). Because the guard REFUSES symlinks for both roots, the
+// symlinked `.claude/skills` side is skipped and the real `.agents/skills` side is
+// what supplies the skills; a repo on the old `.claude/skills`-real layout is
+// unaffected. Adding the second root does NOT widen the containment seam: symlink
+// refusal is unchanged, both roots are REAL directories inside the clone, and no
+// realpath-follow is introduced. When the SAME name resolves to a real skill under
+// BOTH roots (only possible on a hand-rolled dual-real layout, never the canonical
+// symlink one), `.claude/skills` wins — it is the Claude-specific projection and
+// the worker runs a Claude Code SDK agent — and the shadowed `.agents/skills` entry
+// is recorded as a drop, never silently discarded.
 
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -22,11 +37,24 @@ export const DROP_REPO_INVALID = "repo_invalid";
 /** Reason code for a repo skill whose name collides with a higher-precedence
  *  (delivered, or an earlier repo) skill. Repo skills rank below everything. */
 export const DROP_REPO_COLLISION = "repo_collision";
+/** Reason code for a real `.agents/skills/<name>` shadowed by a same-named real
+ *  `.claude/skills/<name>`. On a real-vs-real collision the Claude-specific
+ *  projection wins (the worker runs a Claude Code SDK agent); the `.agents/skills`
+ *  copy is recorded here rather than silently discarded (issue #1205). */
+export const DROP_SHADOWED_BY_CLAUDE = "shadowed_by_claude";
 
-/** The repo's skills directory inside the clone. Nothing else under .claude/ is
- *  ever read. */
+/** The repo's Claude-side skills directory inside the clone (`.claude/skills`).
+ *  Nothing else under .claude/ is ever read. */
 export function repoSkillsDir(clonePath: string): string {
   return path.join(clonePath, ".claude", "skills");
+}
+
+/** The repo's cross-agent skills directory inside the clone (`.agents/skills`).
+ *  In the canonical cross-agent layout this holds the REAL skill bodies and
+ *  `.claude/skills` is a symlink projection of it; read under the identical rules
+ *  as `repoSkillsDir` (issue #1205). Nothing else under .agents/ is ever read. */
+export function repoAgentsSkillsDir(clonePath: string): string {
+  return path.join(clonePath, ".agents", "skills");
 }
 
 /** Split leading YAML frontmatter, keeping ONLY the name + description keys (every
@@ -67,13 +95,15 @@ function stripQuotes(v: string): string {
 }
 
 /**
- * Enumerate `<clone>/.claude/skills/<name>/SKILL.md` into ClaimSkills, keeping
- * only name+description and applying the name regex + single-line description +
- * non-empty body + size (maxBytes) validation. Symlinks are never followed (the
- * skills dir, each skill dir, and each SKILL.md must be a REAL directory/file),
- * so a hostile repo cannot escape its tree. Sorted by name for a stable result.
- * Missing dir ⇒ no skills. Delivered-skill collision is resolved by the caller
- * (repo is lowest precedence); this returns every valid repo skill.
+ * Enumerate one real-directory skills root (`<root>/<name>/SKILL.md`) into
+ * ClaimSkills, keeping only name+description and applying the name regex +
+ * single-line description + non-empty body + size (maxBytes) validation. Symlinks
+ * are never followed (the root dir, each skill dir, and each SKILL.md must be a
+ * REAL directory/file), so a hostile repo cannot escape its tree. Sorted by name
+ * for a stable result. Missing dir ⇒ no skills. Delivered-skill collision is
+ * resolved by the caller (repo is lowest precedence); this returns every valid
+ * repo skill. Called once per root by `collectRepoSkills` (issue #1205) — the
+ * SAME validation path runs for `.claude/skills` and `.agents/skills`.
  */
 export async function enumerateRepoSkills(
   skillsDir: string,
@@ -122,6 +152,48 @@ export async function enumerateRepoSkills(
       continue;
     }
     skills.push({ name: parsed.name, description: parsed.description, body: parsed.body });
+  }
+
+  skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { skills, dropped };
+}
+
+/**
+ * Enumerate BOTH real-directory skill roots in the clone — `.claude/skills` and
+ * `.agents/skills` — under the identical per-root validation (`enumerateRepoSkills`
+ * is reused verbatim for each), then merge with precedence (issue #1205).
+ *
+ * Precedence: on a real-vs-real name collision `.claude/skills` WINS (it is the
+ * Claude-specific projection and the worker runs a Claude Code SDK agent). The
+ * shadowed `.agents/skills` entry is recorded in `dropped` with
+ * `DROP_SHADOWED_BY_CLAUDE`, never silently discarded. In the canonical
+ * cross-agent layout there is no real-vs-real collision — `.claude/skills` is a
+ * symlink (skipped by the guard) — so this rule fires only on a hand-rolled
+ * dual-real layout, but it is deterministic and tested.
+ *
+ * The symlink refusal is unchanged for both roots; a symlinked root, skill dir,
+ * or SKILL.md is skipped exactly as before. Result is sorted by name for a stable
+ * shape identical to `enumerateRepoSkills`.
+ */
+export async function collectRepoSkills(
+  clonePath: string,
+  maxBytes: number,
+): Promise<{ skills: ClaimSkill[]; dropped: SkillDrop[] }> {
+  // `.claude/skills` is the higher-precedence root; enumerate it first so its
+  // names shadow a same-named real `.agents/skills` entry.
+  const claude = await enumerateRepoSkills(repoSkillsDir(clonePath), maxBytes);
+  const agents = await enumerateRepoSkills(repoAgentsSkillsDir(clonePath), maxBytes);
+
+  const skills: ClaimSkill[] = [...claude.skills];
+  const dropped: SkillDrop[] = [...claude.dropped, ...agents.dropped];
+  const claudeNames = new Set(claude.skills.map((s) => s.name));
+
+  for (const rs of agents.skills) {
+    if (claudeNames.has(rs.name)) {
+      dropped.push({ name: rs.name, reason: DROP_SHADOWED_BY_CLAUDE });
+      continue;
+    }
+    skills.push(rs);
   }
 
   skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));

--- a/agent/src/sdk-executor.ts
+++ b/agent/src/sdk-executor.ts
@@ -2674,6 +2674,8 @@ function describeSkillDrop(name: string, reason: string): string {
       return `skill "${name}" was dropped: its body exceeds the maximum allowed size`;
     case "repo_collision":
       return `repo skill "${name}" was skipped: a higher-precedence skill of the same name is already loaded`;
+    case "shadowed_by_claude":
+      return `repo skill "${name}" from .agents/skills was skipped: a real .claude/skills skill of the same name takes precedence`;
     case "repo_invalid":
       return `repo skill "${name}" was skipped: invalid name, description, or body`;
     default:

--- a/agent/src/skills-run.ts
+++ b/agent/src/skills-run.ts
@@ -6,7 +6,7 @@
 // (repo evicts first); the plugin dir is rebuilt from the survivors.
 
 import type { ClaimConfig, ClaimSkill } from "./protocol.js";
-import { DROP_REPO_COLLISION, enumerateRepoSkills, repoSkillsDir } from "./repo-skills.js";
+import { collectRepoSkills, DROP_REPO_COLLISION } from "./repo-skills.js";
 import { enforceSkillCaps, materializeSkillsPlugin, skillsPluginDir, type SkillDrop } from "./skills-plugin.js";
 
 // Fallbacks only when the claim omits config; the server normally supplies both
@@ -59,9 +59,11 @@ export async function prepareSkillPlugin(ctx: SkillRunInput, caps: SkillCaps): P
 
   // M6: repo-borne skills, opt-in, lowest precedence. A repo skill whose name
   // collides with a delivered (or earlier repo) skill is dropped and logged.
+  // Issue #1205: skills are read from BOTH real roots (`.claude/skills` and
+  // `.agents/skills`) with `.claude/skills` winning a real-vs-real collision.
   const repoKept: ClaimSkill[] = [];
   if (ctx.repoSkillsEnabled) {
-    const repo = await enumerateRepoSkills(repoSkillsDir(ctx.worktreePath), caps.maxBytes);
+    const repo = await collectRepoSkills(ctx.worktreePath, caps.maxBytes);
     drops.push(...repo.dropped);
     const seen = new Set(deliveredSkills.map((s) => s.name));
     for (const rs of repo.skills) {

--- a/agent/test/repo-skills.test.ts
+++ b/agent/test/repo-skills.test.ts
@@ -4,7 +4,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { DROP_REPO_INVALID, enumerateRepoSkills, repoSkillsDir } from "../src/repo-skills.js";
+import {
+  collectRepoSkills,
+  DROP_REPO_INVALID,
+  DROP_SHADOWED_BY_CLAUDE,
+  enumerateRepoSkills,
+  repoAgentsSkillsDir,
+  repoSkillsDir,
+} from "../src/repo-skills.js";
 import { DROP_TOO_LARGE } from "../src/skills-plugin.js";
 
 let clone: string;
@@ -22,8 +29,19 @@ function writeSkill(dir: string, content: string): void {
   fs.writeFileSync(path.join(d, "SKILL.md"), content, "utf8");
 }
 
+/** Write <clone>/.agents/skills/<dir>/SKILL.md (the cross-agent root, #1205). */
+function writeAgentsSkill(dir: string, content: string): void {
+  const d = path.join(repoAgentsSkillsDir(clone), dir);
+  fs.mkdirSync(d, { recursive: true });
+  fs.writeFileSync(path.join(d, "SKILL.md"), content, "utf8");
+}
+
 async function enumerate(maxBytes = 65536) {
   return enumerateRepoSkills(repoSkillsDir(clone), maxBytes);
+}
+
+async function collect(maxBytes = 65536) {
+  return collectRepoSkills(clone, maxBytes);
 }
 
 describe("enumerateRepoSkills", () => {
@@ -142,5 +160,91 @@ describe("enumerateRepoSkills", () => {
     writeSkill("alpha", "---\nname: alpha\ndescription: a.\n---\n\nb\n");
     const { skills } = await enumerate();
     assert.deepEqual(skills.map((s) => s.name), ["alpha", "zeta"]);
+  });
+});
+
+// Issue #1205: `.agents/skills` (the Codex root) is enumerated as a SECOND real
+// root under the identical rules, with `.claude/skills` winning a real-vs-real
+// name collision. The canonical cross-agent layout keeps real bodies under
+// `.agents/skills` and projects `.claude/skills` as a symlink.
+describe("collectRepoSkills (dual-root .claude/skills + .agents/skills)", () => {
+  it("enumerates a real .agents/skills skill when there is no .claude/skills", async () => {
+    writeAgentsSkill("codex-only", "---\nname: codex-only\ndescription: from agents.\n---\n\nbody\n");
+    const { skills, dropped } = await collect();
+    assert.deepEqual(skills.map((s) => s.name), ["codex-only"]);
+    assert.equal(skills[0]!.description, "from agents.");
+    assert.deepEqual(dropped, []);
+    // The old single-root path (.claude/skills only) misses it — this is the bug.
+    const legacy = await enumerate();
+    assert.deepEqual(legacy.skills, [], ".claude/skills-only enumeration cannot see .agents/skills");
+  });
+
+  it("returns nothing when .agents/skills itself is a symlink (containment guard)", async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "uzi-outside-agents-"));
+    fs.mkdirSync(path.join(outside, "x"));
+    fs.writeFileSync(path.join(outside, "x", "SKILL.md"), "---\nname: x\ndescription: y.\n---\n\nb\n");
+    try {
+      fs.mkdirSync(path.join(clone, ".agents"), { recursive: true });
+      fs.symlinkSync(outside, path.join(clone, ".agents", "skills"));
+      const { skills } = await collect();
+      assert.deepEqual(skills, [], "a symlinked .agents/skills dir is never enumerated");
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a symlinked skill dir or SKILL.md under .agents/skills", async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "uzi-outside-agents2-"));
+    fs.writeFileSync(path.join(outside, "SKILL.md"), "---\nname: leaked\ndescription: secret.\n---\n\nbody\n");
+    try {
+      writeAgentsSkill("legit", "---\nname: legit\ndescription: ok.\n---\n\nbody\n");
+      fs.symlinkSync(outside, path.join(repoAgentsSkillsDir(clone), "linked-dir"));
+      fs.mkdirSync(path.join(repoAgentsSkillsDir(clone), "linked-file"));
+      fs.symlinkSync(
+        path.join(outside, "SKILL.md"),
+        path.join(repoAgentsSkillsDir(clone), "linked-file", "SKILL.md"),
+      );
+      const { skills } = await collect();
+      assert.deepEqual(skills.map((s) => s.name), ["legit"], "symlinked dir/file must not be read");
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("canonical layout: real .agents/skills + `.claude/skills -> ../.agents/skills` symlink yields the skills", async () => {
+    // The exact shape PR #1204 moved this repo to. The `.claude/skills` symlink is
+    // rejected by the guard; the real `.agents/skills` side supplies the skills.
+    writeAgentsSkill("deploy", "---\nname: deploy\ndescription: how we deploy.\n---\n\nbody\n");
+    writeAgentsSkill("review", "---\nname: review\ndescription: how we review.\n---\n\nbody\n");
+    fs.mkdirSync(path.join(clone, ".claude"), { recursive: true });
+    fs.symlinkSync("../.agents/skills", path.join(clone, ".claude", "skills"));
+
+    const { skills, dropped } = await collect();
+    assert.deepEqual(skills.map((s) => s.name), ["deploy", "review"]);
+    assert.deepEqual(dropped, []);
+    // Acceptance criterion: SAME result a real `.claude/skills/<name>` tree gives.
+    // The old single-root path over the symlinked `.claude/skills` sees nothing.
+    const legacy = await enumerate();
+    assert.deepEqual(legacy.skills, [], "the symlinked .claude/skills projection is (correctly) empty on its own");
+  });
+
+  it("real-vs-real collision: .claude/skills wins and the .agents/skills copy is dropped", async () => {
+    writeSkill("dup", "---\nname: dup\ndescription: claude wins.\n---\n\nclaude body\n");
+    writeAgentsSkill("dup", "---\nname: dup\ndescription: agents copy.\n---\n\nagents body\n");
+    // A non-colliding .agents skill still comes through, proving the drop is scoped.
+    writeAgentsSkill("solo", "---\nname: solo\ndescription: only in agents.\n---\n\nbody\n");
+
+    const { skills, dropped } = await collect();
+    assert.deepEqual(skills.map((s) => s.name), ["dup", "solo"]);
+    const dup = skills.find((s) => s.name === "dup")!;
+    assert.equal(dup.description, "claude wins.", ".claude/skills is the surviving copy");
+    assert.ok(dup.body.includes("claude body"));
+    assert.deepEqual(dropped, [{ name: "dup", reason: DROP_SHADOWED_BY_CLAUDE }]);
+  });
+
+  it("returns nothing when neither root exists", async () => {
+    const { skills, dropped } = await collect();
+    assert.deepEqual(skills, []);
+    assert.deepEqual(dropped, []);
   });
 });

--- a/api/internal/uzidocs/embed/repo-agents.md
+++ b/api/internal/uzidocs/embed/repo-agents.md
@@ -63,8 +63,8 @@ already materializes.
   carries the same delivered skills as one started with your own templates.
 - **Per-template scoping does not apply.** Allocating a skill to `coder` alone
   is your scoping surface on a template run; on a repo-agent run every subagent
-  sees it. Repo skills (`.claude/skills/`, opt-in per repo) already worked this
-  way, for the same reason.
+  sees it. Repo skills (`.claude/skills/` or `.agents/skills/`, opt-in per repo)
+  already worked this way, for the same reason.
 
 ## The trust trade-off — read before you pick repo agents
 

--- a/api/internal/uzidocs/embed/skills.md
+++ b/api/internal/uzidocs/embed/skills.md
@@ -87,9 +87,20 @@ precedence) are the ones dropped first.
 ## Repo skills (opt-in, default off)
 
 A repo can carry its own skills in `.claude/skills/*/SKILL.md`, the same
-layout Claude Code itself uses. uzi never loads these automatically: on the
+layout Claude Code itself uses. uzi also reads `.agents/skills/*/SKILL.md`,
+the equally-valid cross-agent root (the layout Codex reads), under the same
+rules; the two roots are merged. If the same skill name is a real skill under
+both roots, the `.claude/skills` copy wins and the `.agents/skills` copy is
+dropped (and logged). uzi never loads any of these automatically: on the
 **Repos** page, an owner (or an admin) must click **Load repo skills** for
 that specific repo and accept the warning.
+
+Cross-agent repos usually keep the real skill bodies under `.agents/skills`
+and make `.claude/skills` a symlink to them (per skill, or the whole
+directory). uzi never follows a symlink for either root, so on that layout it
+reads the real `.agents/skills` side; the symlinked `.claude/skills` side is
+skipped, which is why both roots exist. A repo whose `.claude/skills` is a
+real directory keeps working exactly as before.
 
 When enabled, uzi loads **only** `name` and `description` plus the body from
 each `SKILL.md` in that repo, at the **lowest** precedence (a delivered

--- a/docs/repo-agents.md
+++ b/docs/repo-agents.md
@@ -63,8 +63,8 @@ already materializes.
   carries the same delivered skills as one started with your own templates.
 - **Per-template scoping does not apply.** Allocating a skill to `coder` alone
   is your scoping surface on a template run; on a repo-agent run every subagent
-  sees it. Repo skills (`.claude/skills/`, opt-in per repo) already worked this
-  way, for the same reason.
+  sees it. Repo skills (`.claude/skills/` or `.agents/skills/`, opt-in per repo)
+  already worked this way, for the same reason.
 
 ## The trust trade-off — read before you pick repo agents
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -87,9 +87,20 @@ precedence) are the ones dropped first.
 ## Repo skills (opt-in, default off)
 
 A repo can carry its own skills in `.claude/skills/*/SKILL.md`, the same
-layout Claude Code itself uses. uzi never loads these automatically: on the
+layout Claude Code itself uses. uzi also reads `.agents/skills/*/SKILL.md`,
+the equally-valid cross-agent root (the layout Codex reads), under the same
+rules; the two roots are merged. If the same skill name is a real skill under
+both roots, the `.claude/skills` copy wins and the `.agents/skills` copy is
+dropped (and logged). uzi never loads any of these automatically: on the
 **Repos** page, an owner (or an admin) must click **Load repo skills** for
 that specific repo and accept the warning.
+
+Cross-agent repos usually keep the real skill bodies under `.agents/skills`
+and make `.claude/skills` a symlink to them (per skill, or the whole
+directory). uzi never follows a symlink for either root, so on that layout it
+reads the real `.agents/skills` side; the symlinked `.claude/skills` side is
+skipped, which is why both roots exist. A repo whose `.claude/skills` is a
+real directory keeps working exactly as before.
 
 When enabled, uzi loads **only** `name` and `description` plus the body from
 each `SKILL.md` in that repo, at the **lowest** precedence (a delivered


### PR DESCRIPTION
## Summary

`enumerateRepoSkills` (`agent/src/repo-skills.ts`) scanned only `<clone>/.claude/skills`. The cross-agent skill layout (Codex reads `.agents/skills`, Claude Code reads `.claude/skills`) keeps the real skill bodies under `.agents/skills/<name>/` and projects `.claude/skills` as a symlink (per-skill or whole-directory). PR #1204 moved this repo to the whole-directory form. Because the enumerator refuses every symlink by design (ADR-0246 containment guard), the worker then found ZERO repo skills for any repo on that layout with `repo_skills_enabled: true`.

This adds `<clone>/.agents/skills` as a SECOND real-directory enumeration root, under the identical validation already applied to `.claude/skills`. `enumerateRepoSkills` is reused verbatim per root (no forked validation logic); the merge lives in a new `collectRepoSkills`, which the run-assembly caller (`agent/src/skills-run.ts`) now uses.

## Precedence decision (implemented and documented)

When the SAME skill `name` resolves to a real skill under BOTH roots, **`.claude/skills` wins** (it is the Claude-specific projection and the worker runs a Claude Code SDK agent). The shadowed `.agents/skills` entry is **recorded in the `dropped` array** with a new reason code, `DROP_SHADOWED_BY_CLAUDE`, and a human-readable line in `describeSkillDrop`; it is never silently discarded. In the canonical symlink layout there is no real-vs-real collision (the `.claude/skills` side is a symlink and is skipped), so this rule fires only on a hand-rolled dual-real layout, but it is deterministic and tested.

## Security-seam note (symlink refusal unchanged)

The symlink refusal is UNCHANGED for both roots, and no realpath-follow / symlink-follow logic was added. The seam ADR-0246 protects ("a hostile repo cannot redirect enumeration outside its clone") is enforced by the `lstat` + `isDirectory()`/`isFile()` guard, which still rejects any symlinked root, skill dir, or `SKILL.md`. Adding `.agents/skills` adds one more REAL directory INSIDE the clone to scan under exactly those checks; a real directory inside the clone was never the escape vector the guard exists to block. Capability-key stripping (only `name` + `description` survive), the name regex, the size cap, and the lowest-precedence ranking all apply per root unchanged. `settingSources: []` is untouched.

## Test plan

- [x] Real `.agents/skills/<name>/SKILL.md` with no `.claude/skills` at all is enumerated (and the legacy single-root path yields nothing, proving the regression and the fix in one assertion).
- [x] A symlinked `.agents/skills` directory yields nothing (containment guard holds for the new root too).
- [x] A per-skill symlink under `.agents/skills/<name>`, and a symlinked `SKILL.md` under it, are skipped.
- [x] Canonical layout (real `.agents/skills/<name>` + `.claude/skills -> ../.agents/skills` symlink) yields the skills (the issue's acceptance criterion).
- [x] Real-vs-real collision resolves to the `.claude/skills` copy and the `.agents/skills` copy appears in `dropped` with `DROP_SHADOWED_BY_CLAUDE`.
- [x] All existing symlink-escape tests (including "returns nothing when `.claude/skills` itself is a symlink") stay green, unchanged.
- [x] `task gate:agent` EXIT=0 (2332 pass / 0 fail / 0 cancelled / 1 pre-existing skip).
- [x] `task gate:repo` EXIT=0.
- [x] `task gate:api` EXIT=0 (with `GOTOOLCHAIN=go1.26.6`; the embedded docs mirror was synced via `task docs:sync`, `TestEmbeddedDocsMatchSource` green).

## Docs

ADR-0246 (addendum documenting the second root, precedence, and why the seam is not widened), `ARCHITECTURE.md` (Skills paragraph names both roots), `docs/skills.md` and `docs/repo-agents.md` (both roots named), plus the `api/internal/uzidocs/embed/` mirror synced.

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
