### PR TITLE
test(e2e): tolerate the #1213 recovery_wait park in bounded-concurrency

### DIFF
--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -116,7 +116,7 @@ services:
       # resume THROUGH recovery_wait — a hard worker-loss leaves a pending recovery-
       # capture journal, so the re-claim parks to verify the retained runner clone
       # before reseeding — and the sweeper (SWEEP_INTERVAL above) auto-promotes it once
-      # retry_not_before elapses. The park's dominant term is the NON-configurable jitter
+      # recovery_retry_not_before elapses. The park's dominant term is the NON-configurable jitter
       # (recoveryParkJitterMin..Max = 5s..30s, recoverywait.go), so compressing the base
       # to ~1s keeps the whole park inside the phase's resume wait; a small max caps the
       # doubling should a run park more than once. Overlay-only; production defaults

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -110,6 +110,19 @@ services:
       # worker-loss requeue are bounded by ~2s rather than ~15s. Product knob added in
       # the same change; unset ⇒ the api's built-in 15s default.
       SWEEP_INTERVAL: 2s
+      # Transient-recovery park cadence (issue #1197 / #1213): the first recovery
+      # park's backoff base and the ceiling on its doubling. Shrunk from the shipped
+      # 1m/30m defaults because the #42 mid-run-SIGKILL step (phase 45) now routes its
+      # resume THROUGH recovery_wait — a hard worker-loss leaves a pending recovery-
+      # capture journal, so the re-claim parks to verify the retained runner clone
+      # before reseeding — and the sweeper (SWEEP_INTERVAL above) auto-promotes it once
+      # retry_not_before elapses. The park's dominant term is the NON-configurable jitter
+      # (recoveryParkJitterMin..Max = 5s..30s, recoverywait.go), so compressing the base
+      # to ~1s keeps the whole park inside the phase's resume wait; a small max caps the
+      # doubling should a run park more than once. Overlay-only; production defaults
+      # (config.go RUN_RECOVERY_PARK_BASE / RUN_RECOVERY_MAX_PARK) are untouched.
+      RUN_RECOVERY_PARK_BASE: 1s
+      RUN_RECOVERY_MAX_PARK: 5s
       # MR review-watcher debounce (PRD #966 M6 / D6): the review-landed quiet period
       # the mr_rework detector waits after the newest review comment before queuing a
       # rework. Shrunk from the shipped 3m default so phase 71 can inject a note and

--- a/e2e/phases/45-bounded-concurrency.sh
+++ b/e2e/phases/45-bounded-concurrency.sh
@@ -207,7 +207,7 @@ else
   # recovery_wait → queued → claimed → running → awaiting_approval. The overlay
   # compresses the park's backoff base (RUN_RECOVERY_PARK_BASE=1s) so the whole park
   # fits this wait, but the park's jitter is a non-configurable UNIFORM 5-30s
-  # (recoverywait.go), so retry_not_before lands base+jitter ≈ 6-31s out (~20s typical),
+  # (recoverywait.go), so recovery_retry_not_before lands base+jitter ≈ 6-31s out (~20s typical),
   # plus ≤2s sweep granularity and ~0.5s re-claim before recovery work: a ~33.5s
   # deterministic scheduling bound. The ceiling is 90s (give-up, not expected) to absorb
   # that worst case plus re-claim + plan under CI load.

--- a/e2e/phases/45-bounded-concurrency.sh
+++ b/e2e/phases/45-bounded-concurrency.sh
@@ -199,11 +199,21 @@ else
   # Restart the worker (same join token ⇒ same worker id): it re-claims both by
   # affinity and drives them to completion. The exported UZI_WORKER_TOKEN re-sources
   # the `worker_token` secret; no token re-delivery is needed.
+  #
+  # Since issue #1213 the re-claim of a HARD-KILLED run first parks in recovery_wait:
+  # the SIGKILL left a pending recovery-capture journal, so the runner verifies the
+  # retained runner clone before reseeding, then the sweeper auto-promotes it back to
+  # queued for a second re-claim that reaches the gate. So the resume traverses
+  # recovery_wait → queued → claimed → running → awaiting_approval. The overlay
+  # compresses the park's backoff base (RUN_RECOVERY_PARK_BASE) so the whole park fits
+  # this wait, but the park's jitter is a non-configurable 5-30s (recoverywait.go), so
+  # the ceiling is 90s (give-up, not expected — the park promotes in ~10s typically)
+  # to absorb the worst-case jitter plus re-claim under CI load.
   "${COMPOSE[@]}" up -d --wait agent >/dev/null
   wait_worker_online
-  wait_status "$RUN_KA" awaiting_approval 60
-  wait_status "$RUN_KB" awaiting_approval 60
-  pass "restarted worker re-claimed both re-queued runs (affinity) — both back at the gate"
+  wait_status "$RUN_KA" awaiting_approval 90
+  wait_status "$RUN_KB" awaiting_approval 90
+  pass "restarted worker re-claimed both re-queued runs (affinity, via recovery_wait) — both back at the gate"
 
   apipost "/api/runs/$RUN_KA/inputs" '{"kind":"approve_plan","body":""}' >/dev/null
   apipost "/api/runs/$RUN_KB/inputs" '{"kind":"approve_plan","body":""}' >/dev/null

