### PR TITLE
On-demand mr_rework fails at iteration 0: a completed run's recovery-capture journal leaks on ENOTEMPTY cleanup and bricks new runs on the branch

### DIFF
--- a/agent/src/client.ts
+++ b/agent/src/client.ts
@@ -485,7 +485,9 @@ export class WorkerClient {
    *  the caller distinguishes a DEFINITIVE 404 (run not owned / reclaimed) from a transient
    *  error via `err.status`. Reuses GetRunOwnedByWorker server-side; no new query. */
   async getRunOwnership(runId: string): Promise<RunOwnershipResponse> {
-    return (await this.getJSON(`${WORKER_API_PREFIX}/runs/${runId}/ownership`)) as RunOwnershipResponse;
+    // issue #1308 — encode the id (matching the sibling getChatRun): the #1308 self-heal is
+    // the first caller to pass a journal-derived value rather than a claim's own UUID.
+    return (await this.getJSON(`${WORKER_API_PREFIX}/runs/${encodeURIComponent(runId)}/ownership`)) as RunOwnershipResponse;
   }
 
   // ── Chat agent read surface (PRD #39 M3) ───────────────────────────────────

--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -193,6 +193,27 @@ export class PendingRecoveryCaptureError extends Error {
   }
 }
 
+/**
+ * issue #1308 — a DIFFERENT run's recovery-capture journal blocks this acquisition: the
+ * pending journal names a run id and/or clone path that is not this run's. The runner
+ * catches this to attempt self-heal (reclaim when the owner run is terminal-and-idle),
+ * and if it cannot, maps it to the `runner_clone_conflict` fail_origin. The message keeps
+ * the "another run" phrase the git-layer recovery tests match. `pendingRunId` /
+ * `pendingClonePath` name the JOURNAL's owner (the run to probe for terminality and whose
+ * clone to reclaim); `targetClonePath` is the clone THIS run wanted to seed.
+ */
+export class RunnerCloneConflictError extends Error {
+  constructor(
+    readonly pendingRunId: string,
+    readonly pendingClonePath: string,
+    readonly targetClonePath: string,
+    readonly branch: string,
+  ) {
+    super("refusing to replace a retained clone owned by another run");
+    this.name = "RunnerCloneConflictError";
+  }
+}
+
 function recoveryCaptureKey(branch: string): string {
   return `uzi-recovery.${branch}.clone`;
 }
@@ -569,7 +590,10 @@ export class GitCache {
         throw err;
       })) {
         if (pending.runId !== runId || pending.clonePath !== clonePath) {
-          throw new Error("refusing to replace a retained clone owned by another run");
+          // issue #1308 — a TYPED refuse so the runner can self-heal it (reclaim when the
+          // owner run is terminal-and-idle) and, failing that, stamp the closed-vocabulary
+          // `runner_clone_conflict` fail_origin instead of a generic agent_failure.
+          throw new RunnerCloneConflictError(pending.runId, pending.clonePath, clonePath, branch);
         }
         throw new PendingRecoveryCaptureError(clonePath, branch);
       }
@@ -1370,13 +1394,87 @@ export class GitCache {
     });
   }
 
