### PR TITLE
Pick ONE subsystem and audit it deeply for real correctness…

### DIFF
--- a/api/internal/sweeper/sweeper.go
+++ b/api/internal/sweeper/sweeper.go
@@ -107,7 +107,7 @@ func (e *Engine) runOnce(ctx context.Context) {
 	}
 	// Only log when the pass actually did something, to keep the log quiet on an
 	// idle system.
-	if res.WorkersOffline+res.ClaimedReset+res.RunningTimeout+res.StaleFailed+res.StaleRequeued+res.ChatIdleCompleted+res.ProposalsRecovered+res.HealthChanged+res.AutoStopped+res.PoolResumed > 0 {
+	if res.WorkersOffline+res.ClaimedReset+res.RunningTimeout+res.StaleFailed+res.StaleRequeued+res.ChatIdleCompleted+res.ProposalsRecovered+res.HealthChanged+res.AutoStopped+res.LimitPromoted+res.PoolResumed+res.RecoveryPromoted > 0 {
 		slog.Info("sweeper pass",
 			"workers_offline", res.WorkersOffline,
 			"claimed_reset", res.ClaimedReset,
@@ -121,10 +121,18 @@ func (e *Engine) runOnce(ctx context.Context) {
 			// as observability that nothing observes is the wrong shape for an M7
 			// milestone, and without it an auto-stop does not raise this line at all.
 			"auto_stopped", res.AutoStopped,
+			// PRD #35: same reasoning — in the sum above as well as emitted here, so a
+			// tick that only promotes a run out of limit_wait (retry_not_before elapsed)
+			// still raises this line rather than resuming a held run invisibly.
+			"limit_promoted", res.LimitPromoted,
 			// PRD #754 M5: same reasoning — in the sum above as well as emitted here, so a
 			// resume-only tick (nothing else changed) still raises this line rather than
 			// resuming a held run invisibly.
 			"pool_resumed", res.PoolResumed,
+			// issue #1197: same reasoning — in the sum above as well as emitted here, so a
+			// tick that only promotes a run out of recovery_wait (recovery_retry_not_before
+			// elapsed) still raises this line rather than resuming a held run invisibly.
+			"recovery_promoted", res.RecoveryPromoted,
 		)
 	}
 }

--- a/api/internal/sweeper/sweeper_test.go
+++ b/api/internal/sweeper/sweeper_test.go
@@ -3,6 +3,8 @@ package sweeper
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -12,11 +14,12 @@ import (
 type fakeSweeper struct {
 	calls atomic.Int64
 	err   error
+	res   workersvc.SweepResult
 }
 
 func (f *fakeSweeper) Sweep(context.Context) (workersvc.SweepResult, error) {
 	f.calls.Add(1)
-	return workersvc.SweepResult{}, f.err
+	return f.res, f.err
 }
 
 // Boot runs the extra passes alongside the run-liveness sweep. This is what makes
@@ -74,5 +77,99 @@ func TestEngineWithNoPasses(t *testing.T) {
 	New(sw, 0).Boot(context.Background())
 	if sw.calls.Load() != 1 {
 		t.Fatalf("sweep ran %d times, want 1", sw.calls.Load())
+	}
+}
+
+// recordingHandler is a minimal slog.Handler that captures every record so a test
+// can assert on the structured log the sweeper emits.
+type recordingHandler struct {
+	mu      *sync.Mutex
+	records *[]slog.Record
+}
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, r.Clone())
+	return nil
+}
+
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func findRecord(recs []slog.Record, msg string) *slog.Record {
+	for i := range recs {
+		if recs[i].Message == msg {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func attrInt(r *slog.Record, key string) (int64, bool) {
+	var (
+		out   int64
+		found bool
+	)
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			out, found = a.Value.Int64(), true
+			return false
+		}
+		return true
+	})
+	return out, found
+}
+
+// A tick that ONLY promotes a run out of limit_wait or recovery_wait is still a
+// resume the operator log must show. The guard and the emit list must therefore
+// include LimitPromoted and RecoveryPromoted, exactly as they include PoolResumed
+// (sweeper.go documents this invariant for pool_resumed at the emit site). A
+// resume-only tick that raised no "sweeper pass" line would resume a held run
+// invisibly. Note: this test swaps slog.SetDefault (process-global), so it must not
+// run in parallel with other tests that touch the default logger.
+func TestSweeperPassLogsResumeOnlyTicks(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cases := []struct {
+		name string
+		res  workersvc.SweepResult
+		attr string // "" => expect NO "sweeper pass" record
+	}{
+		{name: "limit_wait promotion alone", res: workersvc.SweepResult{LimitPromoted: 1}, attr: "limit_promoted"},
+		{name: "recovery_wait promotion alone", res: workersvc.SweepResult{RecoveryPromoted: 1}, attr: "recovery_promoted"},
+		{name: "idle tick logs nothing", res: workersvc.SweepResult{}, attr: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				mu   sync.Mutex
+				recs []slog.Record
+			)
+			slog.SetDefault(slog.New(recordingHandler{mu: &mu, records: &recs}))
+
+			New(&fakeSweeper{res: tc.res}, 0).Boot(context.Background())
+
+			rec := findRecord(recs, "sweeper pass")
+			if tc.attr == "" {
+				if rec != nil {
+					t.Fatal(`an idle sweep result raised a "sweeper pass" line; want none`)
+				}
+				return
+			}
+			if rec == nil {
+				t.Fatalf("a resume-only tick (%s) raised no \"sweeper pass\" line — the run was resumed invisibly", tc.name)
+			}
+			got, ok := attrInt(rec, tc.attr)
+			if !ok {
+				t.Fatalf("%q attribute missing from the \"sweeper pass\" line (emit list not updated?)", tc.attr)
+			}
+			if got != 1 {
+				t.Fatalf("%q = %d, want 1", tc.attr, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Ad-hoc scheduled prompt run (PRD #241 Decision 10). This run was created from a
schedule's stored prompt against this repository — there is no tracking issue, so
this MR references the task but closes nothing.

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.


---
Opened automatically by the uzi agent from branch `uzi/prompt-38d682e2-f24e-469b-8bed-0b7df9bfada2`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sweeper activity logs now appear when runs are promoted from waiting states, including limit and recovery waits.
  * Log entries include the corresponding promotion counts for improved visibility.

* **Tests**
  * Added coverage to verify logging for promotion-only sweeps and confirm that idle sweeps remain quiet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->