--- a/e2e/phases/45-bounded-concurrency.sh
+++ b/e2e/phases/45-bounded-concurrency.sh
@@ -205,15 +205,28 @@ else
   # retained runner clone before reseeding, then the sweeper auto-promotes it back to
   # queued for a second re-claim that reaches the gate. So the resume traverses
   # recovery_wait → queued → claimed → running → awaiting_approval. The overlay
-  # compresses the park's backoff base (RUN_RECOVERY_PARK_BASE) so the whole park fits
-  # this wait, but the park's jitter is a non-configurable 5-30s (recoverywait.go), so
-  # the ceiling is 90s (give-up, not expected — the park promotes in ~10s typically)
-  # to absorb the worst-case jitter plus re-claim under CI load.
+  # compresses the park's backoff base (RUN_RECOVERY_PARK_BASE=1s) so the whole park
+  # fits this wait, but the park's jitter is a non-configurable UNIFORM 5-30s
+  # (recoverywait.go), so retry_not_before lands base+jitter ≈ 6-31s out (~20s typical),
+  # plus ≤2s sweep granularity and ~0.5s re-claim before recovery work: a ~33.5s
+  # deterministic scheduling bound. The ceiling is 90s (give-up, not expected) to absorb
+  # that worst case plus re-claim + plan under CI load.
   "${COMPOSE[@]}" up -d --wait agent >/dev/null
   wait_worker_online
   wait_status "$RUN_KA" awaiting_approval 90
   wait_status "$RUN_KB" awaiting_approval 90
-  pass "restarted worker re-claimed both re-queued runs (affinity, via recovery_wait) — both back at the gate"
+  # OBSERVE the recovery_wait traversal, don't just assume it (the pass line claims it).
+  # Each re-claim of a hard-killed run must park EXACTLY once: 0 ⇒ the resume never went
+  # through recovery_wait (the assertion above became vacuous — e.g. the retained-clone
+  # detection regressed), >1 ⇒ an unnecessary re-park that the compressed cadence would
+  # otherwise hide (handleRecoveryExhausted's verified capture must clear the journal so
+  # the promoted re-claim proceeds instead of parking again). recovery_wait_count is not
+  # on the run DTO, so read it straight from the row.
+  RWC_KA="$(db_psql "SELECT recovery_wait_count FROM runs WHERE id = '$RUN_KA'")"
+  RWC_KB="$(db_psql "SELECT recovery_wait_count FROM runs WHERE id = '$RUN_KB'")"
+  { [ "$RWC_KA" = 1 ] && [ "$RWC_KB" = 1 ]; } \
+    || fail "each re-claimed run must park in recovery_wait exactly once (got KA=$RWC_KA KB=$RWC_KB): 0=resume skipped the park, >1=an unnecessary re-park"
+  pass "restarted worker re-claimed both re-queued runs (affinity, via recovery_wait ×1 each) — both back at the gate"
 
   apipost "/api/runs/$RUN_KA/inputs" '{"kind":"approve_plan","body":""}' >/dev/null
   apipost "/api/runs/$RUN_KB/inputs" '{"kind":"approve_plan","body":""}' >/dev/null


### PR DESCRIPTION
## Problem

The nightly `E2E` workflow (gitlab lane) started failing on the `bounded-concurrency` phase (run 34317245560, 2026-09-09):

```
FAIL timeout: run <id> never reached 'awaiting_approval' (last: recovery_wait)
```

Bisected to #1213 (merged 2026-09-08, first in the 09-09 nightly; the 09-08 nightly that lacked it was green).

## Root cause

#1213 (`runner.ts` retained-clone path) makes a **hard worker-loss (SIGKILL) resume route through `recovery_wait`**: on re-claim the runner finds a pending recovery-capture journal, parks to verify the retained runner clone before reseeding, and the sweeper auto-promotes it once `recovery_retry_not_before` elapses. This is intended behavior with unit + live-DB coverage.

The `bounded-concurrency` phase part (e) SIGKILLs the agent and then waited only **60s** for the re-claimed runs to reach `awaiting_approval`. But the park defers by `RUN_RECOVERY_PARK_BASE` (default **60s**) plus a **non-configurable 5-30s jitter** (`recoverywait.go`), i.e. 65-90s, so the resume could not finish inside the 60s wait. Fresh runs (parts b/e-pre-kill) do not park and stayed green.

## Fix (harness only; production defaults untouched)

- `e2e/docker-compose.e2e.yml`: compress the park cadence for the isolated stack, matching the existing `SWEEP_INTERVAL` / `MR_REVIEW_QUIET_PERIOD` overlay convention:
  - `RUN_RECOVERY_PARK_BASE: 1s`
  - `RUN_RECOVERY_MAX_PARK: 5s`
- `e2e/phases/45-bounded-concurrency.sh`: raise the part-(e) resume wait 60s -> 90s to absorb the fixed 5-30s jitter under CI load, and document that the resume now traverses `recovery_wait -> queued -> claimed -> running -> awaiting_approval`.

`task gate:repo` green (`lint:shell`, `lint:yaml` clean on both files).

## Verification

E2E never runs on PR (nightly + manual dispatch only), so it is dispatched manually on this branch; result linked once it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)