-  async clearRecoveryCapture(barePath: string, branch: string, runId: string): Promise<void> {
+  /**
+   * issue #1308 — terminal-cleanup release of a run's runner clone AND its recovery journal,
+   * under the ONE per-bare lock, with an exact-owner compare-and-check on BOTH the delete and
+   * the clear.
+   *
+   * The clone is deleted ONLY while the journal still names exactly (runId, clonePath). A
+   * same-key SUCCESSOR run can reclaim this journal and reseed a FRESH clone at the same path
+   * BEFORE this finished execution's cleanup runs (the runner drops the run from activeRuns
+   * before this cleanup, and codex dispose can hold the finally open), so an UNCONDITIONAL
+   * delete would destroy that live successor clone. When the journal no longer names us — a
+   * successor reclaimed it, or this run failed before it ever journaled — we touch NOTHING:
+   * any leftover is then unjournaled and harmless (the next same-key reseed's pre-seed rm
+   * removes it, and no journal means no refuse).
+   *
+   * When it IS still ours, the journal is cleared whether the delete succeeded or FAILED
+   * (ENOTEMPTY/EBUSY): a terminal run's work is already pushed, so the journal protects
+   * nothing and must be released even when the leftover dir survives on disk — releasing it
+   * is exactly the #1308 availability fix. `refs/uzi-runner/<branch>` is never touched.
+   */
+  async removeRunnerCloneAndReleaseRecovery(barePath: string, clonePath: string, branch: string, runId: string): Promise<void> {
     await this.withLock(barePath, async () => {
       const pending = await this.readRecoveryCapture(barePath, branch);
-      if (pending?.runId === runId) {
-        await this.runGit(barePath, ["config", "--local", recoveryCaptureKey(branch), ""]);
+      if (pending?.runId !== runId || pending?.clonePath !== clonePath) {
+        return;
       }
+      try {
+        await this.removeRunnerClone(clonePath);
+      } catch (e) {
+        this.log.warn("terminal cleanup: runner clone removal failed; releasing recovery journal anyway", {
+          clone: clonePath,
+          error: gitErrorMessage(e),
+        });
+      }
+      await this.runGit(barePath, ["config", "--local", recoveryCaptureKey(branch), ""]);
     });
+  }
+
+  /**
+   * issue #1308 — reclaim a TERMINAL owner run's leftover recovery residue so a NEW run on
+   * the same branch is not bricked by a stale journal (the mr_rework-at-iteration-0 bug). The
+   * runner calls this ONLY after confirming, out of band, that the journal's owner run is
+   * terminal (completed/failed/cancelled) AND not locally active. Under the ONE per-bare lock,
+   * with the same exact-owner CAS as the terminal release:
+   *   - if the journal no longer names (ownerRunId, ownerClonePath) — a concurrent reclaimer
+   *     or the owner itself already handled it — do NOTHING;
+   *   - else best-effort delete the recorded owner clone, but ONLY when it is inside this
+   *     repo's runner root (containment: a recorded path elsewhere is never deleted), and
+   *     deletion NEVER gates the clear;
+   *   - then clear the journal (release protection).
+   * `refs/uzi-runner/<branch>` (the durable off-PVC recovery artifact) is never touched — the
+   * retained clone is only same-run recovery state.
+   */
+  async reclaimTerminalRecoveryClone(barePath: string, branch: string, ownerRunId: string, ownerClonePath: string): Promise<void> {
+    await this.withLock(barePath, async () => {
+      const pending = await this.readRecoveryCapture(barePath, branch);
+      if (pending?.runId !== ownerRunId || pending?.clonePath !== ownerClonePath) {
+        return;
+      }
+      if (this.isInsideRunnerRoot(ownerClonePath)) {
+        await this.removeRunnerClone(ownerClonePath).catch((e) =>
+          this.log.warn("reclaim: best-effort delete of terminal owner clone failed", {
+            clone: ownerClonePath,
+            error: gitErrorMessage(e),
+          }),
+        );
+      } else {
+        this.log.warn("reclaim: recorded clone path is outside the runner root; not deleting", {
+          clone: ownerClonePath,
+        });
+      }
+      await this.runGit(barePath, ["config", "--local", recoveryCaptureKey(branch), ""]);
+    });
+  }
+
+  /** issue #1308 — true iff `p` resolves to a location strictly inside `this.runnerRoot`.
+   *  Guards the reclaim delete so a journal recording a path outside the runner root (a bug
+   *  or tampering) is never deleted. `path.relative` rejects `..` escapes and absolute
+   *  re-roots; the empty-relative (the root itself) is also rejected. */
+  private isInsideRunnerRoot(p: string): boolean {
+    const rel = path.relative(this.runnerRoot, path.resolve(p));
+    return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
   }
 
   private async readRecoveryCapture(barePath: string, branch: string): Promise<{ runId: string; clonePath: string } | undefined> {

--- a/agent/src/git.ts
+++ b/agent/src/git.ts
@@ -11,6 +11,7 @@ import type { BoundaryProcessHandle, BoundaryProcessRequest } from "./harness.js
 import { runnerCommand, runnerPath, runnerTmpdir } from "./runner-uid.js";
 import { withForgeRetry } from "./forge-retry.js";
 import { flagCIConfigPaths } from "./ci-config-guard.js";
+import { rmTreeForce } from "./rmtree.js";
 import {
   commitsScannedFromStderr,
   gitleaksArgs,
@@ -572,7 +573,13 @@ export class GitCache {
         }
         throw new PendingRecoveryCaptureError(clonePath, branch);
       }
-      await fs.rm(clonePath, { recursive: true, force: true });
+      // issue #1308 — pre-seed cleanup of a stale (unjournaled) leftover goes through the
+      // same hardened removal (`rmTreeForce`) as terminal cleanup, so an `ENOTEMPTY`/`EBUSY`
+      // leftover does not fail the reseed's `git clone` into a non-empty <key> dir. Calls
+      // `rmTreeForce` directly rather than `this.removeRunnerClone` so the reseed's pre-seed
+      // rm keeps its own identity — `removeRunnerClone` names ONLY the terminal-cleanup /
+      // reclaim removal that recovery tests intercept and barrier on.
+      await rmTreeForce(clonePath);
       // The clone's parent dir. Under the M4 split it must be group-`runner`-writable so
       // the runner-uid `git clone` can create <key> inside it: /data/runner is
       // worker:runner 2775 (setgid) from the entrypoint, and the worker runs with umask
@@ -1589,9 +1596,15 @@ export class GitCache {
   }
 
   /** Remove the run's runner clone (a standalone clone, not a linked worktree — no
-   *  bare interaction). The warm bare and the fetched refs/objects are kept. */
+   *  bare interaction). The warm bare and the fetched refs/objects are kept.
+   *
+   *  issue #1308 — routed through `rmTreeForce` so it gets BOTH the `EACCES`/`EPERM`
+   *  directory-writability repair (a `go build` leaves 0555 module-cache dirs) AND
+   *  the bounded `ENOTEMPTY`/`EBUSY` retries (a lingering writer under a cache dir,
+   *  e.g. `web/node_modules/.vite`). A plain `fs.rm` threw `ENOTEMPTY` here and leaked
+   *  the recovery journal, which bricked later runs on the branch. */
   async removeRunnerClone(clonePath: string): Promise<void> {
-    await fs.rm(clonePath, { recursive: true, force: true });
+    await rmTreeForce(clonePath);
   }
 
   /**

--- a/agent/src/rmtree.ts
+++ b/agent/src/rmtree.ts
@@ -26,10 +26,22 @@ import path from "node:path";
  * when it fails with a permission error do we walk the tree restoring owner
  * write+execute on directories and retry. A partially-removed tree is fine: `rm`
  * is idempotent, and the second pass finishes what the first started.
+ *
+ * issue #1308 — both `fs.rm` calls carry a small bounded retry. Node applies
+ * `maxRetries`/`retryDelay` to `ENOTEMPTY`/`EBUSY` (among `EPERM`/`EMFILE`/
+ * `ENFILE`), the transient class a lingering writer under a cache dir raises (the
+ * incident's `web/node_modules/.vite`). The chmod walk above does NOT help those —
+ * they are not a permission problem — so the retry is what makes a leftover rare.
+ * `maxRetries` is kept small: the SUCCESS path removes on the first attempt and
+ * pays nothing, and the other best-effort callers (home-reclaim, model-pass, the
+ * runHome sweep) must not stall for long on a genuinely stuck tree. Only a FAILING
+ * rm pays, and even then only until it clears or the bound is hit.
  */
+const RM_RETRY = { maxRetries: 3, retryDelay: 100 } as const;
+
 export async function rmTreeForce(target: string): Promise<void> {
   try {
-    await fs.rm(target, { recursive: true, force: true });
+    await fs.rm(target, { recursive: true, force: true, ...RM_RETRY });
     return;
   } catch (err) {
     if (!isPermissionError(err)) throw err;
@@ -38,7 +50,7 @@ export async function rmTreeForce(target: string): Promise<void> {
   // Anything still un-removable after this throws, and the caller decides. The
   // run-terminal caller logs and continues: cleanup is best-effort by design and
   // must never turn a completed run into a failed one.
-  await fs.rm(target, { recursive: true, force: true });
+  await fs.rm(target, { recursive: true, force: true, ...RM_RETRY });
 }
 
 /** EACCES (no write on the parent) or EPERM (the same refusal on some platforms

--- a/agent/src/runner.ts
+++ b/agent/src/runner.ts
@@ -51,7 +51,7 @@ import { withForgeRetry } from "./forge-retry.js";
 import { makeRedactor, makeTextRedactor } from "./redact.js";
 import { sessionTranscriptResolvable } from "./sdk-session.js";
 import { errMessage, RUN_ID_RE, sleep } from "./util.js";
-import { PendingRecoveryCaptureError } from "./git.js";
+import { PendingRecoveryCaptureError, RunnerCloneConflictError } from "./git.js";
 import {
   buildCheckEnv,
   defaultCheckRunner,
@@ -995,11 +995,16 @@ export class RunRunner {
         // structured origin the judge can key on; an ordinary agent failure maps to
         // undefined and the server defaults it to 'agent_failure'. PRD #1077: a
         // TerminalReportError carries its own typed origin (push_secret_blocked) whose
-        // terminal report threw after exhausting retries — honor it verbatim.
+        // terminal report threw after exhausting retries — honor it verbatim. issue #1308:
+        // a RunnerCloneConflictError that survived self-heal (owner nonterminal / still
+        // active / unreachable) is a pre-start infra refuse — stamp runner_clone_conflict so
+        // it is diagnosable and does not enqueue the Judge at iteration 0.
         const failOrigin =
           err instanceof TerminalReportError
             ? err.failOrigin
-            : failOriginForReason(rawReason);
+            : err instanceof RunnerCloneConflictError
+              ? "runner_clone_conflict"
+              : failOriginForReason(rawReason);
         runLog.error("run failed", { error: reason });
         batcher.emit({
           kind: "error",
@@ -1109,9 +1114,20 @@ export class RunRunner {
       //     code says otherwise. A hang here is this bug until proven otherwise.
       if (flight.worktreePath && !flight.preserveRecoveryClone) {
         try {
-          await this.git.removeRunnerClone(flight.worktreePath);
           if (flight.barePath && flight.branch) {
-            await this.git.clearRecoveryCapture(flight.barePath, flight.branch, runId);
+            // issue #1308 — delete-then-clear under ONE per-bare lock, with an exact-owner
+            // CAS gating BOTH the delete and the clear: the journal is released even when the
+            // rm fails (ENOTEMPTY/EBUSY), so a leftover no longer bricks the branch, and a
+            // same-key successor's freshly reclaimed clone is never destroyed by this run.
+            await this.git.removeRunnerCloneAndReleaseRecovery(
+              flight.barePath,
+              flight.worktreePath,
+              flight.branch,
+              runId,
+            );
+          } else {
+            // No bare/branch context (no journal to release): plain best-effort remove.
+            await this.git.removeRunnerClone(flight.worktreePath);
           }
         } catch (e) {
           runLog.warn("runner clone cleanup failed", { error: errMessage(e) });
@@ -4839,18 +4855,81 @@ export class RunRunner {
       claim,
       runId,
     );
-    if (cloneBranch)
-      return this.git.runnerCloneForBranch(
-        barePath,
-        cloneBranch.branch,
-        cloneBranch.slug,
-        runId,
-        resume,
-        expectedCheckpointTip,
-      );
-    if (claim.issue_iid == null)
-      throw new Error("issue run claim is missing issue_iid");
-    return this.git.createOrAttachRunnerClone(barePath, claim.issue_iid, runId, resume, expectedCheckpointTip);
+    const seed = async (): Promise<RunnerClone> => {
+      if (cloneBranch)
+        return this.git.runnerCloneForBranch(
+          barePath,
+          cloneBranch.branch,
+          cloneBranch.slug,
+          runId,
+          resume,
+          expectedCheckpointTip,
+        );
+      if (claim.issue_iid == null)
+        throw new Error("issue run claim is missing issue_iid");
+      return this.git.createOrAttachRunnerClone(barePath, claim.issue_iid, runId, resume, expectedCheckpointTip);
+    };
+    // issue #1308 — a DIFFERENT run's stale recovery-capture journal (left behind when its
+    // clone cleanup failed, e.g. ENOTEMPTY) refuses this seed. When that owner run is
+    // definitively terminal-and-idle, self-heal by reclaiming its residue and retry the seed
+    // ONCE; otherwise fail closed (the RunnerCloneConflictError propagates and stamps the
+    // runner_clone_conflict fail_origin). The same-run PendingRecoveryCaptureError path is
+    // untouched — that error type is not caught here.
+    try {
+      return await seed();
+    } catch (err) {
+      if (!(err instanceof RunnerCloneConflictError)) throw err;
+      if (!(await this.tryReclaimTerminalRecovery(barePath, err))) throw err;
+      return await seed();
+    }
+  }
+
+  /**
+   * issue #1308 — decide whether a cross-run clone-conflict can self-heal, and if so, reclaim
+   * the terminal owner's residue so the caller can retry the seed ONCE. Returns true IFF the
+   * journal's owner run is DEFINITIVELY terminal AND not locally active, after which the
+   * journal has been exact-CAS-cleared and its contained clone best-effort deleted. Returns
+   * false — FAIL CLOSED, changing NOTHING — in every uncertain case:
+   *   - the owner is still in local `activeRuns` (a server-terminal status can race a
+   *     partitioned worker; the journal is live, not stale);
+   *   - the ownership probe throws — a definitive 404 (not owned / reclaimed by another
+   *     worker) or any transient/API error;
+   *   - the probe returns a non-terminal or unknown status.
+   */
+  private async tryReclaimTerminalRecovery(barePath: string, err: RunnerCloneConflictError): Promise<boolean> {
+    if (this.activeRuns.has(err.pendingRunId)) {
+      this.log.warn("runner clone conflict: owner run still active locally; not reclaiming", {
+        owner_run_id: err.pendingRunId,
+        branch: err.branch,
+      });
+      return false;
+    }
+    let status: string;
+    try {
+      status = (await this.client.getRunOwnership(err.pendingRunId)).status;
+    } catch (probeErr) {
+      this.log.warn("runner clone conflict: owner terminality probe failed; not reclaiming", {
+        owner_run_id: err.pendingRunId,
+        branch: err.branch,
+        error: errMessage(probeErr),
+      });
+      return false;
+    }
+    if (!FOLLOWUP_TERMINAL_STATUSES.has(status)) {
+      this.log.warn("runner clone conflict: owner run not terminal; not reclaiming", {
+        owner_run_id: err.pendingRunId,
+        branch: err.branch,
+        owner_status: status,
+      });
+      return false;
+    }
+    this.log.info("runner clone conflict: reclaiming a terminal owner's stale recovery residue", {
+      owner_run_id: err.pendingRunId,
+      owner_status: status,
+      branch: err.branch,
+    });
+    await this.git.reclaimTerminalRecoveryClone(barePath, err.branch, err.pendingRunId, err.pendingClonePath);
+    return true;
   }
 
   /** Post awaiting_approval with the plan and await the steering verdict, bounded.

--- a/agent/test/git-recovery-release.test.ts
+++ b/agent/test/git-recovery-release.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { makeFixture, type Fixture } from "./fixture-repo.js";
+import { nullLogger } from "./helpers.js";
+import { GitCache } from "../src/git.js";
+
+// issue #1308 (m1-m3) — the #1197 recovery-capture journal (worker-owned bare config,
+// key `uzi-recovery.<branch>.clone`, value JSON `{runId, clonePath}`) used to brick every
+// later run on a branch: terminal cleanup cleared the journal ONLY when the clone rm
+// succeeded, so an ENOTEMPTY/EBUSY leftover left the journal pointing at a run that would
+// never come back. These tests drive the git-layer fix directly with REAL git (no mocks
+// beyond a spied/overridden `removeRunnerClone`):
+//   - removeRunnerCloneAndReleaseRecovery: releases the journal EVEN WHEN the delete
+//     fails, but ONLY when it still exactly names (runId, clonePath) — a same-key
+//     successor's live reclaim must never be destroyed by a stale predecessor's cleanup.
+//   - reclaimTerminalRecoveryClone: the runner's self-heal primitive — same exact-owner
+//     CAS, plus a containment check so a corrupted/tampered journal naming a path outside
+//     the runner root is never deleted (though the journal is still released).
+//
+// `refs/uzi-runner/<branch>` (the durable off-PVC recovery artifact) is asserted UNCHANGED
+// throughout — this whole mechanism is about the runner-owned CLONE and its journal, never
+// the worker-side tracking ref.
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_TERMINAL_PROMPT: "0",
+};
+
+function gitIn(dir: string, args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf8", env: GIT_ENV }).trim();
+}
+
+function recoveryConfigKey(branch: string): string {
+  return `uzi-recovery.${branch}.clone`;
+}
+
+/** Read the journal's raw config value with plain git (not the private git.ts reader), so
+ *  the assertion is independent of the code under test. `undefined` when the key is
+ *  entirely absent (git config --get exits 1); `""` when it was cleared (present, empty). */
+function readJournalRaw(bare: string, branch: string): string | undefined {
+  try {
+    const out = execFileSync(
+      "git",
+      ["-C", bare, "config", "--local", "--get", recoveryConfigKey(branch)],
+      { encoding: "utf8", env: GIT_ENV },
+    );
+    return out.replace(/\n$/, "");
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { status?: number };
+    if (err.status === 1) return undefined;
+    throw e;
+  }
+}
+
+function assertJournalCleared(bare: string, branch: string, msg?: string): void {
+  const raw = readJournalRaw(bare, branch);
+  assert.ok(
+    raw === undefined || raw === "",
+    msg ?? `expected the journal for ${branch} to be cleared, got ${JSON.stringify(raw)}`,
+  );
+}
+
+function assertJournalNames(
+  bare: string,
+  branch: string,
+  runId: string,
+  clonePath: string,
+  msg?: string,
+): void {
+  const raw = readJournalRaw(bare, branch);
+  assert.ok(raw, `expected a live journal entry for ${branch}, got ${JSON.stringify(raw)}`);
+  assert.deepStrictEqual(JSON.parse(raw!), { runId, clonePath }, msg);
+}
+
+let fx: Fixture;
+let git: GitCache;
+
+beforeEach(() => {
+  fx = makeFixture();
+  git = new GitCache(fx.dataDir, nullLogger());
+});
+
+afterEach(() => fx.cleanup());
+
+describe("removeRunnerCloneAndReleaseRecovery (issue #1308 m1/m2)", () => {
+  it("releases the owner's journal even when removeRunnerClone throws ENOTEMPTY, leaving the leftover dir on disk", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    const branch = "agent/issue-9001";
+    const runId = "10000000-0000-4000-8000-000000000001";
+    const clonePath = fs.mkdtempSync(path.join(os.tmpdir(), "uzi-recover-p1-"));
+    try {
+      fs.writeFileSync(path.join(clonePath, "marker.txt"), "still here\n");
+      await git.markRecoveryCapture(bare, clonePath, branch, runId);
+      assertJournalNames(bare, branch, runId, clonePath, "precondition: the journal names this run");
+
+      let removeCalls = 0;
+      git.removeRunnerClone = (async () => {
+        removeCalls++;
+        const err: NodeJS.ErrnoException = new Error("ENOTEMPTY: directory not empty");
+        err.code = "ENOTEMPTY";
+        throw err;
+      }) as typeof git.removeRunnerClone;
+
+      await git.removeRunnerCloneAndReleaseRecovery(bare, clonePath, branch, runId);
+
+      assert.strictEqual(removeCalls, 1, "the removal was attempted exactly once");
+      assertJournalCleared(bare, branch, "a terminal run's journal is released EVEN THOUGH the delete failed");
+      assert.strictEqual(fs.existsSync(clonePath), true, "the leftover directory survives the failed rm — this is the #1197 bricking shape, minus the bricking");
+    } finally {
+      fs.rmSync(clonePath, { recursive: true, force: true });
+    }
+  });
+
+  it("never destroys a same-key SUCCESSOR's live clone/journal (exact-owner CAS on both the delete and the clear)", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    const branch = "agent/issue-9002";
+    const run1 = "10000000-0000-4000-8000-000000000002";
+    const run2 = "10000000-0000-4000-8000-000000000003";
+    const successorClone = fs.mkdtempSync(path.join(os.tmpdir(), "uzi-recover-p2-"));
+    try {
+      fs.writeFileSync(path.join(successorClone, "live.txt"), "run2's live work\n");
+      // run2 reclaimed the journal and reseeded its OWN clone at this path BEFORE run1's
+      // delayed terminal cleanup runs — the exact race the CAS guard exists for.
+      await git.markRecoveryCapture(bare, successorClone, branch, run2);
+
+      const originalRemove = git.removeRunnerClone.bind(git);
+      let removeCalls = 0;
+      git.removeRunnerClone = (async (p: string) => {
+        removeCalls++;
+        return originalRemove(p);
+      }) as typeof git.removeRunnerClone;
+
+      // run1's terminal cleanup — its OWN old clonePath happened to be this same path
+      // (same branch, same on-disk key), but the journal no longer names run1.
+      await git.removeRunnerCloneAndReleaseRecovery(bare, successorClone, branch, run1);
+
+      assert.strictEqual(removeCalls, 0, "a mismatched owner must never even attempt the delete");
+      assert.strictEqual(fs.existsSync(successorClone), true, "the successor's live clone survives");
+      assert.strictEqual(fs.existsSync(path.join(successorClone, "live.txt")), true);
+      assertJournalNames(bare, branch, run2, successorClone, "the successor's journal entry is byte-for-byte untouched");
+    } finally {
+      fs.rmSync(successorClone, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("reclaimTerminalRecoveryClone (issue #1308 m2 self-heal primitive)", () => {
+  it("deletes the terminal owner's clone, clears the journal, and never touches refs/uzi-runner/<branch>", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    const branch = "agent/issue-9003";
+    const owner = "20000000-0000-4000-8000-000000000001";
+    const ownerClone = path.join(fx.dataDir, "runner", "reclaim-happy", "issue-9003");
+    fs.mkdirSync(ownerClone, { recursive: true });
+    fs.writeFileSync(path.join(ownerClone, "owner.txt"), "owner clone\n");
+    await git.markRecoveryCapture(bare, ownerClone, branch, owner);
+
+    const trackingRef = `refs/uzi-runner/${branch}`;
+    const sha = gitIn(bare, ["rev-parse", "refs/remotes/origin/main"]);
+    gitIn(bare, ["update-ref", trackingRef, sha]);
+
+    await git.reclaimTerminalRecoveryClone(bare, branch, owner, ownerClone);
+
+    assert.strictEqual(fs.existsSync(ownerClone), false, "the terminal owner's clone is actually deleted");
+    assertJournalCleared(bare, branch);
+    assert.strictEqual(
+      gitIn(bare, ["rev-parse", trackingRef]),
+      sha,
+      "the durable off-PVC tracking ref is untouched by a clone-level reclaim",
+    );
+  });
+
+  it("is a no-op when the journal no longer names EXACTLY the given (ownerRunId, ownerClonePath)", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    const branch = "agent/issue-9004";
+    const owner = "20000000-0000-4000-8000-000000000002";
+    const ownerClone = path.join(fx.dataDir, "runner", "reclaim-cas", "issue-9004");
+    fs.mkdirSync(ownerClone, { recursive: true });
+    await git.markRecoveryCapture(bare, ownerClone, branch, owner);
+
+    const differentPath = path.join(fx.dataDir, "runner", "reclaim-cas", "not-the-real-owner-clone");
+    await git.reclaimTerminalRecoveryClone(bare, branch, owner, differentPath);
+
+    assert.strictEqual(fs.existsSync(ownerClone), true, "the real owner clone is untouched by a mismatched-path reclaim call");
+    assertJournalNames(bare, branch, owner, ownerClone, "a CAS mismatch leaves the journal exactly as it was");
+  });
+
+  it("never deletes a recorded clone path OUTSIDE the runner root, but still releases the journal (deletion never gates the clear)", async () => {
+    const bare = await git.ensureClone(fx.originPath);
+    const branch = "agent/issue-9005";
+    const owner = "20000000-0000-4000-8000-000000000003";
+    const outsidePath = fs.mkdtempSync(path.join(os.tmpdir(), "uzi-recover-outside-"));
+    try {
+      fs.writeFileSync(path.join(outsidePath, "sentinel.txt"), "must survive\n");
+      // A corrupted/tampered journal — or an old worker layout — naming a path elsewhere
+      // on disk. markRecoveryCapture itself never validates containment, so this is a
+      // realistic shape for the read side to defend against.
+      await git.markRecoveryCapture(bare, outsidePath, branch, owner);
+
+      await git.reclaimTerminalRecoveryClone(bare, branch, owner, outsidePath);
+
+      assert.strictEqual(fs.existsSync(outsidePath), true, "containment blocks the delete of a path outside runnerRoot");
+      assert.strictEqual(fs.existsSync(path.join(outsidePath, "sentinel.txt")), true);
+      assertJournalCleared(bare, branch, "the journal is still released — containment gates the DELETE, not the clear");
+    } finally {
+      fs.rmSync(outsidePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent/test/rmtree.test.ts
+++ b/agent/test/rmtree.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -110,6 +110,66 @@ describe("rmTreeForce (PRD #108 M6)", () => {
     const root = await mktmp();
     await fs.rm(root, { recursive: true, force: true });
     await rmTreeForce(path.join(root, "never-existed"));
+  });
+
+  // issue #1308 m1. `restoreTreeWritability`'s chmod walk targets EACCES/EPERM — a
+  // permission problem — and does nothing for ENOTEMPTY/EBUSY, a lingering-writer
+  // problem (a `git maintenance` child, `web/node_modules/.vite`). Node's own
+  // `fs.rm(recursive, { maxRetries, retryDelay })` retries THOSE transient codes
+  // internally, inside a single call — invisible to rmTreeForce's own try/catch, which
+  // never sees more than one rejection either way. So the fix IS the `RM_RETRY` options
+  // object reaching every `fs.rm` call: drop it and a transient ENOTEMPTY/EBUSY that a
+  // real retry would have ridden out instead propagates straight out, unfixed.
+  //
+  // A REAL race (an actual concurrent writer) would make this flaky and timing-bound —
+  // exactly what this repo's rules forbid asserting on. So this pins the same contract
+  // deterministically: fs.rm is mocked to fail the underlying removal once with a
+  // synthetic ENOTEMPTY and only succeed on a second attempt IF it was handed a retry
+  // budget (opts.maxRetries) — mirroring, at the call-argument level, exactly what
+  // Node's real implementation conditions its internal retry on. No real timer is
+  // exercised (the retry is immediate), so this is a call-count / completion assertion,
+  // never a wall-clock one.
+  it("resolves through a transient ENOTEMPTY when fs.rm carries a retry budget (deterministic, no timing assertion)", async () => {
+    const root = await mktmp();
+    try {
+      const nested = path.join(root, "nested");
+      await fs.mkdir(nested, { recursive: true });
+      await fs.writeFile(path.join(nested, "f.txt"), "x", "utf8");
+      const realRm = fs.rm.bind(fs);
+      let attempts = 0;
+      const m = mock.method(
+        fs,
+        "rm",
+        async (p: Parameters<typeof fs.rm>[0], opts?: { maxRetries?: number }) => {
+          attempts++;
+          if (attempts === 1) {
+            if (!opts?.maxRetries) {
+              // No retry budget was passed — exactly the unfixed #1308 m1 shape: one
+              // attempt, no retry, the transient error propagates.
+              const err: NodeJS.ErrnoException = new Error("ENOTEMPTY: directory not empty");
+              err.code = "ENOTEMPTY";
+              throw err;
+            }
+            // A retry budget IS present: mirror Node's own internal retry — the
+            // caller's single `await fs.rm(...)` still resolves, having ridden out one
+            // transient failure underneath. Counted as a second attempt.
+            attempts++;
+            return realRm(p, opts);
+          }
+          return realRm(p, opts);
+        },
+      );
+      try {
+        await rmTreeForce(root);
+
+        assert.strictEqual(await exists(root), false, "the tree is eventually removed");
+        assert.ok(attempts >= 2, `the retry budget must be exercised at least twice, got ${attempts}`);
+      } finally {
+        m.mock.restore();
+      }
+    } finally {
+      await forceCleanup(root);
+    }
   });
 
   it("never follows a symlink out of the tree while restoring permissions", async (t) => {

--- a/agent/test/runner-clone-conflict.test.ts
+++ b/agent/test/runner-clone-conflict.test.ts
@@ -1,0 +1,325 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { type ExecutorFactory } from "../src/runner.js";
+import { recordingLogger } from "./helpers.js";
+import {
+  api,
+  deferred,
+  fakeGitlab,
+  fx,
+  git,
+  gitlabClaim,
+  homeDir,
+  installHarness,
+  runnerWith,
+  worktreeDirFor,
+} from "./runner-harness.js";
+
+installHarness();
+
+// issue #1308 m2/m3 — the runner-layer half of the cross-run clone-conflict fix. When a
+// DIFFERENT run's stale recovery-capture journal (worker-owned bare config,
+// `uzi-recovery.<branch>.clone`) refuses this run's clone seed (RunnerCloneConflictError),
+// the runner self-heals EXACTLY when the journal's owner run is definitively terminal
+// (completed/failed/cancelled) AND not locally active — reclaiming the owner's residue and
+// retrying the seed once. Every other case must fail CLOSED: the journal, the owner's
+// clone, and refs/uzi-runner/<branch> are all left exactly as they were, and the run
+// terminates with `fail_origin: "runner_clone_conflict"` rather than silently destroying
+// or adopting another run's retained work.
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_TERMINAL_PROMPT: "0",
+};
+
+function recoveryConfigKey(branch: string): string {
+  return `uzi-recovery.${branch}.clone`;
+}
+
+function readJournalRaw(bare: string, branch: string): string | undefined {
+  try {
+    const out = execFileSync(
+      "git",
+      ["-C", bare, "config", "--local", "--get", recoveryConfigKey(branch)],
+      { encoding: "utf8", env: GIT_ENV },
+    );
+    return out.replace(/\n$/, "");
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { status?: number };
+    if (err.status === 1) return undefined;
+    throw e;
+  }
+}
+
+function writeJournalRaw(bare: string, branch: string, value: string): void {
+  execFileSync("git", ["-C", bare, "config", "--local", recoveryConfigKey(branch), value], { env: GIT_ENV });
+}
+
+/** Seed a stale journal on `branch` naming `ownerRunId` at `branch`'s deterministic clone
+ *  path, with a real directory (containing a marker file) so the git-layer's `fs.lstat`
+ *  existence gate actually fires (a journal naming a vanished path is silently ignored,
+ *  not a conflict). Returns the seeded clone path. */
+async function seedStaleOwnerJournal(iid: number, ownerRunId: string): Promise<{ bare: string; branch: string; clonePath: string }> {
+  const bare = await git.ensureClone(fx.originPath);
+  const branch = `agent/issue-${iid}`;
+  const clonePath = worktreeDirFor(iid);
+  fs.mkdirSync(clonePath, { recursive: true });
+  fs.writeFileSync(path.join(clonePath, "OWNER_MARKER.txt"), "stale owner clone\n");
+  await git.markRecoveryCapture(bare, clonePath, branch, ownerRunId);
+  return { bare, branch, clonePath };
+}
+
+/** Spy on `git.reclaimTerminalRecoveryClone`, recording every call and forwarding to the
+ *  real implementation so the test still exercises production behaviour. */
+function spyReclaim(): { calls: Array<{ barePath: string; branch: string; ownerRunId: string; ownerClonePath: string }> } {
+  const original = git.reclaimTerminalRecoveryClone.bind(git);
+  const calls: Array<{ barePath: string; branch: string; ownerRunId: string; ownerClonePath: string }> = [];
+  git.reclaimTerminalRecoveryClone = (async (barePath: string, branch: string, ownerRunId: string, ownerClonePath: string) => {
+    calls.push({ barePath, branch, ownerRunId, ownerClonePath });
+    return original(barePath, branch, ownerRunId, ownerClonePath);
+  }) as typeof git.reclaimTerminalRecoveryClone;
+  return { calls };
+}
+
+/** A minimal executor that just proves the model was reached, then throws a plain
+ *  (non-typed) error so the run terminates quickly without needing full finalize/push
+ *  machinery. Distinguishing this from a `runner_clone_conflict` failure is exactly the
+ *  point: reaching here at all is proof the self-heal retried the seed successfully. */
+function modelReachedFactory(claimRunId: string, started: () => void): ExecutorFactory {
+  return () => ({
+    homeDir: path.join(homeDir, claimRunId),
+    executor: {
+      run: async () => {
+        started();
+        throw new Error("stop after reaching the model (test)");
+      },
+    },
+  });
+}
+
+function failedStateFor(runId: string): { fail_origin?: string; failure_reason?: string } | undefined {
+  return api.states.find((s) => s.runId === runId && s.body.status === "failed")?.body;
+}
+
+describe("cross-run clone-conflict self-heal (issue #1308 m2/m3)", () => {
+  const TERMINAL_STATUSES = ["completed", "failed", "cancelled"] as const;
+  TERMINAL_STATUSES.forEach((ownerStatus, i) => {
+    it(`reclaims a terminal (${ownerStatus}) owner's stale journal and lets the retry reach the model`, async () => {
+      const iid = 9200 + i;
+      const ownerRunId = `30000000-0000-4000-8000-00000000000${i}`;
+      const { bare, branch, clonePath } = await seedStaleOwnerJournal(iid, ownerRunId);
+      api.setOwnershipStatus(ownerRunId, ownerStatus);
+      const reclaim = spyReclaim();
+
+      let modelStarted = false;
+      const claim = gitlabClaim(iid);
+      const { gitlab } = fakeGitlab();
+      await runnerWith(modelReachedFactory(claim.run_id, () => { modelStarted = true; }), gitlab).execute(claim);
+
+      assert.strictEqual(reclaim.calls.length, 1, "the self-heal reclaim fires exactly once");
+      assert.deepStrictEqual(
+        reclaim.calls[0],
+        { barePath: bare, branch, ownerRunId, ownerClonePath: clonePath },
+        "the reclaim targets exactly the journal's recorded owner",
+      );
+      assert.strictEqual(modelStarted, true, "a successful self-heal must let the retried seed reach the model");
+      assert.strictEqual(
+        fs.existsSync(path.join(clonePath, "OWNER_MARKER.txt")),
+        false,
+        "the terminal owner's clone content is gone — a fresh clone was reseeded at the same path",
+      );
+      const failed = failedStateFor(claim.run_id);
+      assert.ok(failed, "the run still terminates (the injected model error), but NOT via the conflict path");
+      assert.notStrictEqual(failed!.fail_origin, "runner_clone_conflict", "a successful self-heal must not stamp the conflict fail_origin");
+    });
+  });
+
+  it("fails CLOSED when the journal's owner run is NOT terminal — nothing is touched, fail_origin is the typed conflict", async () => {
+    const iid = 9210;
+    const ownerRunId = "30000000-0000-4000-8000-000000000010";
+    const { bare, branch, clonePath } = await seedStaleOwnerJournal(iid, ownerRunId);
+    api.setOwnershipStatus(ownerRunId, "running");
+    const reclaim = spyReclaim();
+    const { logger, lines } = recordingLogger();
+
+    let modelStarted = false;
+    const claim = gitlabClaim(iid);
+    const { gitlab } = fakeGitlab();
+    await runnerWith(modelReachedFactory(claim.run_id, () => { modelStarted = true; }), gitlab, undefined, logger).execute(claim);
+
+    assert.strictEqual(reclaim.calls.length, 0, "a non-terminal owner must never be reclaimed");
+    assert.strictEqual(modelStarted, false, "the model must never start on a fail-closed conflict");
+    assert.strictEqual(fs.existsSync(path.join(clonePath, "OWNER_MARKER.txt")), true, "the owner's clone survives, byte-for-byte");
+    const failed = failedStateFor(claim.run_id);
+    assert.ok(failed, "the challenger run must fail");
+    assert.strictEqual(failed!.fail_origin, "runner_clone_conflict");
+    assert.match(failed!.failure_reason ?? "", /another run/);
+    assert.deepStrictEqual(JSON.parse(readJournalRaw(bare, branch)!), { runId: ownerRunId, clonePath }, "the journal is unchanged");
+    assert.ok(
+      lines.some((l) => (l as { level?: string; msg?: string }).msg === "runner clone conflict: owner run not terminal; not reclaiming"),
+      "the non-terminal-owner guard must fire and be observable",
+    );
+  });
+
+  for (const mode of ["not-owned (404)", "transient error (5xx)"] as const) {
+    it(`fails CLOSED when the ownership probe errors — ${mode}`, async () => {
+      const iid = mode.startsWith("not-owned") ? 9211 : 9212;
+      const ownerRunId = mode.startsWith("not-owned")
+        ? "30000000-0000-4000-8000-000000000011"
+        : "30000000-0000-4000-8000-000000000012";
+      const { bare, branch, clonePath } = await seedStaleOwnerJournal(iid, ownerRunId);
+      if (mode.startsWith("not-owned")) api.setOwnershipNotOwned(ownerRunId);
+      else api.failOwnership(ownerRunId, 500);
+      const reclaim = spyReclaim();
+      const { logger, lines } = recordingLogger();
+
+      let modelStarted = false;
+      const claim = gitlabClaim(iid);
+      const { gitlab } = fakeGitlab();
+      await runnerWith(modelReachedFactory(claim.run_id, () => { modelStarted = true; }), gitlab, undefined, logger).execute(claim);
+
+      assert.strictEqual(reclaim.calls.length, 0, "an unreachable/uncertain ownership probe must never be reclaimed");
+      assert.strictEqual(modelStarted, false);
+      assert.strictEqual(fs.existsSync(path.join(clonePath, "OWNER_MARKER.txt")), true, "the owner's clone survives");
+      const failed = failedStateFor(claim.run_id);
+      assert.ok(failed, "the challenger run must fail");
+      assert.strictEqual(failed!.fail_origin, "runner_clone_conflict");
+      assert.deepStrictEqual(JSON.parse(readJournalRaw(bare, branch)!), { runId: ownerRunId, clonePath }, "the journal is unchanged");
+      assert.ok(
+        lines.some((l) => (l as { level?: string; msg?: string }).msg === "runner clone conflict: owner terminality probe failed; not reclaiming"),
+        "the probe-failure guard must fire and be observable",
+      );
+    });
+  }
+
+  it("fails CLOSED on an unknown/non-terminal ownership status (e.g. awaiting_input)", async () => {
+    const iid = 9213;
+    const ownerRunId = "30000000-0000-4000-8000-000000000013";
+    const { bare, branch, clonePath } = await seedStaleOwnerJournal(iid, ownerRunId);
+    api.setOwnershipStatus(ownerRunId, "awaiting_input");
+    const reclaim = spyReclaim();
+
+    let modelStarted = false;
+    const claim = gitlabClaim(iid);
+    const { gitlab } = fakeGitlab();
+    await runnerWith(modelReachedFactory(claim.run_id, () => { modelStarted = true; }), gitlab).execute(claim);
+
+    assert.strictEqual(reclaim.calls.length, 0, "an unrecognised status must not be treated as terminal");
+    assert.strictEqual(modelStarted, false);
+    assert.strictEqual(fs.existsSync(path.join(clonePath, "OWNER_MARKER.txt")), true);
+    const failed = failedStateFor(claim.run_id);
+    assert.ok(failed);
+    assert.strictEqual(failed!.fail_origin, "runner_clone_conflict");
+    assert.deepStrictEqual(JSON.parse(readJournalRaw(bare, branch)!), { runId: ownerRunId, clonePath });
+  });
+
+  it("fails CLOSED on a malformed (non-JSON) journal — no reclaim is even attempted, the malformed value survives", async () => {
+    const iid = 9214;
+    const branch = `agent/issue-${iid}`;
+    const bare = await git.ensureClone(fx.originPath);
+    writeJournalRaw(bare, branch, "not-json-at-all");
+    const reclaim = spyReclaim();
+
+    let modelStarted = false;
+    const claim = gitlabClaim(iid);
+    const { gitlab } = fakeGitlab();
+    await runnerWith(modelReachedFactory(claim.run_id, () => { modelStarted = true; }), gitlab).execute(claim);
+
+    assert.strictEqual(reclaim.calls.length, 0, "a malformed journal is not a RunnerCloneConflictError — no reclaim attempt");
+    assert.strictEqual(modelStarted, false, "the model never starts over an unreadable journal");
+    const failed = failedStateFor(claim.run_id);
+    assert.ok(failed, "the run fails rather than silently reseeding over a corrupt journal");
+    assert.notStrictEqual(failed!.fail_origin, "runner_clone_conflict", "a parse error is not the typed conflict");
+    assert.strictEqual(readJournalRaw(bare, branch), "not-json-at-all", "the malformed journal is left exactly as it was");
+  });
+
+  it("fails CLOSED on a malformed (shape-invalid) journal — missing clonePath — with the typed parse error surfaced", async () => {
+    const iid = 9215;
+    const branch = `agent/issue-${iid}`;
+    const bare = await git.ensureClone(fx.originPath);
+    writeJournalRaw(bare, branch, JSON.stringify({ runId: "some-run-id" }));
+    const reclaim = spyReclaim();
+
+    let modelStarted = false;
+    const claim = gitlabClaim(iid);
+    const { gitlab } = fakeGitlab();
+    await runnerWith(modelReachedFactory(claim.run_id, () => { modelStarted = true; }), gitlab).execute(claim);
+
+    assert.strictEqual(reclaim.calls.length, 0);
+    assert.strictEqual(modelStarted, false);
+    const failed = failedStateFor(claim.run_id);
+    assert.ok(failed);
+    assert.notStrictEqual(failed!.fail_origin, "runner_clone_conflict");
+    assert.match(failed!.failure_reason ?? "", /invalid retained recovery clone journal/);
+    assert.strictEqual(readJournalRaw(bare, branch), JSON.stringify({ runId: "some-run-id" }), "the malformed journal is left exactly as it was");
+  });
+
+  it("(case 11) an owner still active in THIS worker's local activeRuns is never reclaimed, even though the API already reports it terminal", async () => {
+    const iid = 9216;
+    const branch = `agent/issue-${iid}`;
+    await git.ensureClone(fx.originPath);
+    const { gitlab } = fakeGitlab();
+    const { logger, lines } = recordingLogger();
+
+    const ownerStarted = deferred();
+    const releaseOwner = deferred();
+    const challengerClaim = gitlabClaim(iid);
+    const ownerClaim = gitlabClaim(iid);
+    let modelStartedChallenger = false;
+
+    const factory: ExecutorFactory = (runId) => ({
+      homeDir: path.join(homeDir, runId),
+      executor: {
+        run: async () => {
+          if (runId === challengerClaim.run_id) {
+            modelStartedChallenger = true;
+            return { branch };
+          }
+          // The owner run: register as active, then block until released.
+          ownerStarted.resolve();
+          await releaseOwner.promise;
+          throw new Error("owner torn down after the probe (test)");
+        },
+      },
+    });
+    const runner = runnerWith(factory, gitlab, undefined, logger);
+    const ownerExecution = runner.execute(ownerClaim);
+    try {
+      await ownerStarted.promise;
+      // The server-side row already reads terminal — the local activeRuns entry is the
+      // ONLY thing that must stop the challenger from reclaiming a live owner.
+      api.setOwnershipStatus(ownerClaim.run_id, "completed");
+
+      await runner.execute(challengerClaim);
+
+      assert.strictEqual(modelStartedChallenger, false, "the challenger must fail closed, never reaching the model");
+      const failed = failedStateFor(challengerClaim.run_id);
+      assert.ok(failed, "the challenger run fails");
+      assert.strictEqual(failed!.fail_origin, "runner_clone_conflict");
+      assert.ok(
+        lines.some((l) => {
+          const r = l as { level?: string; msg?: string; owner_run_id?: string };
+          return (
+            r.level === "warn" &&
+            r.msg === "runner clone conflict: owner run still active locally; not reclaiming" &&
+            r.owner_run_id === ownerClaim.run_id
+          );
+        }),
+        "the still-active-locally guard must fire and be observable, naming the correct owner",
+      );
+      assert.strictEqual(
+        fs.existsSync(worktreeDirFor(iid)),
+        true,
+        "the still-active owner's clone is untouched",
+      );
+    } finally {
+      releaseOwner.resolve();
+      await ownerExecution;
+    }
+  });
+});

--- a/api/internal/store/migrations/00221_run_runner_clone_conflict.sql
+++ b/api/internal/store/migrations/00221_run_runner_clone_conflict.sql
@@ -1,0 +1,69 @@
+-- +goose Up
+
+-- worker cross-run recovery-clone conflict origin (issue #1308): widen the
+-- runs.fail_origin domain with a thirteenth value, `runner_clone_conflict`. When a
+-- runner reuses a recovery clone whose journal names a DIFFERENT owner run, the runner
+-- self-heals by reclaiming the clone directory; if that owner run is still nonterminal /
+-- active / unreachable the conflict survives self-heal at iteration 0, and the runner
+-- fails typed with this origin instead of a raw clone error. It is a worker-reportable
+-- (CoerceFailOrigin passes it through — see workerReportableFailOrigins) and a
+-- pre-start-infra origin (the Judge is skipped for it at iteration 0 — see
+-- preStartInfraFailOrigins), so a run that never got to do anything reviewable is not
+-- sent to the most expensive per-run call.
+--
+-- The fail_origin CHECK is `runs_fail_origin_check` (created inline-unnamed in 00126,
+-- Postgres auto-named it <table>_<column>_check; widened by 00137 for
+-- workflow_scope_missing, by 00139 for finalize_base_align_conflict, and by 00186 for
+-- push_secret_blocked). Drop and re-add it with the widened set — the twelve values
+-- carried verbatim from 00186's Up plus runner_clone_conflict.
+-- TestFailOriginVocabularyMatchesCheck parses THIS migration's CHECK and asserts it
+-- equals AllFailOrigins(), so adding a member on one side without the other reddens at
+-- `go test` rather than raising 23514 on a user's failed run.
+--
+-- NUMBER ASSIGNED AT LANDING. Drafted as 00221 against a live head of
+-- 00220_validate_run_budget_extension.sql; renumber above the live head on the landing
+-- rebase if another migration merged first (strict goose refuses to boot on a version
+-- below an already-applied head — store/migrate.go), per the CLAUDE.md goose convention
+-- (no allow-missing).
+ALTER TABLE runs DROP CONSTRAINT runs_fail_origin_check;
+ALTER TABLE runs ADD CONSTRAINT runs_fail_origin_check
+    CHECK (fail_origin IN (
+        'provisioning_failed',
+        'credential_unavailable',
+        'guardrail_blocked',
+        'rate_limited',
+        'run_timeout',
+        'worker_lost',
+        'agent_failure',
+        'plan_rejected',
+        'auto_stopped',
+        'workflow_scope_missing',
+        'finalize_base_align_conflict',
+        'push_secret_blocked',
+        'runner_clone_conflict'
+    ));
+
+-- +goose Down
+
+-- Narrow back to the twelve-value set (00186's Up). Any `runner_clone_conflict` rows
+-- written while this migration was applied would violate the narrower CHECK, so clear
+-- the now-forbidden value first. NULL it (fail_origin is nullable) rather than DELETE the
+-- rows — a down-migration undoing this FEATURE must not destroy whole run records; the
+-- human-readable failure_reason on those runs is untouched.
+UPDATE runs SET fail_origin = NULL WHERE fail_origin = 'runner_clone_conflict';
+ALTER TABLE runs DROP CONSTRAINT runs_fail_origin_check;
+ALTER TABLE runs ADD CONSTRAINT runs_fail_origin_check
+    CHECK (fail_origin IN (
+        'provisioning_failed',
+        'credential_unavailable',
+        'guardrail_blocked',
+        'rate_limited',
+        'run_timeout',
+        'worker_lost',
+        'agent_failure',
+        'plan_rejected',
+        'auto_stopped',
+        'workflow_scope_missing',
+        'finalize_base_align_conflict',
+        'push_secret_blocked'
+    ));

--- a/api/internal/workersvc/failorigin.go
+++ b/api/internal/workersvc/failorigin.go
@@ -56,6 +56,10 @@ var failOrigins = []string{
 	// PARSES the remote reject, failing typed with the diff preserved instead of a raw
 	// `remote rejected` (worker-reportable — see workerReportableFailOrigins).
 	"push_secret_blocked",
+	// issue #1308: a cross-run recovery-clone conflict that survived self-heal at iteration 0
+	// (the journal's owner run is nonterminal / still active / unreachable). Worker-reportable,
+	// and a pre-start infra origin (see workerReportableFailOrigins / preStartInfraFailOrigins).
+	"runner_clone_conflict",
 }
 
 // failOriginSet is the lookup form. Built once; failOrigins stays the declaration so
@@ -90,9 +94,12 @@ func AllFailOrigins() []string {
 // workflow_scope_missing (PRD #377: the finalize detection that the branch touches
 // .github/workflows/** the bot PAT cannot push), finalize_base_align_conflict
 // (PRD #456: the finalize base-align merge AND rebase both conflict, so the worker
-// aborts and preserves the diff), and push_secret_blocked (issue #974: the finalize
+// aborts and preserves the diff), push_secret_blocked (issue #974: the finalize
 // pre-push gitleaks range scan finds a secret, or the push is rejected by GitHub Push
-// Protection / GH013, so the worker fails typed and preserves the diff); agent_failure
+// Protection / GH013, so the worker fails typed and preserves the diff), and
+// runner_clone_conflict (issue #1308: a cross-run runner-clone conflict the runner
+// reports at iteration 0 when self-heal cannot reclaim the clone directory because the
+// journal's owner run is still active/unreachable); agent_failure
 // is included because it is the judgeable
 // default the `failed` arm applies anyway, so an explicit worker agent_failure is
 // harmless and semantically correct. The partition (worker-reportable + server-only ==
@@ -105,6 +112,7 @@ var workerReportableFailOrigins = map[string]bool{
 	"workflow_scope_missing":       true,
 	"finalize_base_align_conflict": true,
 	"push_secret_blocked":          true,
+	"runner_clone_conflict":        true,
 }
 
 // CoerceFailOrigin maps a worker-reported fail_origin onto the WORKER-REPORTABLE subset.

--- a/api/internal/workersvc/failorigin_test.go
+++ b/api/internal/workersvc/failorigin_test.go
@@ -65,7 +65,7 @@ func TestCoerceFailOrigin(t *testing.T) {
 // parses the migration rather than restating the list, because a second hand-typed copy
 // is exactly the drift it prevents.
 func TestFailOriginVocabularyMatchesCheck(t *testing.T) {
-	const path = "../store/migrations/00186_run_push_secret_blocked.sql"
+	const path = "../store/migrations/00221_run_runner_clone_conflict.sql"
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)

--- a/api/internal/workersvc/judge_enqueue.go
+++ b/api/internal/workersvc/judge_enqueue.go
@@ -17,17 +17,22 @@ import (
 	"github.com/vtmocanu/uzi/api/internal/store"
 )
 
-// preStartInfraFailOrigins is the fail_origin set that means a run failed BEFORE the
-// agent did anything reviewable (PRD #69 M7a Pass B, Decision 12): a
-// provisioning/credential/guardrail block that is permanent until the config or policy
-// is fixed. Gate 4b skips the judge for such a run at iteration_count == 0 — there is no
-// agent behavior to retrospect. Deliberately EXACTLY these three: not
-// rate_limited/worker_lost/run_timeout (transient) and not agent_failure (judgeable).
-// The members are a strict subset of failorigin.go's vocabulary.
+// preStartInfraFailOrigins is the fail_origin set naming a failure that struck during
+// run SETUP, before the agent produced anything reviewable (PRD #69 M7a Pass B,
+// Decision 12; extended by issue #1308). Gate 4b skips the judge for such a run at
+// iteration_count == 0: with no agent behavior to retrospect, the judge is skipped
+// whatever the cause — a PERMANENT policy/config denial (provisioning_failed /
+// credential_unavailable / guardrail_blocked, cleared only by fixing the config or
+// policy) or a TRANSIENT setup conflict a later retry may clear (runner_clone_conflict,
+// issue #1308, stamped when the runner cannot reclaim a cross-run recovery clone whose
+// owner run is still active). It excludes rate_limited/worker_lost/run_timeout (runtime
+// failure classes, not run-setup) and agent_failure (judgeable). The members are a
+// strict subset of failorigin.go's vocabulary.
 var preStartInfraFailOrigins = map[string]bool{
 	"provisioning_failed":    true,
 	"credential_unavailable": true,
 	"guardrail_blocked":      true,
+	"runner_clone_conflict":  true,
 }
 
 // maybeEnqueueJudgeByID reloads a run by id and runs the judge gate. Used by the
@@ -103,27 +108,28 @@ func (s *Service) maybeEnqueueJudge(ctx context.Context, run store.Run) {
 		}
 		return // no token ⇒ nothing to spend ⇒ no judge run
 	}
-	// Gate 4b (PRD #69 M7a Pass B, Decision 12): skip the judge for a PRE-START INFRA
-	// failure — a run that failed BEFORE the agent did anything worth retrospecting.
-	// The set is EXACTLY the three policy/config-denied origins, AND only at
-	// iteration_count == 0. An agent that started and crashed at iteration 0 carries
-	// 'agent_failure' (the worker-reported default), stays out of this set, and is still
-	// judged (SC3); the iteration conjunct is the PRD's defensive guard for that. NOT
-	// rate_limited/worker_lost/run_timeout (transient) and NOT agent_failure (judgeable).
-	// This is the ACCURACY+SPEND fix: a pre-start infra failure has no agent behavior to
-	// review, and skipping avoids the most expensive per-run call (opus) on a run that
-	// did nothing.
+	// Gate 4b (PRD #69 M7a Pass B, Decision 12; extended by issue #1308): skip the judge
+	// for a PRE-START INFRA failure — a run that failed during SETUP, before the agent did
+	// anything worth retrospecting. The set is preStartInfraFailOrigins (see its
+	// declaration), AND only at iteration_count == 0. An agent that started and crashed at
+	// iteration 0 carries 'agent_failure' (the worker-reported default), stays out of this
+	// set, and is still judged (SC3); the iteration conjunct is the PRD's defensive guard
+	// for that. The set excludes rate_limited/worker_lost/run_timeout (runtime failure
+	// classes, not run-setup) and agent_failure (judgeable). This is the ACCURACY+SPEND
+	// fix: a pre-start failure has no agent behavior to review, and skipping avoids the
+	// most expensive per-run call (opus) on a run that did nothing.
 	//
 	// DETERMINISTIC INFRA NOTIFICATION — delivered here by the EXISTING RunFailureNotifier,
 	// NOT injected. The judge is a REPLACEMENT for these runs, not an addition, so they
 	// still owe a failure notification. Every path that can reach this gate carrying one
-	// of these three origins is the worker-reported SetState terminal transition, which
+	// of these pre-start origins is the worker-reported SetState terminal transition, which
 	// fires s.bcast.PublishState(runID,"failed") BEFORE calling maybeEnqueueJudge; the
 	// RunFailureNotifier subscribes to that PublishState and notifies every
 	// non-cancelled/non-plan_rejected failure (infra included), so the notification has
 	// already been delivered on the SAME transition and this gate need only skip the
-	// judge. (The server-side claim-assembly failer that also stamps these three origins
-	// via MarkRunFailedByID never calls maybeEnqueueJudge at all, so it is not
+	// judge. (The server-side claim-assembly failer that also stamps the three server-side
+	// infra origins — provisioning_failed/credential_unavailable/guardrail_blocked — via
+	// MarkRunFailedByID never calls maybeEnqueueJudge at all, so it is not
 	// gate-reachable; it notifies through its own s.notify.) No notifysvc injection is
 	// possible anyway — notifysvc imports workersvc (RunFailureNotifier is a
 	// workersvc.Broadcaster), so injecting it would create an import cycle.

--- a/api/internal/workersvc/judge_m7a_test.go
+++ b/api/internal/workersvc/judge_m7a_test.go
@@ -64,13 +64,14 @@ func TestJudgeClaimCarriesFailureClass(t *testing.T) {
 	})
 }
 
-// TestPreStartInfraFailureSkipsJudge (Decision 12): a failed run at iteration_count == 0
-// whose fail_origin is one of the three pre-start policy/config-denied origins is NOT
-// judged — there is no agent behavior to retrospect, and skipping avoids the most
-// expensive per-run call. The deterministic failure notification is delivered separately
-// by RunFailureNotifier on the same PublishState transition (asserted by trace, not here).
+// TestPreStartInfraFailureSkipsJudge (Decision 12; extended by issue #1308): a failed run
+// at iteration_count == 0 whose fail_origin is a pre-start setup origin — a permanent
+// policy/config denial OR the transient runner_clone_conflict — is NOT judged: there is
+// no agent behavior to retrospect, and skipping avoids the most expensive per-run call.
+// The deterministic failure notification is delivered separately by RunFailureNotifier on
+// the same PublishState transition (asserted by trace, not here).
 func TestPreStartInfraFailureSkipsJudge(t *testing.T) {
-	for _, origin := range []string{"provisioning_failed", "credential_unavailable", "guardrail_blocked"} {
+	for _, origin := range []string{"provisioning_failed", "credential_unavailable", "guardrail_blocked", "runner_clone_conflict"} {
 		t.Run(origin+" at iter 0 is not enqueued", func(t *testing.T) {
 			fs, svc, run := eligibleFixture(t)
 			run.Status = "failed"


### PR DESCRIPTION
Implements issue #1308.

Closes #1308

> ⚠️ This run used agent definitions from the repository's own `.claude/agents/` (architect, auditor, coder, documenter, fact-checker, release, researcher, reviewer, spec-keeper, tester, tui-ux, ux-designer, web-ux). The internal review was performed by those repo-authored agents, not by uzi's built-in reviewer — review this change accordingly.

---
Opened automatically by the uzi agent from branch `agent/issue-1308`. Please review and merge manually — the agent never merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from stale or conflicting runner clones, including safe cleanup and automatic retry when the previous run has finished.
  * Improved cleanup reliability when temporary files are busy or briefly inaccessible.
  * Prevented active or unrelated recovery data from being removed during cleanup.
  * Run identifiers containing special characters are now handled safely.

* **Run Reporting**
  * Added a `runner_clone_conflict` failure classification for setup failures caused by unrecoverable clone conflicts.
  * These setup failures are now excluded from judging while still delivering failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->