### PR TITLE
Dashboard per-user breakdown: SHARE cell wraps inconsistently on mobile

### DIFF
--- a/web/src/components/UsageCards.tsx
+++ b/web/src/components/UsageCards.tsx
@@ -183,13 +183,15 @@ export function PerUserUsageTable({ admin }: { admin: AdminUsage }) {
                     <Td>{formatTokens(u.b.out)}</Td>
                     <Td cost>{money(u.b.cost)}</Td>
                     <Td>
-                      {pct}%
-                      <span
-                        className="ml-2 inline-block h-1 w-16 overflow-hidden rounded bg-edge align-middle"
-                        role="img"
-                        aria-label={`${pct} percent of factory tokens`}
-                      >
-                        <span className="block h-full bg-brand" style={{ width: `${pct}%` }} />
+                      <span className="inline-flex items-center justify-end gap-2 whitespace-nowrap">
+                        {pct}%
+                        <span
+                          className="inline-block h-1 w-16 overflow-hidden rounded bg-edge align-middle"
+                          role="img"
+                          aria-label={`${pct} percent of factory tokens`}
+                        >
+                          <span className="block h-full bg-brand" style={{ width: `${pct}%` }} />
+                        </span>
                       </span>
                     </Td>
                   </tr>


### PR DESCRIPTION
Implements issue #1249.

Closes #1249

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1249`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment between percentage values and progress indicators in the per-user usage table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->