### PR TITLE
chore(deps): bump zizmor to 1.30.0 (ignore new self-repository audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
           # an unrelated PR, the drift lint:shell pins shellcheck against. No sha to
           # maintain (pip verifies from PyPI), so Renovate bumps this fully automatically.
           # renovate: datasource=pypi depName=zizmor versioning=pep440
-          pipx install zizmor==1.29.0
+          pipx install zizmor==1.30.0
       - name: Install semgrep (pinned; matches the baked worker toolchain)
         # semgrep is a PyPI-packaged tool, so pipx mirrors the yamllint/zizmor
         # installs above. Pinned to the SAME version baked into the worker toolchain

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration.
+#
+# self-repository: zizmor >= 1.30 flags workspace-relative local-action refs
+# (`uses: ./.github/actions/...`) and recommends GitHub's `$/...` self-repository
+# syntax (GA 2026-07-30). We keep `uses: ./` because actionlint (the other half of
+# `lint:actions`, pinned v1.7.12, upstream maintenance stalled) does not yet parse
+# `$/` and rejects it as an invalid `uses:` format (rhysd/actionlint#711). Adopt the
+# rewrite once actionlint ships `$/` support; until then this audit is a false gate.
+rules:
+  self-repository:
+    ignore:
+      - ci.yml
+      - main-guard.yml
+      - release.yml

--- a/scripts/lint-actions.sh
+++ b/scripts/lint-actions.sh
@@ -31,7 +31,12 @@
 #   * --min-confidence=high: after SHA-pinning every `uses:`, the only High-confidence
 #     findings are `unpinned-uses` (which now gates any FUTURE unpinned action) and
 #     High-confidence `template-injection` (a `${{ }}` context that can carry
-#     attacker input into a shell). The remaining audits on this repo -- `artipacked`
+#     attacker input into a shell). zizmor 1.30 adds a third High-confidence
+#     (Low-severity) audit, `self-repository`, flagging workspace-relative
+#     `uses: ./` local-action refs; it passes this --min-confidence=high filter but
+#     is suppressed in .github/zizmor.yml because actionlint (pinned) rejects the
+#     recommended `$/` self-repo syntax (rhysd/actionlint#711) -- re-enable it once
+#     actionlint supports `$/`. The remaining audits on this repo -- `artipacked`
 #     (Medium/Low: persist-credentials on checkout) and Low-confidence
 #     template-injection -- are REPORTED by a bare `zizmor` run but are NOT gated,
 #     the same severity-staging this repo uses for golangci's warn tier. Lowering


### PR DESCRIPTION
Bumps zizmor `1.29.0 → 1.30.0` (pin in `ci.yml`) and adds `.github/zizmor.yml` to ignore the one new audit that would falsely gate.

**Why the ignore:** zizmor 1.30 adds the `self-repository` audit, which flags workspace-relative local-action refs (`uses: ./.github/actions/...`) across ci.yml/main-guard.yml/release.yml (17 sites) and recommends GitHub's `$/...` self-repository syntax (GA 2026-07-30). Adopting that rewrite reddens the **other** half of `lint:actions`: actionlint (pinned v1.7.12, latest release, upstream maintenance stalled) does not parse `$/` and rejects it as an invalid `uses:` format — see rhysd/actionlint#711. So the two tools disagree; we keep `uses: ./` (actionlint-clean, GitHub-supported) and scope-ignore just `self-repository` so every other zizmor 1.30 audit — including the real vulnerability audits — keeps gating.

Revisit the `$/` hardening once actionlint ships support for it.

`gate:repo` passes locally (actionlint + zizmor 1.30 + yamllint all clean). Renovate auto-closes #1274 once 1.30.0 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
